### PR TITLE
Refactor documentation into modular CLAUDE.md knowledge graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,69 +81,17 @@ Hidden aliases (backward compat): `morning`→`plan`, `extract`→`process`, `ag
 - `daily_plans` — generated daily plans
 - `reading_queue` — prioritized reading list
 
-## Key data flows
+## Module documentation
 
-### PDF finding (3-tier)
-1. `direct_path` from DB
-2. BetterBibTeX JSON lookup (`library_json` → citekey → attachment path)
-3. Fuzzy filename matching (exact citekey, title words + year, author in prefix)
+Detailed documentation for each subsystem lives in its directory, loaded incrementally as the agent navigates:
 
-### Fragment extraction
-PDF → PyMuPDF text → AI analysis → fragments to SQLite + vault (`## 💬 Цитаты для диссертации`)
-
-### Vault note creation
-`klemma extract <citekey>` → if @citekey.md missing, auto-creates it via `note_factory.create_vault_note()`:
-1. AI annotation (`annotate.md` prompt) analyzes PDF with full library context (174 entries)
-2. Extracts: summary, methodology, relevance, key_references (bibliography analysis)
-3. Renders structured vault note with sections: metadata, summary, methods, relevance, key references, quotes
-4. Saves reference gaps (missing refs from bibliography) to `reference_gaps` table
-
-### Reference gap tracking
-Each annotated paper's bibliography is cross-checked against our library. Missing relevant refs accumulate across sources.
-- **Score formula**: `count × avg_source_quality × section_weight` (section_weight=2.0 for НР1/НР2 sections)
-- **Auto-resolve**: when a gap's author+year matches a newly added source, it's marked resolved
-- **Surfacing**: CLI status line (every command), `klemma gaps`, TUI dashboard, TUI gaps screen
-
-### Research briefing
-`klemma research -s X.X` → auto-extract fragments → collect context (draft, fragments, sources, coverage) → Claude analysis → `Research_X.X.md` in vault
-
-Incremental mode: if Research note exists, reads `## ✏️ Что нового` (user notes), computes delta (new sources, fragments), sends incremental prompt. User notes archived to `## 📋 История изменений` with timestamp.
-
-### Paper acquisition
-`klemma acquire <url> --title "..." --authors "..." --year N --section X.X` or `klemma acquire --batch papers.json`.
-Pipeline: download PDF → pyzotero `create_items` → `create_attachment_record` (metadata only, no cloud upload) → place PDF in `{storage_path}/{attachment_key}/` → poll BBT JSON for citekey → `state.register_sources([citekey])` + `set_pdf_path()` → optional `klemma process`.
-PDF storage: bypasses Zotero cloud (paid quota), stores locally in Zotero storage dir. Zotero sees attachment record and finds file locally.
-Core logic in `skills/acquirer.py`. Zotero write methods: `ZoteroLibrary.create_item()`, `ZoteroLibrary.create_attachment_record()`.
-Requires: `ZOTERO_API_KEY` env var, `zotero.library_id` in config.yaml.
-
-### Agent
-`klemma ask "query"` → build_agent_context() gathers all research data (sources, coverage, gaps, fragments, plan) → renders Jinja2 system prompt → launches `claude --system-prompt <context> <query>` interactively. Claude saves response to `Agent/Agent_<date>.md` in vault. For non-Claude backends (no interactive mode): `ai.call()` with full context → prints response to terminal.
-
-### Agent Skills (Claude Code)
-Agent uses Claude Code Skills from `.claude/skills/` instead of reading source code:
-- `klemma-acquire` — full acquire pipeline instructions (single + batch JSON format)
-- `klemma-process` — fragment extraction (single, batch, parallel)
-- `klemma-status` — coverage and gaps check
-
-Skills are auto-discovered by Claude Code in `--system-prompt` mode. Agent prompt (`agent.md`) references Skills via `/klemma-acquire`, `/klemma-process`, `/klemma-status`.
-
-### Library analysis
-`klemma library` → gather library context (summary, quality tiers, ref-gaps, sources compact list) → Claude analysis via `librarian.md` prompt → structured LibraryReport → saved to `Library/Library_{mode}_{date}.md` in vault. Three modes: status (health), recommend (section-focused), audit (deep quality check).
-
-### MCP tool integration
-`klemma tools add <name> --command <cmd> --args <args>` registers an MCP server in `config.yaml → mcp.servers`. ToolRegistry lazily creates MCPClient instances (sync wrapper over async MCP SDK, stdio transport). Each `call_tool()` spawns a fresh connection. Servers are not installed by Klemma — only launch commands are registered.
-
-### Paper search
-`klemma search "query"` → ToolRegistry.call("academia", "arxiv_search", ...) → rich table output. Requires registered `academia` MCP server.
-
-### Discovery pipeline
-`klemma discover -s X.X` → Phase 1 (deterministic: MCP search per ref-gap + section keywords, deduplicate against library) → Phase 2 (Claude: relevance assessment, usage type, priority) → results saved to `discoveries` table. Can run as background subprocess via `--background`. Review with `--review`.
-
-### Auto-sync sections
-On every `research`, `library`, `status` command: `_sync_sections()` → reads all vault @citekey.md frontmatter (~60ms), compares with DB, updates section assignments where vault differs. Also discovers new Zotero entries not yet in DB (auto-classified via config regex patterns, registered as `pending`).
-
-### Multi-section sources
-Frontmatter `sections: [1.1, 1.4.1, 3.2.2]` → `source_sections` table → `get_by_section()` uses JOIN to find all relevant sources.
+- [Core infrastructure](src/klemma/CLAUDE.md) — config, state, AI providers, vault, library, CLI, context
+- [AI Skills](src/klemma/skills/CLAUDE.md) — planner, extractor, researcher, librarian, agent, acquirer
+- [MCP Tools](src/klemma/tools/CLAUDE.md) — MCPClient, ToolRegistry, discovery pipeline
+- [Literature](src/klemma/literature/CLAUDE.md) — Zotero, PDF extraction, models, vault note factory
+- [TUI](src/klemma/tui/CLAUDE.md) — Textual dashboard and screens
+- [Prompts](prompts/CLAUDE.md) — Jinja2 templates for AI calls
+- [Tests](tests/CLAUDE.md) — testing patterns and conventions
 
 ## Development
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,51 @@ pip install -e ".[litellm]"    # LiteLLM universal backend (100+ providers)
 pip install -e ".[all-ai]"     # all AI backends
 klemma --help
 ```
+
+## Maintaining CLAUDE.md documentation
+
+This documentation is a modular knowledge graph — 8 interconnected CLAUDE.md files loaded incrementally as the agent navigates directories. **Keep it up to date when changing code.**
+
+### When to update
+- **Adding a module**: add entry to the parent directory's CLAUDE.md (module name, line count, purpose, key functions)
+- **Adding a CLI command**: update "Key commands" section here + relevant skill/tool CLAUDE.md
+- **Adding a SQLite table**: update "SQLite tables" here + `src/klemma/CLAUDE.md` state.py section
+- **Adding a prompt template**: update `prompts/CLAUDE.md` (template table + variables) + skill's CLAUDE.md
+- **Adding a data flow**: document in the primary owner's CLAUDE.md, add cross-references
+- **Renaming/removing a module**: update the CLAUDE.md where it's documented, fix any cross-reference links
+- **Changing function signatures or key behavior**: update the relevant module entry
+
+### When to create a new CLAUDE.md
+Create a new child CLAUDE.md when a **new subdirectory** is added that contains 2+ modules with shared context. Follow this template:
+
+```markdown
+# <Subsystem Name>
+
+<One-line purpose.>
+
+## Modules
+
+### module.py (N lines)
+<Purpose.>
+- `key_function()` — what it does
+- `KeyClass` — what it represents
+
+## Data flows
+
+### <Flow name>
+<Step-by-step description of the end-to-end flow.>
+
+## Maintaining this file
+Update when modules are added/removed/renamed in this directory, or when key functions/classes change.
+
+See: [links to related CLAUDE.md files]
+```
+
+After creating a new child, add a link to the **Module documentation** section above.
+
+### Structure rules
+- **Primary owner**: each data flow is documented fully in one CLAUDE.md, other files only link to it
+- **Line counts**: listed as `(N lines)` next to module names — update after significant changes
+- **Cross-references**: every child ends with `See:` links to related CLAUDE.md files; use relative paths
+- **Self-contained**: each child should be understandable without reading the root
+- **Concise**: document what an agent needs to navigate and modify code, not exhaustive API docs

--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -1,0 +1,42 @@
+# Prompt Templates
+
+Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template receives specific context variables.
+
+## Templates
+
+| Template | Used by | Purpose |
+|----------|---------|---------|
+| `morning.md` | `skills/planner.py` | Daily briefing |
+| `extract.md` | `skills/extractor.py` | Fragment extraction |
+| `annotate.md` | `literature/note_factory.py` | AI annotation for vault notes |
+| `research.md` | `skills/researcher.py` | Research briefing (initial) |
+| `research_incremental.md` | `skills/researcher.py` | Research briefing (incremental) |
+| `librarian.md` | `skills/librarian.py` | Library analysis (3 modes) |
+| `agent.md` | `skills/agent.py` | System prompt for interactive agent |
+
+## Key variables by template
+
+### morning.md
+`dissertation_context`, `current_chapter`, `chapter_name`, `current_deadline`, `days_until_deadline`, `days_without_progress`, `streak`, `yesterday_plan`, `chapter_plan`, `library_digest`, `coverage`, `gaps`, `ref_gaps`
+
+### extract.md
+`title`, `authors`, `year`, `journal`, `doi`, `abstract`, `pdf_text`, `dissertation_context`, `available_tags`
+
+### annotate.md
+`title`, `authors`, `year`, `journal`, `abstract`, `pdf_text`, `library_context`, `dissertation_context`, `available_tags`
+
+### research.md / research_incremental.md
+`section`, `chapter`, `section_title`, `dissertation_context`, `draft_text`, `fragments`, `sources`, `coverage` + (incremental: `user_notes`, `delta_sources`, `delta_fragments`, `previous_analysis`)
+
+### librarian.md
+`mode`, `dissertation_context`, `library_summary`, `quality_tiers`, `ref_gaps`, `sources_compact`, `focus_section`, `deadline`, `days_until_deadline`
+
+### agent.md
+`dissertation_context`, `chapters`, `scientific_results`, `priority_terms`, `current_chapter`, `chapter_name`, `current_section`, `current_deadline`, `days_until_deadline`, `sources`, `coverage`, `gaps`, `min_sources`, `fragment_stats`, `today_plan`, `next_reading`, `vault_path`, `today`
+
+## Conventions
+- All templates in Russian (dissertation language) except `extract.md` (English for international papers)
+- `{{ variable }}` syntax with Jinja2 control flow (`{% for %}`, `{% if %}`)
+- Rendered by `AIProviderBase.render_prompt()` which loads file and applies `Template()`
+
+See: [AI Skills](../src/klemma/skills/CLAUDE.md) for the skill that uses each template

--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -39,4 +39,7 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 - `{{ variable }}` syntax with Jinja2 control flow (`{% for %}`, `{% if %}`)
 - Rendered by `AIProviderBase.render_prompt()` which loads file and applies `Template()`
 
+## Maintaining this file
+Update when: adding a new prompt template (add to table + variables section), changing template variables (update the variables list), or changing which skill uses a template. The template table and variable lists must stay in sync with the actual `.md` files in this directory.
+
 See: [AI Skills](../src/klemma/skills/CLAUDE.md) for the skill that uses each template

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -72,4 +72,7 @@ Also discovers new Zotero entries not in DB (auto-classified via config regex pa
 ### Multi-section sources
 Frontmatter `sections: [1.1, 1.4.1, 3.2.2]` → `source_sections` table → `get_by_section()` uses JOIN.
 
+## Maintaining this file
+Update when: adding/removing/renaming root-level modules in `src/klemma/`, changing key class/function signatures, adding SQLite tables to `state.py`, modifying `KlemmaContext` fields, or adding new CLI commands to `cli.py`. Line counts should be refreshed after significant changes.
+
 See: [AI Skills](skills/CLAUDE.md) | [MCP Tools](tools/CLAUDE.md) | [Literature](literature/CLAUDE.md) | [TUI](tui/CLAUDE.md) | [Prompts](../../prompts/CLAUDE.md) | [Tests](../../tests/CLAUDE.md)

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -1,0 +1,75 @@
+# Core Infrastructure
+
+Foundation layer: config, state, AI providers, vault, library abstraction, CLI entry point, and context.
+
+## Modules
+
+### cli.py (1480 lines)
+Click CLI entry point. Defines all 11 commands + hidden aliases.
+- `_init_components()` — creates `KlemmaContext` from config
+- `_init_ai()` — creates AI client (separated for commands that don't need API key)
+- `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
+
+### context.py (30 lines)
+`KlemmaContext` dataclass — single object per CLI command invocation.
+Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional).
+
+### config.py (164 lines)
+Pydantic config models loaded from `config.yaml`.
+Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `MCPConfig`, `MCPServerConfig`.
+
+### state.py (1207 lines)
+SQLite state manager. Tables:
+- `sources` — Zotero entries (citekey, title, status, chapter, quality, pdf_path)
+- `source_sections` — junction table: source_id × section (multi-section support)
+- `fragments` — extracted citation fragments (text, type, chapter, section, relevance, page)
+- `reference_gaps` — missing references from bibliographies (status: open/resolved, score)
+- `discoveries` — papers from discovery pipeline (status: pending/accepted/rejected)
+- `daily_plans` — generated daily plans
+- `reading_queue` — prioritized reading list
+- `prune_verdicts` — librarian audit results
+
+Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`), `get_coverage_stats()`, `get_gap_summary()`, `save_discovery()`, `save_plan()`.
+
+### ai.py (243 lines)
+`AIProvider` protocol → `AIProviderBase` → `ClaudeClient` + `create_ai()` factory.
+- `AIProvider.call()` / `call_json()` — main interface for AI calls
+- `AIProviderBase.render_prompt()` — Jinja2 template rendering
+- `extract_json()` — parses JSON from markdown code blocks and unstructured text
+- `ClaudeClient` — subprocess wrapper for `claude -p --model <model>`
+- Retry logic with configurable timeout
+
+### ai_openai.py (103 lines)
+`OpenAIClient` — wraps OpenAI Python SDK. Supports structured JSON mode (`response_format`).
+Works with: OpenAI, Ollama, vLLM, LM Studio (via `base_url`).
+
+### ai_litellm.py (67 lines)
+`LiteLLMClient` — thin wrapper around `litellm.completion()`. Model format: `provider/model`.
+
+### vault.py (250 lines)
+`VaultAdapter` — Obsidian vault file I/O.
+- `read_note()` / `write_note()` — file read/write
+- `update_section()` — replace content between markdown heading markers
+- `get_properties()` — parse YAML frontmatter
+- `list_notes()` — enumerate vault notes
+
+### library_provider.py (195 lines)
+`LibraryProvider` protocol with two backends:
+- `LocalLibrary` — wraps `PDFExtractor.load_entry_lookup()` (BBT JSON)
+- `MCPLibrary` — uses zotero-mcp server via MCP protocol
+- `create_library(config)` — factory, selects based on `config.zotero.backend`
+
+### app.py (124 lines)
+`KlemmaApp` — Textual TUI application. Mounts screens from `tui/` package.
+
+## Data flows
+
+### Auto-sync sections
+Triggered on every `research`, `library`, `status` command from `cli.py._sync_sections()`.
+Reads all vault `@citekey.md` frontmatter (~60ms), compares with DB, updates section assignments.
+Also discovers new Zotero entries not in DB (auto-classified via config regex patterns, registered as `pending`).
+
+### Multi-section sources
+Frontmatter `sections: [1.1, 1.4.1, 3.2.2]` → `source_sections` table → `get_by_section()` uses JOIN.
+
+See: [AI Skills](skills/CLAUDE.md) | [MCP Tools](tools/CLAUDE.md) | [Literature](literature/CLAUDE.md) | [TUI](tui/CLAUDE.md) | [Prompts](../../prompts/CLAUDE.md) | [Tests](../../tests/CLAUDE.md)

--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -1,0 +1,56 @@
+# Literature Management
+
+Zotero library access, PDF text extraction, Pydantic data models, and vault note generation.
+
+## Modules
+
+### models.py (202 lines)
+All Pydantic models for the data layer:
+- `ZoteroEntry`, `Author` — Zotero item representation (`year`, `authors_str`, `citation` properties)
+- `DissertationRelevance` — chapter/section relevance scoring (NR1/NR2, 0-5)
+- `Fragment`, `ExtractionResult` — extraction output (text, type, chapter, section, relevance, page)
+- `DailyPlan` — daily briefing output
+- `CitationEntry`, `ArgumentBlock`, `ResearchResult` — research briefing output
+- `LibraryReport` — library analysis output
+- `AnnotationResult`, `Quote` — AI annotation output
+
+### pdf.py (202 lines)
+`PDFExtractor` — PyMuPDF-based text extraction with BBT JSON integration.
+- `extract()` — text with `[Page N]` markers, truncated to `max_chars`
+- `find_pdf()` — 3-tier PDF finding (see data flows below)
+- `load_pdf_lookup()` — citekey → pdf_path from BBT JSON
+- `load_entry_lookup()` — citekey → `ZoteroEntry` from BBT JSON
+- CamelCase splitting: `wagnerSeaiceInformation2020` → `[wagner, seaice, information, 2020]`
+
+### zotero.py (205 lines)
+`ZoteroLibrary` — pyzotero wrapper for Zotero API access.
+- Read: `get_all_items()`, `get_item()`, `search()`
+- Write (used by acquirer): `create_item()`, `create_attachment_record()` (metadata-only, no cloud upload)
+- Citekey discovery: `extra` field `"Citation Key:"` → fallback to `item_key`
+
+### note_factory.py (470 lines)
+Vault note creation pipeline — largest module in the package:
+1. `auto_classify()` — regex-based chapter/section/tag assignment from title+abstract
+2. `annotate_source()` — AI annotation via `prompts/annotate.md` → JSON
+3. `build_frontmatter()` — YAML frontmatter matching zobsidian format
+4. `create_vault_note()` — renders structured note with frontmatter + sections
+5. Reference gap extraction — bibliography cross-check against library
+
+## Data flows
+
+### PDF finding (3-tier)
+1. `direct_path` from DB (`state.get_source()["pdf_path"]`)
+2. BetterBibTeX JSON lookup (`library_json` → citekey → attachment path)
+3. Fuzzy filename matching (exact citekey, title words + year, author in prefix)
+
+### Vault note creation
+Triggered by `klemma process <citekey>` when `@citekey.md` is missing.
+`note_factory.create_vault_note()` → AI annotation → structured note → reference gap extraction.
+
+### Reference gap tracking
+Each annotated paper's bibliography is cross-checked against the library.
+- **Score formula**: `count × avg_source_quality × section_weight` (section_weight=2.0 for NR1/NR2 sections)
+- **Auto-resolve**: when a gap's author+year matches a newly added source, it's marked resolved
+- **Surfacing**: CLI status line, `klemma status`, TUI dashboard, TUI gaps screen
+
+See: [Core infrastructure](../CLAUDE.md) for `state.py` tables | [AI Skills](../skills/CLAUDE.md) for extraction pipeline | [Prompts](../../../prompts/CLAUDE.md) for `annotate.md` template

--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -53,4 +53,7 @@ Each annotated paper's bibliography is cross-checked against the library.
 - **Auto-resolve**: when a gap's author+year matches a newly added source, it's marked resolved
 - **Surfacing**: CLI status line, `klemma status`, TUI dashboard, TUI gaps screen
 
+## Maintaining this file
+Update when: adding/changing Pydantic models in `models.py`, modifying PDF finding tiers, changing vault note structure in `note_factory.py`, adding Zotero write methods, or changing the reference gap scoring formula. If `annotate.md` variables change, also update [Prompts](../../../prompts/CLAUDE.md).
+
 See: [Core infrastructure](../CLAUDE.md) for `state.py` tables | [AI Skills](../skills/CLAUDE.md) for extraction pipeline | [Prompts](../../../prompts/CLAUDE.md) for `annotate.md` template

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -1,0 +1,85 @@
+# AI Skills
+
+AI-powered features that compose config + state + vault + ai + literature into higher-level operations.
+All skills receive dependencies via function arguments (not global state).
+
+Shared constant: `planner.DISSERTATION_CONTEXT` is imported by extractor, researcher, librarian, agent.
+
+## Modules
+
+### planner.py (229 lines)
+Morning briefing generation. Gathers: deadline, streak, yesterday's plan, chapter plan, library digest, coverage stats, ref-gaps.
+- `generate_morning_plan()` — full context → `prompts/morning.md` → Claude → `DailyPlan` → state + vault
+- `DISSERTATION_CONTEXT` — shared constant (topic, chapters, deadlines, keywords), imported by all other skills
+- `_get_current_deadline()` — calculate days remaining for current chapter
+- `_read_chapter_plan()` — load session plan from vault
+- Intervention types: `NONE`, `REPLAN`, `BOOST`, `SKIP`
+
+### extractor.py (205 lines)
+Fragment extraction from PDFs.
+- `extract_fragments()` — renders `prompts/extract.md` with paper text + dissertation context → Claude → `ExtractionResult`
+- `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze)
+- `save_fragments_to_vault()` — appends to `@citekey.md` under quotes section; auto-creates note if missing
+- Domain-specific `AVAILABLE_TAGS` for sea ice / ML / remote sensing taxonomy
+
+### researcher.py (730 lines — largest skill)
+Section research briefings. Two modes:
+- **Initial**: auto-extract fragments → collect context → `prompts/research.md` → `ResearchResult` → vault
+- **Incremental**: reads existing research note `## ✏️ Что нового` (user annotations), computes delta (new sources, fragment count), `prompts/research_incremental.md` → merged result. User notes archived to `## 📋 История изменений` with timestamp.
+- `research_section()` — main entry point
+- `pre_extract_sources()` — auto-extract fragments for section/chapter sources before research
+- `_load_previous_research()` — parse user notes, history, delta from existing research note
+- `_load_section_sources()` — enrich sources with vault AI summaries
+
+### librarian.py (253 lines)
+Library health analysis. Three modes: `status` (health), `recommend` (section-focused), `audit` (deep quality check).
+- `analyze_library()` — gathers context → `prompts/librarian.md` → `LibraryReport` → vault
+- `_gather_library_context()` — summary, quality tiers, ref-gaps, sources compact list
+- `_format_sources_compact()` — compact list for prompt (citekey, author, year, title, q, ch, s, f)
+- Prune verdicts (audit mode): saved to DB with "drop" and "maybe" categories
+
+### agent.py (97 lines)
+Builds full dissertation context for interactive Claude sessions.
+- `build_agent_context()` — gathers sources, coverage, gaps, fragments, plan, reading queue → `prompts/agent.md` → system prompt
+- For Claude backend: launches `claude --system-prompt` interactively
+- For non-Claude backends: `ai.call()` with full context → terminal output
+- Saves responses to `Agent/Agent_<date>.md` in vault
+
+### acquirer.py (258 lines)
+Paper acquisition pipeline: download → Zotero → DB.
+- `acquire_paper()` — orchestrates full pipeline
+- `download_pdf()` — HTTP stream with validation (min 10KB, content-type check)
+- `parse_authors()` — Russian name parsing (Фамилия И.О. → Zotero creators)
+- `poll_bbt_citekey()` — polls BBT JSON export for new citekey (2s intervals, 30s timeout)
+- `_store_pdf_locally()` — copy to Zotero storage dir (bypasses cloud quota)
+- `load_batch()` — parse JSON batch file
+- Dataclasses: `PaperMetadata`, `AcquireResult`
+
+## Data flows
+
+### Fragment extraction (end-to-end)
+`klemma process` → `literature.pdf.PDFExtractor` extracts text → `extractor.extract_fragments()` calls Claude → fragments saved to state → `save_fragments_to_vault()` writes to `@citekey.md`.
+If vault note missing: triggers `literature.note_factory.create_vault_note()` first.
+
+### Research briefing
+`klemma research -s X.X` → `_sync_sections()` → `researcher.research_section()` → auto-extracts fragments (if needed) → builds context → Claude → `ResearchResult` → vault note.
+
+### Paper acquisition
+`klemma acquire <url>` → `acquirer.acquire_paper()` → download PDF → pyzotero `create_items` → `create_attachment_record` → local storage → poll BBT for citekey → `state.register_sources()`.
+Requires: `ZOTERO_API_KEY`, `zotero.library_id` in config.
+
+### Library analysis
+`klemma library` → `librarian.analyze_library()` → `LibraryReport` → `Library/Library_{mode}_{date}.md` in vault.
+
+### Agent context
+`klemma ask "query"` → `agent.build_agent_context()` → system prompt → interactive Claude or `ai.call()`.
+
+### Agent Skills (Claude Code)
+Agent uses Claude Code Skills from `.claude/skills/` instead of reading source code:
+- `klemma-acquire` — full acquire pipeline instructions
+- `klemma-process` — fragment extraction (single, batch, parallel)
+- `klemma-status` — coverage and gaps check
+
+Skills auto-discovered by Claude Code in `--system-prompt` mode. Agent prompt references via `/klemma-acquire`, `/klemma-process`, `/klemma-status`.
+
+See: [Literature](../literature/CLAUDE.md) for PDF extraction and note creation | [MCP Tools](../tools/CLAUDE.md) for search and discovery | [Prompts](../../../prompts/CLAUDE.md) for template variables | [Core](../CLAUDE.md) for AI providers and state

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -82,4 +82,7 @@ Agent uses Claude Code Skills from `.claude/skills/` instead of reading source c
 
 Skills auto-discovered by Claude Code in `--system-prompt` mode. Agent prompt references via `/klemma-acquire`, `/klemma-process`, `/klemma-status`.
 
+## Maintaining this file
+Update when: adding a new skill module, changing skill function signatures or data flow steps, adding new Claude Code skills to `.claude/skills/`, or modifying how skills compose with infrastructure. If a new skill uses a prompt template, also update [Prompts](../../../prompts/CLAUDE.md).
+
 See: [Literature](../literature/CLAUDE.md) for PDF extraction and note creation | [MCP Tools](../tools/CLAUDE.md) for search and discovery | [Prompts](../../../prompts/CLAUDE.md) for template variables | [Core](../CLAUDE.md) for AI providers and state

--- a/src/klemma/tools/CLAUDE.md
+++ b/src/klemma/tools/CLAUDE.md
@@ -1,0 +1,42 @@
+# MCP Tool Integration
+
+External tool access via Model Context Protocol (MCP). Servers are not installed by Klemma — only launch commands are registered in `config.yaml`.
+
+## Modules
+
+### client.py (133 lines)
+`MCPClient` — sync wrapper around async MCP Python SDK (stdio transport).
+- `list_tools()` → `ToolInfo` list (name, description, input_schema)
+- `call_tool()` → `ToolResult` (content, is_error, raw)
+- Each call spawns a fresh subprocess connection (stateless, no persistent session)
+- Handles async-in-sync: detects running event loop, falls back to `ThreadPoolExecutor`
+
+### registry.py (129 lines)
+`ToolRegistry` — created once per `KlemmaContext`, manages MCP server configs from `config.mcp.servers`.
+- `_get_client()` — lazy create or return cached `MCPClient`
+- `call()` — route tool call to the right server
+- `list_tools()` / `available_tools()` — enumerate server capabilities
+- `add_server()` / `remove_server()` — edit `config.yaml` with regex (preserves formatting)
+
+### discovery.py (262 lines)
+Hybrid discovery pipeline for finding new literature:
+- **Phase 1** (deterministic): MCP search per ref-gap + section keywords → deduplicate against existing library
+- **Phase 2** (Claude): relevance assessment, usage type, priority scoring
+- Results saved to `discoveries` table (status: pending/accepted/rejected)
+- Can run as background subprocess: `python -m klemma.tools.discovery --section X.X --config config.yaml`
+
+## Data flows
+
+### MCP tool integration
+`klemma tools add <name> --command <cmd> --args <args>` → `registry.add_server()` writes to `config.yaml`.
+`klemma tools call <server> <tool> <args>` → `registry.call()` → `client.call_tool()` → MCP stdio.
+
+### Paper search
+`klemma search "query"` → `ToolRegistry.call("academia", "arxiv_search", ...)` → rich table output.
+Requires registered `academia` MCP server.
+
+### Discovery pipeline
+`klemma discover -s X.X` → `discovery.run_discovery()` → Phase 1 + Phase 2 → `state.save_discovery()`.
+Background mode: `--background` spawns subprocess; `--status` checks progress; `--review` shows results.
+
+See: [Core infrastructure](../CLAUDE.md) for `ToolRegistry` in `KlemmaContext` | [AI Skills](../skills/CLAUDE.md) for how discovery feeds research briefings

--- a/src/klemma/tools/CLAUDE.md
+++ b/src/klemma/tools/CLAUDE.md
@@ -39,4 +39,7 @@ Requires registered `academia` MCP server.
 `klemma discover -s X.X` → `discovery.run_discovery()` → Phase 1 + Phase 2 → `state.save_discovery()`.
 Background mode: `--background` spawns subprocess; `--status` checks progress; `--review` shows results.
 
+## Maintaining this file
+Update when: adding new MCP server types, changing `MCPClient`/`ToolRegistry` interfaces, modifying discovery pipeline phases, or adding new tool-related CLI commands.
+
 See: [Core infrastructure](../CLAUDE.md) for `ToolRegistry` in `KlemmaContext` | [AI Skills](../skills/CLAUDE.md) for how discovery feeds research briefings

--- a/src/klemma/tui/CLAUDE.md
+++ b/src/klemma/tui/CLAUDE.md
@@ -19,4 +19,7 @@ Entry point: `app.py` → `KlemmaApp` → mounts screens.
 - Data via: `state.get_stats()`, `state.get_fragment_stats()`, `state.get_plan()`, `state.get_gap_summary()`, `state.get_coverage_stats()`, `state.get_fragments()`
 - Status colors: green (ok), yellow (low), red (gap)
 
+## Maintaining this file
+Update when: adding new TUI screens, changing screen data dependencies, or modifying the state query methods that screens rely on.
+
 See: [Core infrastructure](../CLAUDE.md) for state query methods used by TUI

--- a/src/klemma/tui/CLAUDE.md
+++ b/src/klemma/tui/CLAUDE.md
@@ -1,0 +1,22 @@
+# TUI — Textual Dashboard
+
+Textual-based TUI app launched via bare `klemma` command (no subcommand).
+Entry point: `app.py` → `KlemmaApp` → mounts screens.
+
+## Screens
+
+| Screen | Lines | Purpose |
+|--------|-------|---------|
+| `dashboard.py` | 110 | Main: stats row + today's plan + coverage + ref-gaps |
+| `coverage.py` | 68 | Chapter/section coverage table with color-coded status |
+| `gaps.py` | 69 | Reference gaps with scores |
+| `fragments.py` | 47 | Fragment browser (source, type, section, relevance, text) |
+| `stats.py` | 68 | Processing statistics (completed/pending/failed) |
+
+## Architecture
+- Pure **read-only layer** over state — no direct AI or literature imports
+- All screens import only: `config.KlemmaConfig`, `state.StateManager`, `vault.VaultAdapter`
+- Data via: `state.get_stats()`, `state.get_fragment_stats()`, `state.get_plan()`, `state.get_gap_summary()`, `state.get_coverage_stats()`, `state.get_fragments()`
+- Status colors: green (ok), yellow (low), red (gap)
+
+See: [Core infrastructure](../CLAUDE.md) for state query methods used by TUI

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -20,4 +20,7 @@ pytest tests/
 - Mock external dependencies (AI CLIs, SDKs, Zotero API, MCP servers)
 - Mirror source structure: `test_<module>.py` for `src/klemma/<module>.py`
 
+## Maintaining this file
+Update when: adding new test files (add to "Current test suite"), changing testing patterns, or adding integration test infrastructure.
+
 See: [Core infrastructure](../src/klemma/CLAUDE.md) for AI provider architecture

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,23 @@
+# Tests
+
+## Current test suite
+- `test_ai.py` (112 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
+- `test_ai_openai.py` (118 lines) — `OpenAIClient` with mocked openai SDK
+
+## Patterns
+- pytest + `unittest.mock` (`patch`, `MagicMock`)
+- AI backends tested with mocked subprocess (Claude) or mocked SDK (OpenAI)
+- Config fixtures use `AIConfig` Pydantic models with test values
+- No integration tests (all mocked)
+
+## Running
+```bash
+pip install -e ".[dev]"
+pytest tests/
+```
+
+## Adding tests
+- Mock external dependencies (AI CLIs, SDKs, Zotero API, MCP servers)
+- Mirror source structure: `test_<module>.py` for `src/klemma/<module>.py`
+
+See: [Core infrastructure](../src/klemma/CLAUDE.md) for AI provider architecture


### PR DESCRIPTION
## Summary
Restructured the monolithic CLAUDE.md documentation into a modular knowledge graph of 8 interconnected files, one per subsystem. Each file is self-contained and loaded incrementally as the agent navigates directories, making the codebase easier to understand and maintain.

## Key Changes

- **Root CLAUDE.md** (`CLAUDE.md`): Converted from detailed data flows to a high-level index with:
  - Module documentation links (7 subsystems)
  - Development setup instructions
  - Maintenance guidelines for the documentation system itself
  - Rules for when/how to update child CLAUDE.md files

- **Core infrastructure** (`src/klemma/CLAUDE.md`): New file documenting foundation layer:
  - 7 root-level modules (cli, context, config, state, ai, vault, library_provider, app)
  - SQLite table schema with key methods
  - Auto-sync sections and multi-section source data flows

- **AI Skills** (`src/klemma/skills/CLAUDE.md`): New file for 6 skill modules:
  - planner, extractor, researcher, librarian, agent, acquirer
  - Fragment extraction, research briefing, paper acquisition, library analysis, and agent context flows
  - Claude Code Skills integration

- **Literature Management** (`src/klemma/literature/CLAUDE.md`): New file for data layer:
  - 4 modules (models, pdf, zotero, note_factory)
  - 3-tier PDF finding algorithm
  - Vault note creation pipeline and reference gap tracking

- **MCP Tools** (`src/klemma/tools/CLAUDE.md`): New file for external tool integration:
  - 3 modules (client, registry, discovery)
  - MCP server management and discovery pipeline

- **Prompts** (`prompts/CLAUDE.md`): New file documenting Jinja2 templates:
  - Template table mapping templates to skills
  - Key variables for each template
  - Naming conventions

- **TUI** (`src/klemma/tui/CLAUDE.md`): New file for dashboard:
  - 5 screens with line counts and purposes
  - Read-only architecture and state dependencies

- **Tests** (`tests/CLAUDE.md`): New file for test patterns:
  - Current test suite overview
  - Testing patterns and conventions
  - Running and adding tests

## Implementation Details

- **Structure rules** enforced: primary owner per data flow, line counts, cross-references with relative paths, self-contained modules, concise documentation
- **Maintenance guidelines** specify when to update (adding modules, CLI commands, tables, prompts, data flows, renaming)
- **Template for new CLAUDE.md files** provided to ensure consistency
- All child files end with "See:" links to related documentation for navigation
- No source code changes — purely documentation restructuring

https://claude.ai/code/session_01V7RhwjFHdxCmgN3fnHMSNc