### PR TITLE
Extract user-specific data to ~/.klemma/ for OSS readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ exports/
 *.swp
 *.swo
 .claude/settings.local.json
+
+# User-specific files (use config.example.yaml as template)
+config.yaml
+PROJECT_LOG.md
+*.code-workspace
+secure-ai-assistant-roadmap.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ Klemma is a CLI tool for PhD dissertation work. It manages literature (via Zoter
 ```
 src/klemma/
 ├── cli.py              — Click CLI entry point
-├── config.py           — Pydantic config models (incl. MCPServerConfig, MCPConfig)
+├── config.py           — Pydantic config models + get_klemma_home(), load helpers, resolve_prompt()
 ├── context.py          — KlemmaContext dataclass (single object per CLI command)
+├── setup.py            — `klemma init` logic — scaffolds ~/.klemma/ from example files
 ├── state.py            — SQLite state manager
 ├── ai.py               — AIProvider protocol + AIProviderBase + ClaudeClient + create_ai() factory
 ├── ai_openai.py        — OpenAI-compatible backend (OpenAI, Ollama, vLLM, LM Studio)
@@ -30,21 +31,25 @@ src/klemma/
     ├── client.py       — MCPClient (sync wrapper over async MCP SDK)
     ├── registry.py     — ToolRegistry (server management, lazy client creation)
     └── discovery.py    — Hybrid discovery pipeline (MCP search + Claude assessment)
-prompts/
-├── morning.md              — Jinja2 prompt for daily plans
-├── extract.md              — Jinja2 prompt for fragment extraction
-├── annotate.md             — Jinja2 prompt for vault note AI annotation
-├── research.md             — Jinja2 prompt for research briefing (first run)
-├── research_incremental.md — Jinja2 prompt for incremental research update
-├── librarian.md            — Jinja2 prompt for library analysis (3 modes)
-└── agent.md                — Jinja2 system prompt for interactive agent
+prompts/                    — Shipped Jinja2 prompt templates (overridable via ~/.klemma/prompts/)
+├── morning.md              — daily plans
+├── extract.md              — fragment extraction
+├── annotate.md             — vault note AI annotation
+├── research.md             — research briefing (first run)
+├── research_incremental.md — incremental research update
+├── librarian.md            — library analysis (3 modes)
+└── agent.md                — interactive agent system prompt
+config.example.yaml         — Template config for `klemma init`
+context.example.md          — Template dissertation context
+tags.example.yaml           — Template tag taxonomy
 .claude/skills/
 ├── klemma-acquire/SKILL.md — Agent skill: paper acquisition pipeline
 ├── klemma-process/SKILL.md — Agent skill: fragment extraction
 └── klemma-status/SKILL.md  — Agent skill: coverage & gaps check
 ```
 
-## Key commands (10)
+## Key commands (11)
+- `klemma init` — scaffold `~/.klemma/` with config templates (first-time setup)
 - `klemma plan` — daily plan generation (library digest included)
 - `klemma status` — unified stats + coverage + gaps + ref-gaps (`--verbose`, `--chapter N`)
 - `klemma process [<citekeys>...]` — extract fragments from PDF; no arg = batch all pending; parallel by default
@@ -59,7 +64,21 @@ prompts/
 Hidden aliases (backward compat): `morning`→`plan`, `extract`→`process`, `agent`→`ask`, `stats`/`coverage`/`gaps`→`status`, `prepopulate`→`import`
 
 ## Config
-- `config.yaml` — main config (Zotero, Obsidian, AI, dissertation structure, MCP servers)
+
+User data lives in `~/.klemma/` (overridable via `KLEMMA_HOME` env var):
+```
+~/.klemma/
+├── config.yaml    — main config (Zotero, Obsidian, AI, dissertation structure, MCP)
+├── context.md     — dissertation context (topic, results, chapters, key terms)
+├── tags.yaml      — tag taxonomy for fragment classification (list of strings)
+├── prompts/       — optional user overrides for shipped Jinja2 prompt templates
+└── data/
+    └── klemma.db  — SQLite database
+```
+
+Run `klemma init` to scaffold from `config.example.yaml`, `context.example.md`, `tags.example.yaml`.
+
+**Config keys:**
 - `zotero.library_json` — path to BetterBibTeX JSON export (for PDF lookup)
 - `zotero.backend` — `"local"` (default, BBT JSON) or `"mcp"` (zotero-mcp server)
 - `mcp.servers` — registered MCP servers (managed via `klemma tools add/remove`)
@@ -68,6 +87,10 @@ Hidden aliases (backward compat): `morning`→`plan`, `extract`→`process`, `ag
 - `ai.api_key_env` — env var name for API key (e.g. `"OPENAI_API_KEY"`)
 - `ai.json_mode` — enable structured JSON output when backend supports it
 - Requires: AI backend (`claude` CLI by default, or `pip install klemma[openai]` / `klemma[litellm]`), optionally `ZOTERO_API_KEY`
+
+**Prompt resolution:** `resolve_prompt(name, klemma_home)` checks `~/.klemma/prompts/<name>` first, then falls back to shipped `prompts/<name>`.
+
+**Fallbacks:** If `context.md` is missing, context is built from `config.dissertation` fields. If `tags.yaml` is missing, tags are extracted from `config.tags.auto_mapping` keys.
 
 ## SQLite tables
 - `sources` — Zotero entries with processing status and dissertation metadata
@@ -96,6 +119,8 @@ pip install -e ".[dev]"
 pip install -e ".[openai]"     # OpenAI / Ollama / vLLM / LM Studio backend
 pip install -e ".[litellm]"    # LiteLLM universal backend (100+ providers)
 pip install -e ".[all-ai]"     # all AI backends
+klemma init                    # scaffold ~/.klemma/ with config templates
+# edit ~/.klemma/config.yaml, context.md, tags.yaml for your project
 klemma --help
 ```
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,126 @@
+# =============================================================================
+# KLEMMA CONFIGURATION — Example
+# =============================================================================
+# Copy to ~/.klemma/config.yaml and customize for your project.
+# See: https://github.com/bolkhovsky/klemma
+
+instance:
+  name: "my-dissertation"
+  type: "academic"
+
+zotero:
+  library_id: "YOUR_LIBRARY_ID"       # Zotero library ID (from Settings → Feeds/API)
+  library_type: "user"                 # "user" or "group"
+  api_key_env: "ZOTERO_API_KEY"        # env var holding your Zotero API key
+  local: false
+  library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
+  storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
+
+obsidian:
+  vault_path: "/path/to/your/obsidian/vault"
+  notes_folder: "References"           # folder with @citekey.md notes
+  tags_folder: "Tags"                  # optional folder for tag notes
+  use_cli: null
+
+ai:
+  model: "sonnet"                      # claude model: "opus", "sonnet", "haiku"
+  max_pdf_chars: 50000
+  timeout: 300
+  retries: 2
+  # Uncomment for OpenAI-compatible backends (Ollama, vLLM, LM Studio):
+  # backend: "openai"
+  # base_url: "http://localhost:11434/v1"
+  # api_key_env: "OPENAI_API_KEY"
+  # json_mode: true
+
+state:
+  db_path: "./data/klemma.db"          # relative to ~/.klemma/ or absolute
+
+dissertation:
+  current_chapter: 1
+  current_section: "1.1"
+  title: "Your dissertation title"
+  chapters:
+    1: "Literature review"
+    2: "Methodology"
+    3: "Results and discussion"
+    4: "Implementation"
+  scientific_results:
+    nr1: "First scientific result"
+    nr2: "Second scientific result"
+  deadlines:
+    - chapter: "1"
+      deadline: "2026-06-01"
+      label: "Chapter 1"
+    - chapter: "2"
+      deadline: "2026-09-01"
+      label: "Chapter 2"
+    - chapter: "3"
+      deadline: "2026-11-01"
+      label: "Chapter 3"
+    - chapter: "4"
+      deadline: "2027-01-01"
+      label: "Chapter 4"
+  chapter_plan_pattern: "Plan_Chapter{chapter}"
+  writing_constraints: "1-2 hours/day, 200-400 words/day"
+  priority_terms:
+    - your_key_term_1
+    - your_key_term_2
+  min_sources_per_section: 3
+  chapter_mapping:
+    # Map keywords in source text to chapters/sections:
+    # - pattern: "regex pattern"
+    #   chapter: 1
+    #   section: "1.2.1"
+    - pattern: "literature review|survey|state of the art"
+      chapter: 1
+      section: "1.1"
+    - pattern: "methodology|method|approach"
+      chapter: 2
+      section: "2.1"
+
+planning:
+  dissertation_focus: "Chapter 1, Section 1.1"
+  assistant_roadmap:
+    - "Fragment extraction (klemma process)"
+    - "Reading queue"
+
+reading:
+  snippet_length: 2000
+  daily_papers: 1
+  priority_boost_chapters: [1, 2]
+
+processing:
+  batch_size: 2
+  skip_no_pdf: true
+  min_pdf_length: 500
+
+tags:
+  auto_mapping:
+    # Map keywords to tags for automatic classification:
+    - pattern: "review|survey|meta.?analysis"
+      tag: "Review"
+    - pattern: "dataset|benchmark|open data"
+      tag: "Dataset"
+    - pattern: "methodology|method"
+      tag: "Methodology"
+    - pattern: "machine learning|deep learning|neural network"
+      tag: "Machine Learning"
+    - pattern: "statistical|regression|correlation"
+      tag: "Statistics"
+
+export:
+  output_dir: "./exports"
+  pandoc:
+    timeout: 300
+    number_sections: true
+
+mcp:
+  servers: {}
+  # Example: add MCP servers for external search
+  # servers:
+  #   zotero:
+  #     command: "uvx"
+  #     args: ["zotero-mcp"]
+  #     env:
+  #       ZOTERO_LOCAL: "true"

--- a/context.example.md
+++ b/context.example.md
@@ -1,0 +1,15 @@
+# Dissertation Context
+
+Topic: "Your dissertation title here"
+
+Scientific Results:
+- NR1: First scientific result — what you aim to prove or build
+- NR2: Second scientific result — the methodology or framework
+
+Chapters:
+1. Literature review and domain analysis (deadline: 2026-06-01)
+2. Methodology and model design (deadline: 2026-09-01)
+3. Results and validation (deadline: 2026-11-01)
+4. Implementation and software (deadline: 2027-01-01)
+
+Key terms: term1, term2, term3, abbreviation1, abbreviation2

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -10,13 +10,21 @@ Click CLI entry point. Defines all 11 commands + hidden aliases.
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
 
-### context.py (30 lines)
+### context.py (35 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.
-Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional).
+Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional), `klemma_home`, `dissertation_context`, `available_tags`.
 
-### config.py (164 lines)
+### config.py (~200 lines)
 Pydantic config models loaded from `config.yaml`.
 Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `MCPConfig`, `MCPServerConfig`.
+- `get_klemma_home()` — returns `Path(KLEMMA_HOME)` or `~/.klemma`
+- `load_dissertation_context(klemma_home, config)` — reads `context.md`, fallback from config fields
+- `load_available_tags(klemma_home, config)` — reads `tags.yaml`, fallback from `tags.auto_mapping`
+- `resolve_prompt(name, klemma_home)` — user override in `klemma_home/prompts/`, then shipped `prompts/`
+
+### setup.py (42 lines)
+`klemma init` logic — creates `~/.klemma/` from example template files.
+- `init_klemma_home(klemma_home)` — copies config.example.yaml → config.yaml, etc.
 
 ### state.py (1207 lines)
 SQLite state manager. Tables:

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from . import __version__, get_banner
 from .ai import create_ai
-from .config import load_config
+from .config import get_klemma_home, load_available_tags, load_config, load_dissertation_context
 from .context import KlemmaContext
 from .library_provider import create_library
 from .state import StateManager
@@ -21,14 +21,42 @@ from .vault import VaultAdapter
 console = Console()
 
 
-def _init_components(config_path: str) -> KlemmaContext:
-    """Initialize all components from config."""
-    cfg = load_config(config_path)
-    state = StateManager(cfg.state.db_path)
+def _init_components(config_path: str | None) -> KlemmaContext:
+    """Initialize all components from config.
+
+    If config_path is the default sentinel, loads from klemma_home.
+    """
+    klemma_home = get_klemma_home()
+
+    # Use explicit --config if provided, otherwise default to klemma_home
+    if config_path is None:
+        cfg = load_config(None)  # uses get_klemma_home() / "config.yaml"
+    else:
+        cfg = load_config(config_path)
+
+    # Resolve db_path relative to klemma_home if relative
+    db_path = cfg.state.db_path
+    if not Path(db_path).is_absolute():
+        db_path = str(klemma_home / db_path)
+
+    state = StateManager(db_path)
     vault = VaultAdapter(cfg.obsidian.vault_path, use_cli=cfg.obsidian.use_cli)
     library = create_library(cfg)
     tools = ToolRegistry(cfg) if cfg.mcp.servers else None
-    return KlemmaContext(config=cfg, state=state, vault=vault, library=library, tools=tools)
+
+    dissertation_context = load_dissertation_context(klemma_home, cfg)
+    available_tags = load_available_tags(klemma_home, cfg)
+
+    return KlemmaContext(
+        config=cfg,
+        state=state,
+        vault=vault,
+        library=library,
+        tools=tools,
+        klemma_home=klemma_home,
+        dissertation_context=dissertation_context,
+        available_tags=available_tags,
+    )
 
 
 def _init_ai(cfg):
@@ -226,7 +254,7 @@ def _print_ref_gaps_table(state: StateManager, limit: int = 20):
 
 @click.group(invoke_without_command=True)
 @click.version_option(version=__version__)
-@click.option("--config", "-c", default="config.yaml", help="Config file path")
+@click.option("--config", "-c", default=None, help="Config file path (default: ~/.klemma/config.yaml)")
 @click.pass_context
 def main(ctx, config):
     """Klemma — AI academic assistant.
@@ -235,6 +263,21 @@ def main(ctx, config):
     """
     ctx.ensure_object(dict)
     ctx.obj["config_path"] = config
+
+    # Check klemma_home exists for all commands except init
+    klemma_home = get_klemma_home()
+    if (
+        ctx.invoked_subcommand is not None
+        and ctx.invoked_subcommand != "init"
+        and config is None
+        and not (klemma_home / "config.yaml").exists()
+    ):
+        console.print(
+            f"[yellow]Config not found at {klemma_home / 'config.yaml'}[/yellow]\n"
+            "Run [bold]klemma init[/bold] to set up, or use --config to specify a config file."
+        )
+        ctx.exit(1)
+        return
 
     # Banner
     console.print(get_banner(cwd=str(Path.cwd())))
@@ -253,6 +296,31 @@ def main(ctx, config):
 
 @main.command()
 @click.pass_context
+def init(ctx):
+    """Initialize ~/.klemma/ with config templates."""
+    from .setup import init_klemma_home
+
+    klemma_home = get_klemma_home()
+    result = init_klemma_home(klemma_home)
+
+    if result["created"]:
+        console.print(f"[green]Created {klemma_home}/[/green]")
+        for name in result["created"]:
+            console.print(f"  + {name}")
+    if result["skipped"]:
+        for name in result["skipped"]:
+            console.print(f"  [dim]~ {name} (already exists, skipped)[/dim]")
+
+    console.print()
+    console.print("[bold]Next steps:[/bold]")
+    console.print(f"  1. Edit [cyan]{klemma_home / 'config.yaml'}[/cyan] — set Zotero/Obsidian paths")
+    console.print(f"  2. Edit [cyan]{klemma_home / 'context.md'}[/cyan] — describe your dissertation")
+    console.print(f"  3. Edit [cyan]{klemma_home / 'tags.yaml'}[/cyan] — define your topic taxonomy")
+    console.print(f"  4. Run [bold]klemma status[/bold] to verify")
+
+
+@main.command()
+@click.pass_context
 def plan(ctx):
     """Daily plan — focus, recommendations, deadlines."""
     config_path = ctx.obj["config_path"]
@@ -263,7 +331,11 @@ def plan(ctx):
     from .skills.planner import generate_morning_plan
 
     with console.status("Генерация утреннего брифинга", spinner="dots"):
-        plan = generate_morning_plan(cfg, state, vault, ai)
+        plan = generate_morning_plan(
+            cfg, state, vault, ai,
+            dissertation_context=kctx.dissertation_context,
+            klemma_home=kctx.klemma_home,
+        )
 
     console.print()
 
@@ -367,7 +439,9 @@ def process(ctx, citekeys, serial):
         ):
             with ThreadPoolExecutor(max_workers=3) as pool:
                 futures = {
-                    pool.submit(_process_single, ck, cfg, state, vault, ai, pdf_extractor, kctx.library, quiet=True): ck
+                    pool.submit(_process_single, ck, cfg, state, vault, ai, pdf_extractor, kctx.library, quiet=True,
+                               dissertation_context=kctx.dissertation_context, available_tags=kctx.available_tags,
+                               klemma_home=kctx.klemma_home): ck
                     for ck in keys
                 }
                 for future in as_completed(futures):
@@ -392,14 +466,18 @@ def process(ctx, citekeys, serial):
         for idx, ck in enumerate(keys, 1):
             if len(keys) > 1:
                 console.print(f"\n[bold][{idx}/{len(keys)}] {ck}[/bold]")
-            n_frags, _ = _process_single(ck, cfg, state, vault, ai, pdf_extractor, kctx.library)
+            n_frags, _ = _process_single(ck, cfg, state, vault, ai, pdf_extractor, kctx.library,
+                                         dissertation_context=kctx.dissertation_context,
+                                         available_tags=kctx.available_tags,
+                                         klemma_home=kctx.klemma_home)
             if n_frags > 0:
                 processed += 1
         if len(keys) > 1:
             console.print(f"\n[green]Done: {processed}/{len(keys)} processed.[/green]")
 
 
-def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quiet=False):
+def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quiet=False,
+                    dissertation_context="", available_tags=None, klemma_home=None):
     """Process a single source: find PDF, extract fragments, save to vault.
 
     Returns (fragment_count, status_message). When quiet=True, suppresses console output
@@ -442,7 +520,12 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
         return (0, "text too short")
 
     # Extract fragments
-    result = extract_fragments(entry, pdf_text, cfg, state, ai)
+    result = extract_fragments(
+        entry, pdf_text, cfg, state, ai,
+        dissertation_context=dissertation_context,
+        available_tags=available_tags,
+        klemma_home=klemma_home,
+    )
 
     if not result or not result.fragments:
         if not quiet:
@@ -457,6 +540,9 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
         citekey, result.fragments, vault,
         entry=entry, config=cfg, state=state,
         pdf_text=pdf_text, ai=ai, entry_lookup=library.entries,
+        dissertation_context=dissertation_context,
+        available_tags=available_tags,
+        klemma_home=klemma_home,
     )
     if not quiet:
         if saved_path:
@@ -633,6 +719,9 @@ def research(ctx, section, no_save, force, enrich):
             force=force,
             library=kctx.library,
             on_progress=lambda ck, st, i, n: None,  # suppress inside spinner
+            dissertation_context=kctx.dissertation_context,
+            available_tags=kctx.available_tags,
+            klemma_home=kctx.klemma_home,
         )
 
     extracted = extract_result["extracted"]
@@ -664,7 +753,11 @@ def research(ctx, section, no_save, force, enrich):
         spinner_text = f"Анализ раздела {section}"
 
     with console.status(spinner_text, spinner="dots"):
-        result = research_section(section, cfg, state, vault, ai, save_to_vault=not no_save)
+        result = research_section(
+            section, cfg, state, vault, ai, save_to_vault=not no_save,
+            dissertation_context=kctx.dissertation_context,
+            klemma_home=kctx.klemma_home,
+        )
 
     if not result.section_status:
         console.print("[red]Не удалось сгенерировать брифинг.[/red]")
@@ -827,7 +920,11 @@ def ask(ctx, query, section, chapter):
     from .skills.agent import build_agent_context
 
     with console.status("Сборка контекста исследования", spinner="dots"):
-        context = build_agent_context(cfg, state, vault, section=section, chapter=chapter)
+        context = build_agent_context(
+            cfg, state, vault, section=section, chapter=chapter,
+            dissertation_context=kctx.dissertation_context,
+            klemma_home=kctx.klemma_home,
+        )
 
     console.print(f"[dim]Query: {query}[/dim]")
 
@@ -873,7 +970,11 @@ def library(ctx, section, audit):
     mode = "audit" if audit else "recommend" if section else "status"
 
     with console.status(f"Analyzing library ({mode})", spinner="dots"):
-        report = analyze_library(cfg, state, vault, ai, entry_lookup, mode=mode, focus_section=section)
+        report = analyze_library(
+            cfg, state, vault, ai, entry_lookup, mode=mode, focus_section=section,
+            dissertation_context=kctx.dissertation_context,
+            klemma_home=kctx.klemma_home,
+        )
 
     if not report:
         console.print("[red]Failed to generate library analysis.[/red]")
@@ -1127,7 +1228,10 @@ def acquire(ctx, url, title, authors, year, journal, volume, issue, section, bat
                     from .literature.pdf import PDFExtractor
                     pdf_extractor = PDFExtractor(max_chars=cfg.ai.max_pdf_chars)
                     with console.status(f"Extracting fragments from @{result.citekey}", spinner="arc"):
-                        _process_single(result.citekey, cfg, state, kctx.vault, ai, pdf_extractor, kctx.library)
+                        _process_single(result.citekey, cfg, state, kctx.vault, ai, pdf_extractor, kctx.library,
+                                        dissertation_context=kctx.dissertation_context,
+                                        available_tags=kctx.available_tags,
+                                        klemma_home=kctx.klemma_home)
 
             ok += 1
         else:

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -1,11 +1,22 @@
 """Configuration loader with Pydantic validation."""
 
+import logging
 import os
 from pathlib import Path
 from typing import Optional
 
 import yaml
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Shipped prompts directory (relative to this file → repo root / prompts)
+_SHIPPED_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
+
+
+def get_klemma_home() -> Path:
+    """Return klemma home directory (~/.klemma/ or KLEMMA_HOME env var)."""
+    return Path(os.environ.get("KLEMMA_HOME", "~/.klemma")).expanduser()
 
 
 class ZoteroConfig(BaseModel):
@@ -144,9 +155,16 @@ class KlemmaConfig(BaseModel):
     mcp: MCPConfig = Field(default_factory=MCPConfig)
 
 
-def load_config(config_path: str | Path = "config.yaml") -> KlemmaConfig:
-    """Load and validate configuration from YAML file."""
-    path = Path(config_path)
+def load_config(config_path: str | Path | None = None) -> KlemmaConfig:
+    """Load and validate configuration from YAML file.
+
+    If config_path is None, uses get_klemma_home() / "config.yaml".
+    """
+    if config_path is None:
+        path = get_klemma_home() / "config.yaml"
+    else:
+        path = Path(config_path)
+
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
 
@@ -162,3 +180,69 @@ def load_config(config_path: str | Path = "config.yaml") -> KlemmaConfig:
             raw["zotero"] = migrated
 
     return KlemmaConfig.model_validate(raw)
+
+
+def load_dissertation_context(klemma_home: Path, config: KlemmaConfig) -> str:
+    """Load dissertation context from context.md or build from config fields.
+
+    Looks for klemma_home/context.md first. If not found, builds a basic
+    context string from config.dissertation fields as fallback.
+    """
+    context_path = klemma_home / "context.md"
+    if context_path.exists():
+        text = context_path.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+
+    # Fallback: build from config fields
+    parts = []
+    if config.dissertation.title:
+        parts.append(f"Topic: {config.dissertation.title}")
+    if config.dissertation.scientific_results:
+        parts.append("")
+        for key, val in config.dissertation.scientific_results.items():
+            parts.append(f"{key.upper()}: {val}")
+    if config.dissertation.chapters:
+        parts.append("")
+        parts.append("Chapters:")
+        for ch_num, ch_name in sorted(config.dissertation.chapters.items()):
+            parts.append(f"{ch_num}. {ch_name}")
+    if config.dissertation.priority_terms:
+        parts.append("")
+        parts.append(f"Key terms: {', '.join(config.dissertation.priority_terms)}")
+
+    return "\n".join(parts)
+
+
+def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
+    """Load available tags from tags.yaml or extract from config.
+
+    Looks for klemma_home/tags.yaml first. If not found, extracts unique
+    tag names from config.tags.auto_mapping as fallback.
+    """
+    tags_path = klemma_home / "tags.yaml"
+    if tags_path.exists():
+        with open(tags_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, list):
+            return data
+
+    # Fallback: extract from auto_mapping
+    seen: set[str] = set()
+    tags: list[str] = []
+    for mapping in config.tags.auto_mapping:
+        if mapping.tag not in seen:
+            tags.append(mapping.tag)
+            seen.add(mapping.tag)
+    return tags
+
+
+def resolve_prompt(name: str, klemma_home: Path) -> Path:
+    """Resolve prompt template path: user override first, then shipped.
+
+    Looks in klemma_home/prompts/ first, then the shipped prompts/ directory.
+    """
+    user_path = klemma_home / "prompts" / name
+    if user_path.exists():
+        return user_path
+    return _SHIPPED_PROMPTS_DIR / name

--- a/src/klemma/context.py
+++ b/src/klemma/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -28,3 +29,6 @@ class KlemmaContext:
     ai: Optional[AIProvider] = None
     library: Optional[LibraryProvider] = None
     tools: Optional[ToolRegistry] = None
+    klemma_home: Path = field(default_factory=lambda: Path.home() / ".klemma")
+    dissertation_context: str = ""
+    available_tags: list[str] = field(default_factory=list)

--- a/src/klemma/literature/note_factory.py
+++ b/src/klemma/literature/note_factory.py
@@ -6,23 +6,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..vault import VaultAdapter
 from .models import ZoteroEntry
 
 logger = logging.getLogger(__name__)
-
-# Re-use AVAILABLE_TAGS from extractor
-AVAILABLE_TAGS = [
-    "Sea Ice", "Arctic", "Climate", "Forecasting", "Navigation", "Icebreaking",
-    "GIS", "Machine Learning", "LSTM", "ConvLSTM", "U-Net", "CNN",
-    "Transformer", "Classical ML", "Statistics", "Physical Model",
-    "Validation", "Metrics",
-    "Remote Sensing", "SAR", "Sentinel-1", "Microwave", "AMSR", "SSM-I",
-    "Optical", "ERA5", "Ice Products", "AARI",
-    "Barents Sea", "Kara Sea", "Laptev Sea", "Pacific Arctic", "Antarctic",
-    "Review", "Dataset",
-]
 
 
 def auto_classify(entry: ZoteroEntry, config: KlemmaConfig) -> dict:
@@ -82,6 +70,9 @@ def annotate_source(
     config: KlemmaConfig,
     ai: "AIProvider",
     entry_lookup: Optional[dict] = None,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[dict]:
     """Generate AI annotation (summary, methodology, key findings, relevance).
 
@@ -91,9 +82,7 @@ def annotate_source(
     key_references.
     Returns None on failure.
     """
-    from ..skills.planner import DISSERTATION_CONTEXT
-
-    prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "annotate.md"
+    prompt_path = resolve_prompt("annotate.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "annotate.md"
     user_prompt = ai.render_prompt(
         prompt_path,
         title=entry.title or "Unknown",
@@ -104,8 +93,8 @@ def annotate_source(
         language=entry.language or "Unknown",
         abstract=entry.abstract or "Not available",
         pdf_text=pdf_text,
-        dissertation_context=DISSERTATION_CONTEXT,
-        available_tags=", ".join(AVAILABLE_TAGS),
+        dissertation_context=dissertation_context,
+        available_tags=", ".join(available_tags) if available_tags else "",
         library_entries=_format_library_entries(entry_lookup),
     )
 
@@ -376,6 +365,9 @@ def create_vault_note(
     pdf_text: Optional[str] = None,
     ai: Optional["AIProvider"] = None,
     entry_lookup: Optional[dict] = None,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> Path:
     """Create @citekey.md vault note from BetterBibTeX metadata.
 
@@ -388,7 +380,12 @@ def create_vault_note(
     annotation = None
     if pdf_text and ai:
         logger.info("Generating annotation for @%s...", citekey)
-        annotation = annotate_source(entry, pdf_text, config, ai, entry_lookup=entry_lookup)
+        annotation = annotate_source(
+            entry, pdf_text, config, ai, entry_lookup=entry_lookup,
+            dissertation_context=dissertation_context,
+            available_tags=available_tags,
+            klemma_home=klemma_home,
+        )
 
     # 2. Classification: prefer AI result, fallback to regex
     if annotation and annotation.get("dissertation_relevance"):

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -1,0 +1,41 @@
+"""Setup logic for `klemma init` — creates ~/.klemma/ with template files."""
+
+import shutil
+from pathlib import Path
+
+
+# Example files shipped with the package (repo root)
+_EXAMPLES_DIR = Path(__file__).parent.parent.parent
+
+
+def init_klemma_home(klemma_home: Path) -> dict:
+    """Create klemma_home directory with template files.
+
+    Returns dict with keys: created (list of file names), skipped (list of file names).
+    """
+    created: list[str] = []
+    skipped: list[str] = []
+
+    klemma_home.mkdir(parents=True, exist_ok=True)
+    (klemma_home / "data").mkdir(exist_ok=True)
+
+    templates = {
+        "config.yaml": _EXAMPLES_DIR / "config.example.yaml",
+        "context.md": _EXAMPLES_DIR / "context.example.md",
+        "tags.yaml": _EXAMPLES_DIR / "tags.example.yaml",
+    }
+
+    for target_name, source_path in templates.items():
+        target = klemma_home / target_name
+        if target.exists():
+            skipped.append(target_name)
+            continue
+
+        if source_path.exists():
+            shutil.copy2(source_path, target)
+        else:
+            # Create minimal placeholder if example file not found
+            target.write_text(f"# {target_name} — edit this file\n", encoding="utf-8")
+        created.append(target_name)
+
+    return {"created": created, "skipped": skipped}

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -2,25 +2,22 @@
 
 AI-powered features that compose config + state + vault + ai + literature into higher-level operations.
 All skills receive dependencies via function arguments (not global state).
-
-Shared constant: `planner.DISSERTATION_CONTEXT` is imported by extractor, researcher, librarian, agent.
+Dissertation context and tags are loaded from `~/.klemma/` at CLI startup and passed as parameters.
 
 ## Modules
 
-### planner.py (229 lines)
+### planner.py (~215 lines)
 Morning briefing generation. Gathers: deadline, streak, yesterday's plan, chapter plan, library digest, coverage stats, ref-gaps.
-- `generate_morning_plan()` — full context → `prompts/morning.md` → Claude → `DailyPlan` → state + vault
-- `DISSERTATION_CONTEXT` — shared constant (topic, chapters, deadlines, keywords), imported by all other skills
-- `_get_current_deadline()` — calculate days remaining for current chapter
+- `generate_morning_plan(config, state, vault, ai, dissertation_context, klemma_home)` — full context → `prompts/morning.md` → Claude → `DailyPlan` → state + vault
+- `_get_current_deadline()` — calculate days remaining for current chapter (also used by librarian, agent)
 - `_read_chapter_plan()` — load session plan from vault
 - Intervention types: `NONE`, `REPLAN`, `BOOST`, `SKIP`
 
-### extractor.py (205 lines)
+### extractor.py (~205 lines)
 Fragment extraction from PDFs.
-- `extract_fragments()` — renders `prompts/extract.md` with paper text + dissertation context → Claude → `ExtractionResult`
+- `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult`
 - `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze)
-- `save_fragments_to_vault()` — appends to `@citekey.md` under quotes section; auto-creates note if missing
-- Domain-specific `AVAILABLE_TAGS` for sea ice / ML / remote sensing taxonomy
+- `save_fragments_to_vault(citekey, fragments, vault, ..., dissertation_context, available_tags, klemma_home)` — appends to `@citekey.md`; auto-creates note if missing
 
 ### researcher.py (730 lines — largest skill)
 Section research briefings. Two modes:

--- a/src/klemma/skills/agent.py
+++ b/src/klemma/skills/agent.py
@@ -7,10 +7,10 @@ from typing import Optional
 
 from jinja2 import Template
 
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..state import StateManager
 from ..vault import VaultAdapter
-from .planner import DISSERTATION_CONTEXT, _get_current_deadline
+from .planner import _get_current_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,8 @@ def build_agent_context(
     vault: VaultAdapter,
     section: Optional[str] = None,
     chapter: Optional[int] = None,
+    dissertation_context: str = "",
+    klemma_home: Optional[Path] = None,
 ) -> str:
     """Build a rich system prompt with full research context for the agent.
 
@@ -70,10 +72,10 @@ def build_agent_context(
     next_reading = state.get_next_reading()
 
     # Render prompt
-    prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "agent.md"
+    prompt_path = resolve_prompt("agent.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "agent.md"
     raw = prompt_path.read_text(encoding="utf-8")
     context = Template(raw).render(
-        dissertation_context=DISSERTATION_CONTEXT,
+        dissertation_context=dissertation_context,
         chapters=config.dissertation.chapters,
         scientific_results=config.dissertation.scientific_results,
         priority_terms=config.dissertation.priority_terms,

--- a/src/klemma/skills/extractor.py
+++ b/src/klemma/skills/extractor.py
@@ -5,25 +5,13 @@ from pathlib import Path
 from typing import Optional
 
 from ..ai import AIProvider
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..literature.models import ExtractionResult, Fragment, ZoteroEntry
 from ..literature.pdf import PDFExtractor
 from ..state import StateManager
 from ..vault import VaultAdapter
-from .planner import DISSERTATION_CONTEXT
 
 logger = logging.getLogger(__name__)
-
-AVAILABLE_TAGS = [
-    "Sea Ice", "Arctic", "Climate", "Forecasting", "Navigation", "Icebreaking",
-    "GIS", "Machine Learning", "LSTM", "ConvLSTM", "U-Net", "CNN",
-    "Transformer", "Classical ML", "Statistics", "Physical Model",
-    "Validation", "Metrics",
-    "Remote Sensing", "SAR", "Sentinel-1", "Microwave", "AMSR", "SSM-I",
-    "Optical", "ERA5", "Ice Products", "AARI",
-    "Barents Sea", "Kara Sea", "Laptev Sea", "Pacific Arctic", "Antarctic",
-    "Review", "Dataset",
-]
 
 
 def extract_fragments(
@@ -32,10 +20,13 @@ def extract_fragments(
     config: KlemmaConfig,
     state: StateManager,
     ai: AIProvider,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[ExtractionResult]:
     """Extract citation fragments from a paper's PDF text."""
 
-    prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "extract.md"
+    prompt_path = resolve_prompt("extract.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "extract.md"
     user_prompt = ai.render_prompt(
         prompt_path,
         title=entry.title or "Unknown",
@@ -45,8 +36,8 @@ def extract_fragments(
         doi=entry.DOI or "N/A",
         abstract=entry.abstract or "Not available",
         pdf_text=pdf_text,
-        dissertation_context=DISSERTATION_CONTEXT,
-        available_tags=", ".join(AVAILABLE_TAGS),
+        dissertation_context=dissertation_context,
+        available_tags=", ".join(available_tags) if available_tags else "",
     )
 
     system = (
@@ -129,6 +120,9 @@ def save_fragments_to_vault(
     pdf_text: Optional[str] = None,
     ai: Optional["AIProvider"] = None,
     entry_lookup: Optional[dict] = None,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[str]:
     """Save extracted fragments to the @citekey note in vault.
 
@@ -153,6 +147,9 @@ def save_fragments_to_vault(
             citekey, entry, config, vault,
             state=state, pdf_text=pdf_text, ai=ai,
             entry_lookup=entry_lookup,
+            dissertation_context=dissertation_context,
+            available_tags=available_tags,
+            klemma_home=klemma_home,
         )
         path = vault.update_section(note_name, section_heading, content)
         if path:
@@ -172,6 +169,9 @@ def extract_from_citekey(
     pdf_search_paths: list[Path],
     pdf_lookup: Optional[dict[str, str]] = None,
     entry_lookup: Optional[dict[str, ZoteroEntry]] = None,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[ExtractionResult]:
     """Full extraction pipeline: find source, get PDF, extract fragments."""
 
@@ -202,4 +202,9 @@ def extract_from_citekey(
         logger.error("PDF text too short or extraction failed for %s", citekey)
         return None
 
-    return extract_fragments(entry, pdf_text, config, state, ai)
+    return extract_fragments(
+        entry, pdf_text, config, state, ai,
+        dissertation_context=dissertation_context,
+        available_tags=available_tags,
+        klemma_home=klemma_home,
+    )

--- a/src/klemma/skills/librarian.py
+++ b/src/klemma/skills/librarian.py
@@ -7,15 +7,14 @@ from pathlib import Path
 from typing import Optional
 
 from ..ai import AIProvider
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..literature.models import LibraryReport
 from ..state import StateManager
 from ..vault import VaultAdapter
-from .planner import DISSERTATION_CONTEXT, _get_current_deadline
+from .planner import _get_current_deadline
 
 logger = logging.getLogger(__name__)
 
-PROMPTS_DIR = Path(__file__).parent.parent.parent.parent / "prompts"
 LIBRARY_TIMEOUT = 300  # 5 min — library analysis needs more time than other skills
 
 
@@ -27,6 +26,8 @@ def analyze_library(
     entry_lookup: dict,
     mode: str = "status",
     focus_section: Optional[str] = None,
+    dissertation_context: str = "",
+    klemma_home: Optional[Path] = None,
 ) -> Optional[LibraryReport]:
     """Run AI library analysis and return structured report.
 
@@ -40,10 +41,11 @@ def analyze_library(
     active_sources = [s for s in all_sources if s["id"] not in drop_ids]
 
     context = _gather_library_context(
-        config, state, vault, entry_lookup, active_sources, mode, focus_section
+        config, state, vault, entry_lookup, active_sources, mode, focus_section,
+        dissertation_context=dissertation_context,
     )
 
-    prompt_path = PROMPTS_DIR / "librarian.md"
+    prompt_path = resolve_prompt("librarian.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "librarian.md"
     user_prompt = ai.render_prompt(prompt_path, **context)
 
     system = (
@@ -71,7 +73,7 @@ def analyze_library(
     # Stage 2: separate prune pass if library is oversaturated
     if len(active_sources) > 100:
         logger.info("Running prune analysis (%d active sources)...", len(active_sources))
-        prune_result = _run_prune_analysis(active_sources, entry_lookup, config, ai)
+        prune_result = _run_prune_analysis(active_sources, entry_lookup, config, ai, klemma_home=klemma_home)
         if prune_result:
             report.prune = prune_result
             state.save_prune_verdicts(
@@ -198,6 +200,7 @@ def _gather_library_context(
     active_sources: list[dict],
     mode: str,
     focus_section: Optional[str],
+    dissertation_context: str = "",
 ) -> dict:
     """Collect all data needed for the librarian prompt."""
     deadline, days_remaining = _get_current_deadline(config)
@@ -210,7 +213,7 @@ def _gather_library_context(
     sources_compact = _format_sources_compact(selected, entry_lookup)
 
     context = {
-        "dissertation_context": DISSERTATION_CONTEXT,
+        "dissertation_context": dissertation_context,
         "current_chapter": config.dissertation.current_chapter,
         "chapter_name": config.dissertation.chapters.get(
             config.dissertation.current_chapter, ""
@@ -313,13 +316,14 @@ def _run_prune_analysis(
     entry_lookup: dict,
     config: KlemmaConfig,
     ai: AIProvider,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[dict]:
     """Run focused prune analysis as a separate AI call.
 
     For >300 sources, batches per-chapter in parallel.
     """
     if len(active_sources) <= 300:
-        return _prune_batch(active_sources, entry_lookup, ai)
+        return _prune_batch(active_sources, entry_lookup, ai, klemma_home=klemma_home)
 
     # Per-chapter parallel batching
     by_chapter: dict[int, list] = {}
@@ -332,7 +336,7 @@ def _run_prune_analysis(
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = {
-            pool.submit(_prune_batch, sources, entry_lookup, ai): ch
+            pool.submit(_prune_batch, sources, entry_lookup, ai, klemma_home=klemma_home): ch
             for ch, sources in by_chapter.items()
         }
         for future in as_completed(futures):
@@ -351,12 +355,13 @@ def _run_prune_analysis(
 
 
 def _prune_batch(
-    sources: list[dict], entry_lookup: dict, ai: AIProvider
+    sources: list[dict], entry_lookup: dict, ai: AIProvider,
+    klemma_home: Optional[Path] = None,
 ) -> Optional[dict]:
     """Run prune on a batch of sources."""
     sources_compact = _format_sources_compact(sources, entry_lookup)
 
-    prompt_path = PROMPTS_DIR / "librarian_prune.md"
+    prompt_path = resolve_prompt("librarian_prune.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "librarian_prune.md"
     user_prompt = ai.render_prompt(
         prompt_path,
         sources_compact=sources_compact,

--- a/src/klemma/skills/planner.py
+++ b/src/klemma/skills/planner.py
@@ -8,28 +8,12 @@ from pathlib import Path
 from typing import Optional
 
 from ..ai import AIProvider
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..literature.models import DailyPlan
 from ..state import StateManager
 from ..vault import VaultAdapter
 
 logger = logging.getLogger(__name__)
-
-DISSERTATION_CONTEXT = """\
-Тема: «Геоинформационная методология представления и анализа оперативной НГГМИ
-для оценки ледовой обстановки в арктических акваториях с использованием нейронных сетей»
-
-НР1: Геоинформационная модель валидации прогнозов ледовой обстановки (AMSR2, Баренцево море)
-НР2: Геоинформационная методика оценки качества прогнозов (IIEE-декомпозиция: AEE + ME)
-
-Главы:
-1. Анализ предметной области прогнозирования ледовой обстановки (дедлайн: 15 марта 2026)
-2. Геоинформационная модель оценки качества прогнозов (дедлайн: 31 мая 2026)
-3. Методика валидации прогнозов ледовой обстановки (дедлайн: 31 августа 2026)
-4. Алгоритм и программная реализация валидации (дедлайн: 31 октября 2026)
-
-Ключевые понятия: SIC, IIEE, AEE, ME, IceNet, AMSR2, ДЗЗ, РСА, НГГМИ, НГО, АЗРФ, СМП\
-"""
 
 
 def _get_current_deadline(config: KlemmaConfig) -> tuple[str, int]:
@@ -123,6 +107,8 @@ def generate_morning_plan(
     state: StateManager,
     vault: VaultAdapter,
     ai: AIProvider,
+    dissertation_context: str = "",
+    klemma_home: Optional[Path] = None,
 ) -> DailyPlan:
     """Сгенерировать утренний брифинг через Claude."""
 
@@ -159,10 +145,10 @@ def generate_morning_plan(
         lib_digest += f" Разделы без источников: {', '.join(library_summary['zero_sections'][:5])}."
 
     # Рендер промпта
-    prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "morning.md"
+    prompt_path = resolve_prompt("morning.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "morning.md"
     user_prompt = ai.render_prompt(
         prompt_path,
-        dissertation_context=DISSERTATION_CONTEXT,
+        dissertation_context=dissertation_context,
         current_chapter=config.dissertation.current_chapter,
         current_section=config.dissertation.current_section,
         chapter_name=chapter_name,

--- a/src/klemma/skills/researcher.py
+++ b/src/klemma/skills/researcher.py
@@ -8,13 +8,12 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from ..ai import AIProvider
-from ..config import KlemmaConfig
+from ..config import KlemmaConfig, resolve_prompt
 from ..literature.models import ArgumentBlock, CitationEntry, ResearchResult, ZoteroEntry
 from ..literature.pdf import PDFExtractor
 from ..state import StateManager
 from ..vault import VaultAdapter
 from .extractor import extract_fragments, save_fragments_to_vault
-from .planner import DISSERTATION_CONTEXT
 
 logger = logging.getLogger(__name__)
 
@@ -313,6 +312,9 @@ def pre_extract_sources(
     on_progress: Optional[Callable] = None,
     max_sources: int = 50,
     library=None,
+    dissertation_context: str = "",
+    available_tags: list[str] | None = None,
+    klemma_home: Optional[Path] = None,
 ) -> dict:
     """Извлечь фрагменты из источников раздела, если ещё не извлечены.
 
@@ -389,13 +391,21 @@ def pre_extract_sources(
             continue
 
         # Claude анализ
-        result = extract_fragments(entry, pdf_text, config, state, ai)
+        result = extract_fragments(
+            entry, pdf_text, config, state, ai,
+            dissertation_context=dissertation_context,
+            available_tags=available_tags,
+            klemma_home=klemma_home,
+        )
 
         if result and result.fragments:
             save_fragments_to_vault(
                 ck, result.fragments, vault,
                 entry=entry, config=config, state=state,
                 pdf_text=pdf_text, ai=ai, entry_lookup=entry_lookup,
+                dissertation_context=dissertation_context,
+                available_tags=available_tags,
+                klemma_home=klemma_home,
             )
             extracted += 1
             if on_progress:
@@ -482,6 +492,8 @@ def research_section(
     vault: VaultAdapter,
     ai: AIProvider,
     save_to_vault: bool = True,
+    dissertation_context: str = "",
+    klemma_home: Optional[Path] = None,
 ) -> ResearchResult:
     """Сгенерировать исследовательский брифинг для раздела диссертации.
 
@@ -581,14 +593,12 @@ def research_section(
         current_citekeys = {src["id"] for src in source_summaries}
         new_citekeys = sorted(current_citekeys - prev["previous_citekeys"])
 
-        prompt_path = (
-            Path(__file__).parent.parent.parent.parent
-            / "prompts"
-            / "research_incremental.md"
+        prompt_path = resolve_prompt("research_incremental.md", klemma_home) if klemma_home else (
+            Path(__file__).parent.parent.parent.parent / "prompts" / "research_incremental.md"
         )
         user_prompt = ai.render_prompt(
             prompt_path,
-            dissertation_context=DISSERTATION_CONTEXT,
+            dissertation_context=dissertation_context,
             target_section=section,
             chapter_num=chapter,
             chapter_name=chapter_name,
@@ -629,14 +639,12 @@ def research_section(
             "да" if prev["user_notes"] else "нет",
         )
     else:
-        prompt_path = (
-            Path(__file__).parent.parent.parent.parent
-            / "prompts"
-            / "research.md"
+        prompt_path = resolve_prompt("research.md", klemma_home) if klemma_home else (
+            Path(__file__).parent.parent.parent.parent / "prompts" / "research.md"
         )
         user_prompt = ai.render_prompt(
             prompt_path,
-            dissertation_context=DISSERTATION_CONTEXT,
+            dissertation_context=dissertation_context,
             target_section=section,
             chapter_num=chapter,
             chapter_name=chapter_name,

--- a/tags.example.yaml
+++ b/tags.example.yaml
@@ -1,0 +1,11 @@
+# Tags for automatic source classification.
+# These are used by AI to categorize extracted fragments.
+# Customize to match your research domain.
+- "Review"
+- "Dataset"
+- "Methodology"
+- "Machine Learning"
+- "Statistics"
+- "Experiment"
+- "Theory"
+- "Software"


### PR DESCRIPTION
## Summary

- Move all user-specific data (dissertation context, tags, config, DB) from source tree to `~/.klemma/` (overridable via `KLEMMA_HOME` env var)
- Remove hardcoded `DISSERTATION_CONTEXT` constant from `planner.py` (was imported by 4 other skill modules) and duplicated `AVAILABLE_TAGS` from `extractor.py`/`note_factory.py`
- Add `klemma init` command that scaffolds `~/.klemma/` from shipped template files (`config.example.yaml`, `context.example.md`, `tags.example.yaml`)

### What changed (17 files, +550 / -126)

**New files:**
- `src/klemma/setup.py` — `klemma init` logic
- `config.example.yaml` / `context.example.md` / `tags.example.yaml` — templates for new users

**Core:**
- `config.py` — added `get_klemma_home()`, `load_dissertation_context()`, `load_available_tags()`, `resolve_prompt()` (user override → shipped fallback)
- `context.py` — 3 new fields on `KlemmaContext`: `klemma_home`, `dissertation_context`, `available_tags`
- `cli.py` — updated `_init_components()`, all command callers, added `init` command, `--config` defaults to `~/.klemma/config.yaml`

**Skills (parameterized, no more hardcoded constants):**
- `planner.py`, `extractor.py`, `researcher.py`, `librarian.py`, `agent.py`, `note_factory.py`

**Housekeeping:**
- `.gitignore` — exclude `config.yaml`, `PROJECT_LOG.md`, `*.code-workspace`
- `git rm --cached` personal files
- Updated `CLAUDE.md` docs (root, core, skills)

### Backward compatibility
- Missing `context.md` → builds from `config.dissertation` fields
- Missing `tags.yaml` → extracts from `config.tags.auto_mapping` keys
- `--config path` flag still works for explicit config path
- Existing `~/.klemma/` data (migrated before code changes) works seamlessly

## Test plan

- [x] `klemma --help` shows `init` command
- [x] `klemma status` works end-to-end with `~/.klemma/` config
- [x] All skill module imports succeed (no broken references)
- [x] No remaining `DISSERTATION_CONTEXT` or `AVAILABLE_TAGS` in Python source
- [x] Pre-existing test suite: 6 passed, 1 pre-existing failure (unrelated `timeout` param in test mock)
- [ ] Manual: `klemma plan`, `klemma process`, `klemma research` with real AI backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)