### PR TITLE
OSS polish: LICENSE, CI, English prompts, ai.language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: ruff check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: pytest -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Klemma
+
+Thanks for your interest! Here's how to get started.
+
+## Development Setup
+
+```bash
+git clone https://github.com/bolkhovsky/klemma.git
+cd klemma
+pip install -e ".[dev]"
+```
+
+## Running Tests
+
+```bash
+pytest -v
+```
+
+## Code Style
+
+We use [ruff](https://docs.astral.sh/ruff/) for linting:
+
+```bash
+ruff check src/ tests/
+```
+
+CI runs both `ruff check` and `pytest` on every PR.
+
+## Prompt Language Convention
+
+Shipped prompts in `prompts/` must be in **English** with no hardcoded language strings. Every prompt that produces AI output should end with:
+
+```
+Respond in {{ language }}.
+```
+
+The `ai.language` config field controls the response language at runtime. Users can override any prompt by placing a custom version in `~/.klemma/prompts/`.
+
+## Pull Requests
+
+1. Fork the repo and create a feature branch from `master`
+2. Make your changes, add tests if applicable
+3. Ensure `ruff check` and `pytest` pass
+4. Open a PR with a clear description of what changed and why

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ilya Bolkhovsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,149 @@
+<div align="center">
+
+```
+    /\  /\
+   ( o  o )   Klemma
+   (  >>  )   AI Academic Assistant
+    / || \
+   (_/  \_)
+```
+
+# Klemma
+
+AI-powered CLI assistant for PhD dissertation research.
+
+</div>
+
+Klemma manages your literature library (via Zotero), extracts citation fragments from PDFs using AI (Claude, OpenAI, Ollama, LiteLLM), generates daily plans, research briefings, library analysis, and tracks dissertation coverage across chapters and sections.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+Requirements:
+- Python 3.11+
+- An AI backend (one of):
+  - [Claude Code](https://claude.com/claude-code) CLI (`claude` in PATH) — default
+  - `pip install klemma[openai]` — OpenAI API / Ollama / vLLM / LM Studio
+  - `pip install klemma[litellm]` — 100+ providers via LiteLLM
+- An Obsidian vault with `@citekey.md` source notes
+- Zotero with BetterBibTeX (for PDF lookup)
+
+## Quick Start
+
+```bash
+# 1. Set up your config
+klemma init                          # creates ~/.klemma/ with templates
+# Edit ~/.klemma/config.yaml         — Zotero/Obsidian paths, AI backend
+# Edit ~/.klemma/context.md          — your dissertation topic and structure
+# Edit ~/.klemma/tags.yaml           — your domain tag taxonomy
+
+# 2. Check status
+klemma status                        # sources, coverage, gaps
+
+# 3. Process sources (extract citation fragments from PDFs)
+klemma process                       # all pending sources (parallel)
+klemma process smithIceForecast2023  # specific source
+
+# 4. Daily planning
+klemma plan                          # AI-generated daily focus + briefing
+
+# 5. Research briefing for a section
+klemma research -s 1.3.2             # argument structure + citation plan
+
+# 6. Library analysis
+klemma library                       # health assessment
+klemma library -s 2.3                # section reading recommendations
+klemma library --audit               # deep quality audit
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `klemma init` | Scaffold `~/.klemma/` with config templates |
+| `klemma plan` | Generate daily focus and briefing |
+| `klemma status` | Coverage stats, gaps, reference gaps |
+| `klemma process [citekeys...]` | Extract citation fragments from PDFs |
+| `klemma research -s X.X` | Deep section analysis with citation plan |
+| `klemma library` | AI library analysis (status/recommend/audit) |
+| `klemma ask "query"` | Research agent with full dissertation context |
+| `klemma acquire <url>` | Download PDF, add to Zotero, register |
+| `klemma search "query"` | Search papers via MCP (arXiv, Semantic Scholar) |
+| `klemma discover -s X.X` | Automated literature discovery pipeline |
+| `klemma tools {add,list,remove}` | Manage MCP tool servers |
+
+## Configuration
+
+User data lives in `~/.klemma/` (override with `KLEMMA_HOME` env var):
+
+```
+~/.klemma/
+├── config.yaml    — main config (Zotero, Obsidian, AI, dissertation structure)
+├── context.md     — dissertation context (topic, results, chapters, key terms)
+├── tags.yaml      — tag taxonomy for fragment classification
+├── prompts/       — optional overrides for shipped prompt templates
+└── data/
+    └── klemma.db  — SQLite database
+```
+
+Run `klemma init` to create this from shipped templates. See `config.example.yaml` for all available options.
+
+### AI backends
+
+```yaml
+# ~/.klemma/config.yaml
+ai:
+  backend: "claude"     # default — uses Claude Code CLI
+  model: "sonnet"
+  language: "en"        # AI response language (en, ru, de, etc.)
+
+# Or use OpenAI-compatible API:
+ai:
+  backend: "openai"
+  model: "gpt-4o"
+  base_url: "http://localhost:11434/v1"  # for Ollama
+  api_key_env: "OPENAI_API_KEY"
+```
+
+### Prompt customization
+
+Klemma ships English prompt templates in `prompts/`. To customize:
+1. Copy any prompt to `~/.klemma/prompts/<name>.md`
+2. Edit as needed — user overrides take priority over shipped prompts
+3. Set `ai.language` in config to control AI response language
+
+## Architecture
+
+```
+klemma (CLI)
+├── AI Provider ─── pluggable backend for all AI calls
+│   ├── ClaudeClient ── Claude Code CLI (default)
+│   ├── OpenAIClient ── OpenAI / Ollama / vLLM / LM Studio
+│   └── LiteLLMClient ─ 100+ providers
+├── MCP Tool Layer ─ plug-and-play external servers
+│   ├── zotero-mcp ─── Zotero library access
+│   └── academia-mcp ─ arXiv, Semantic Scholar
+├── LibraryProvider ─ swappable library backend
+│   ├── LocalLibrary ── BetterBibTeX JSON (default)
+│   └── MCPLibrary ──── zotero-mcp server
+├── Obsidian vault ── source notes + research + daily notes
+├── PyMuPDF ───────── PDF text extraction
+└── SQLite ────────── sources, fragments, gaps, plans, queue
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest tests/ -v
+ruff check src/ tests/
+```
+
+See [CLAUDE.md](CLAUDE.md) for detailed architecture docs, module descriptions, and data flows.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,6 +24,7 @@ obsidian:
 
 ai:
   model: "sonnet"                      # claude model: "opus", "sonnet", "haiku"
+  language: "ru"                       # AI response language: "en", "ru", "de", etc.
   max_pdf_chars: 50000
   timeout: 300
   retries: 2

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -1,98 +1,98 @@
-# Контекст исследования
+# Research Context
 
 {{ dissertation_context }}
 
-## Главы диссертации
+## Dissertation Chapters
 
 {% for ch, name in chapters.items() %}
-- Глава {{ ch }}: {{ name }}
+- Chapter {{ ch }}: {{ name }}
 {% endfor %}
 
-## Научные результаты
+## Scientific Results
 
 {% for key, desc in scientific_results.items() %}
 - {{ key | upper }}: {{ desc }}
 {% endfor %}
 
-## Приоритетные термины
+## Priority Terms
 
 {{ priority_terms | join(", ") }}
 
-## Текущий фокус
+## Current Focus
 
-Глава {{ current_chapter }}: {{ chapter_name }}
-Раздел: {{ current_section }}
-Дедлайн: {{ current_deadline }} ({{ days_until_deadline }} дней)
+Chapter {{ current_chapter }}: {{ chapter_name }}
+Section: {{ current_section }}
+Deadline: {{ current_deadline }} ({{ days_until_deadline }} days)
 
-## Покрытие источниками
+## Source Coverage
 
 {% for ch in range(1, 5) %}
-- Глава {{ ch }}: {{ coverage.chapters.get(ch, 0) }} источников
+- Chapter {{ ch }}: {{ coverage.chapters.get(ch, 0) }} sources
 {% endfor %}
 
-## Пробелы (разделы с < {{ min_sources }} источников)
+## Gaps (sections with < {{ min_sources }} sources)
 
 {% if gaps %}
 {% for gap in gaps %}
-- Раздел {{ gap.section }}: {{ gap.count }} источников (нужно ещё {{ min_sources - gap.count }})
+- Section {{ gap.section }}: {{ gap.count }} sources (need {{ min_sources - gap.count }} more)
 {% endfor %}
 {% else %}
-Критических пробелов нет.
+No critical gaps.
 {% endif %}
 
-## Статистика фрагментов
+## Fragment Statistics
 
-- Всего: {{ fragment_stats.total }}
+- Total: {{ fragment_stats.total }}
 {% for ch, cnt in fragment_stats.by_chapter.items() %}
-- Глава {{ ch }}: {{ cnt }} фрагментов
+- Chapter {{ ch }}: {{ cnt }} fragments
 {% endfor %}
 
-## Источники ({{ sources | length }})
+## Sources ({{ sources | length }})
 
 {% for s in sources %}
-- @{{ s.id }}: [Гл.{{ s.primary_chapter or "?" }}, §{{ s.primary_section or "-" }}] quality={{ s.quality_score or 0 }}, fragments={{ s.fragment_count or 0 }}
+- @{{ s.id }}: [Ch.{{ s.primary_chapter or "?" }}, S{{ s.primary_section or "-" }}] quality={{ s.quality_score or 0 }}, fragments={{ s.fragment_count or 0 }}
 {% endfor %}
 
-## План дня
+## Today's Plan
 
 {% if today_plan %}
-- Фокус: {{ today_plan.dissertation_task }}
-{% if today_plan.assistant_task %}- Задача ассистента: {{ today_plan.assistant_task }}{% endif %}
-{% if today_plan.reading_target %}- Чтение: {{ today_plan.reading_target }}{% endif %}
+- Focus: {{ today_plan.dissertation_task }}
+{% if today_plan.assistant_task %}- Assistant task: {{ today_plan.assistant_task }}{% endif %}
+{% if today_plan.reading_target %}- Reading: {{ today_plan.reading_target }}{% endif %}
 {% else %}
-Не сгенерирован.
+Not generated.
 {% endif %}
 
-## Очередь чтения
+## Reading Queue
 
 {% if next_reading %}
-Следующая статья: {{ next_reading.citekey }}
+Next paper: {{ next_reading.citekey }}
 {% else %}
-Очередь чтения пуста.
+Reading queue is empty.
 {% endif %}
 
 ---
 
-# Инструкции
+# Instructions
 
-Ты — исследовательский ассистент для кандидатской диссертации. У тебя полный доступ к инструментам (веб-поиск, файлы, bash). Отвечай на русском.
+You are a research assistant for a PhD dissertation. You have full tool access (web search, files, bash). Respond in {{ language }}.
 
-Правила:
-1. Используй предоставленный контекст для точных ответов
-2. При поиске статей учитывай приоритетные термины и текущий фокус
-3. Ссылайся на @citekey при упоминании известных источников
-4. При работе с файлами vault — путь: {{ vault_path }}
-5. **ВСЕГДА сохраняй результаты запроса в заметку** — даже если пользователь не просит явно
+Rules:
+1. Use the provided context for accurate answers
+2. When searching for papers, consider priority terms and current focus
+3. Reference @citekey when mentioning known sources
+4. When working with vault files — path: {{ vault_path }}
+5. **ALWAYS save query results to a note** — even if the user doesn't explicitly ask
 
-Сохранение результатов:
-- Путь: {{ vault_path }}/Agent/Agent_{{ today }}_<краткое_название>.md
-- Формат: YAML frontmatter (type: agent, date: {{ today }}, query: <запрос пользователя>) + markdown body
-- Для длинных сессий с несколькими запросами — используй уникальные суффиксы (_literature, _search, _analysis и т.д.)
+Saving results:
+- Path: {{ vault_path }}/Agent/Agent_{{ today }}_<brief_name>.md
+- Format: YAML frontmatter (type: agent, date: {{ today }}, query: <user query>) + markdown body
+- For long sessions with multiple queries — use unique suffixes (_literature, _search, _analysis, etc.)
 
-## Инструменты (Skills)
+## Tools (Skills)
 
-Для работы с библиотекой используй Skills — они содержат полные инструкции по каждой команде:
+For library operations, use Skills — they contain full instructions for each command:
 
-- `/klemma-acquire` — добавление статей (скачать PDF → Zotero → klemma). Используй при нахождении релевантных статей.
-- `/klemma-process` — извлечение фрагментов из PDF. Вызывай после acquire.
-- `/klemma-status` — проверка покрытия и пробелов. Используй для оценки результата.
+- `/klemma-acquire` — add papers (download PDF, Zotero, klemma). Use when finding relevant papers.
+- `/klemma-process` — extract fragments from PDF. Call after acquire.
+- `/klemma-status` — check coverage and gaps. Use to assess results.

--- a/prompts/annotate.md
+++ b/prompts/annotate.md
@@ -1,45 +1,45 @@
-Проанализируй научную статью и создай структурированную аннотацию для кандидатской диссертации.
+Analyze a scientific paper and create a structured annotation for a PhD dissertation.
 
-## Метаданные статьи
-- **Название**: {{ title }}
-- **Авторы**: {{ authors }}
-- **Год**: {{ year }}
-- **Журнал**: {{ journal }}
+## Paper Metadata
+- **Title**: {{ title }}
+- **Authors**: {{ authors }}
+- **Year**: {{ year }}
+- **Journal**: {{ journal }}
 - **DOI**: {{ doi }}
-- **Язык**: {{ language }}
+- **Language**: {{ paper_language }}
 
-## Аннотация (из метаданных)
+## Abstract (from metadata)
 {{ abstract }}
 
-## Полный текст
+## Full Text
 {{ pdf_text }}
 
 ---
 
-## Контекст диссертации
+## Dissertation Context
 {{ dissertation_context }}
 
 ---
 
-## Наша библиотека (существующие источники)
+## Our Library (existing sources)
 {{ library_entries }}
 
 ---
 
-## Задача
+## Task
 
-Создай JSON-аннотацию со следующей структурой:
+Create a JSON annotation with the following structure:
 
 ```json
 {
-  "summary": "3-5 предложений, описывающих основной вклад и результаты статьи",
-  "methodology": "Описание методов исследования, источников данных и аналитических подходов",
+  "summary": "3-5 sentences describing the paper's main contribution and results",
+  "methodology": "Description of research methods, data sources, and analytical approaches",
   "key_findings": [
-    "Первый ключевой результат",
-    "Второй ключевой результат",
-    "Третий ключевой результат"
+    "First key result",
+    "Second key result",
+    "Third key result"
   ],
-  "relevance_to_dissertation": "Конкретное объяснение, как статья связана с исследованием валидации прогнозов ледовой обстановки",
+  "relevance_to_dissertation": "Specific explanation of how the paper relates to the dissertation topic",
   "quality_score": 4,
   "citation_priority": "medium",
   "dissertation_relevance": {
@@ -47,17 +47,17 @@
     "primary_section": "2.3.1",
     "relevance_nr1": 3,
     "relevance_nr2": 4,
-    "rationale": "Почему статья релевантна для НР1/НР2"
+    "rationale": "Why the paper is relevant for scientific results NR1/NR2"
   },
   "chapters": [1, 2],
   "sections": ["1.3.1", "2.3.1"],
-  "suggested_tags": ["Sea Ice", "Machine Learning"],
+  "suggested_tags": ["Tag1", "Tag2"],
   "key_references": [
     {
       "authors": "Smith et al.",
       "year": 2020,
       "title": "Exact title from References section",
-      "why_relevant": "Краткое объяснение релевантности для диссертации",
+      "why_relevant": "Brief explanation of relevance to the dissertation",
       "dissertation_sections": ["2.3.1"],
       "in_library": true,
       "citekey": "Smith2020"
@@ -66,34 +66,34 @@
 }
 ```
 
-## Инструкции
+## Instructions
 
-1. **summary**: Краткое содержание статьи — что сделано, какие данные, какой результат. На русском.
-2. **methodology**: Какие методы использованы, какие данные, какой временной период. На русском.
-3. **key_findings**: 2-5 ключевых результатов. На русском.
-4. **relevance_to_dissertation**: Как конкретно статья связана с темой диссертации. На русском.
-5. **quality_score**: Оценка 1-5 по релевантности для диссертации:
-   - 5 = Непосредственно о валидации прогнозов морского льда / ML для Арктики
-   - 4 = О ДЗЗ морского льда или ML-методах применимых к ледовой обстановке
-   - 3 = Об Арктике / ML для геонаук в целом
-   - 2 = Косвенная связь (ГИС-методы, общее ДЗЗ)
-   - 1 = Минимальная релевантность, фоновый источник
-6. **citation_priority**: "high" (ключевой источник), "medium" (поддерживающий), "low" (фоновый)
+1. **summary**: Brief paper overview — what was done, what data, what result
+2. **methodology**: What methods, data, time period
+3. **key_findings**: 2-5 key results
+4. **relevance_to_dissertation**: How specifically the paper connects to the dissertation topic
+5. **quality_score**: Rating 1-5 by relevance to the dissertation:
+   - 5 = Directly about the dissertation's core topic and methods
+   - 4 = About closely related methods or data applicable to the dissertation
+   - 3 = About the broader domain or general methods
+   - 2 = Indirect connection (general methodology, related field)
+   - 1 = Minimal relevance, background source
+6. **citation_priority**: "high" (key source), "medium" (supporting), "low" (background)
 7. **dissertation_relevance**:
-   - primary_chapter: Основная глава (1-4)
-   - primary_section: Конкретный раздел (например "2.3.1")
-   - relevance_nr1: Релевантность для НР1 (модель валидации AMSR2) 0-5
-   - relevance_nr2: Релевантность для НР2 (методика IIEE-декомпозиции) 0-5
-   - rationale: Краткое обоснование
-8. **chapters**: Все релевантные главы [1-4]
-9. **sections**: Все релевантные разделы
-10. **suggested_tags**: 1-5 тегов из списка: {{ available_tags }}
-11. **key_references**: 5-15 наиболее релевантных для диссертации ссылок из списка литературы (References) анализируемой статьи:
-   - Найди раздел References/Bibliography/Литература в полном тексте
-   - Выбери 5-15 ссылок, наиболее важных для тематики диссертации (морской лёд, ДЗЗ, ML, валидация, Арктика)
-   - Для каждой: authors (краткая форма), year, title (точно из References), why_relevant (на русском), dissertation_sections (к каким разделам относится)
-   - **in_library**: true если ссылка соответствует одному из источников в разделе «Наша библиотека» выше (сопоставляй по автору + году + названию). Укажи citekey
-   - **in_library**: false если ссылки нет в нашей библиотеке. citekey = null
-   - Приоритет: выбирай ссылки которых НЕТ в нашей библиотеке — это gap'ы
+   - primary_chapter: Main chapter (1-4)
+   - primary_section: Specific section (e.g. "2.3.1")
+   - relevance_nr1: Relevance for scientific result NR1, scale 0-5
+   - relevance_nr2: Relevance for scientific result NR2, scale 0-5
+   - rationale: Brief justification
+8. **chapters**: All relevant chapters [1-4]
+9. **sections**: All relevant sections
+10. **suggested_tags**: 1-5 tags from the list: {{ available_tags }}
+11. **key_references**: 5-15 most relevant references from the paper's bibliography:
+   - Find the References/Bibliography section in the full text
+   - Select 5-15 references most important for the dissertation topic
+   - For each: authors (short form), year, title (exact from References), why_relevant, dissertation_sections
+   - **in_library**: true if the reference matches a source in "Our Library" above (match by author + year + title). Include citekey
+   - **in_library**: false if the reference is not in our library. citekey = null
+   - Priority: prefer references NOT in our library — these are gaps
 
-Верни ТОЛЬКО валидный JSON. Без markdown-форматирования, без пояснений.
+Respond with ONLY valid JSON. No markdown formatting, no explanations. Respond in {{ language }}.

--- a/prompts/extract.md
+++ b/prompts/extract.md
@@ -44,7 +44,7 @@ Return a JSON object:
       "chapter": 2,
       "section": "2.3.1",
       "relevance": 4,
-      "usage_hint": "Use as evidence for IceNet architecture choice in section 2.3.1",
+      "usage_hint": "Use as evidence for method choice in section 2.3.1",
       "page": 5
     }
   ],
@@ -55,11 +55,11 @@ Return a JSON object:
 Guidelines:
 1. Extract 3-10 fragments per paper, prioritizing high-relevance ones
 2. Include at least one verbatim quote suitable for direct citation
-3. Identify methodology descriptions that could be referenced in Chapter 3
+3. Identify methodology descriptions that could be referenced
 4. Look for results/metrics that support or contrast with the dissertation's approach
-5. Flag definitions of key terms (SIC, IIEE, AEE, ME, etc.)
+5. Flag definitions of key terms
 6. Map each fragment to the most specific section possible
-7. Usage hints should be in Russian
+7. Usage hints should be in {{ language }}
 8. Fragments text stays in original paper language
 
 Respond with ONLY valid JSON.

--- a/prompts/librarian.md
+++ b/prompts/librarian.md
@@ -1,86 +1,86 @@
-Ты — библиотекарь-аналитик PhD-библиотеки. Анализируешь состояние источников для кандидатской диссертации и даёшь стратегические рекомендации.
+You are a library analyst for a PhD dissertation. You analyze the state of sources and provide strategic recommendations.
 
-## Контекст диссертации
+## Dissertation Context
 
 {{ dissertation_context }}
 
-## Дедлайн текущей главы
+## Current Chapter Deadline
 
-Глава {{ current_chapter }}: {{ chapter_name }}
-Дедлайн: {{ deadline }}
-Дней до дедлайна: {{ days_remaining }}
+Chapter {{ current_chapter }}: {{ chapter_name }}
+Deadline: {{ deadline }}
+Days until deadline: {{ days_remaining }}
 
-## Режим: {{ mode }}
+## Mode: {{ mode }}
 
 {% if mode == "status" %}
-## Задача: Оценка здоровья библиотеки
+## Task: Library Health Assessment
 
-Проанализируй состояние библиотеки для КАЖДОЙ главы. Оценивай не только количество источников, но и:
-- Качество (quality_score 1-5): достаточно ли высококачественных источников?
-- Разнообразие: есть ли разные типы (первичные исследования, обзоры, методики)?
-- Актуальность: есть ли свежие работы (2020+) или все устаревшие?
-- Покрытие разделов: какие разделы без источников?
-- Прогресс обработки: сколько ещё не обработано?
+Analyze the library state for EACH chapter. Evaluate not just source count, but also:
+- Quality (quality_score 1-5): are there enough high-quality sources?
+- Diversity: are there different types (primary research, reviews, methodologies)?
+- Recency: are there recent works (2020+) or all outdated?
+- Section coverage: which sections have no sources?
+- Processing progress: how many still unprocessed?
 
-Назови 3-5 критических проблем и конкретные действия для их решения.
-Учитывай дедлайн: что наиболее срочно?
+Name 3-5 critical issues and concrete actions to resolve them.
+Consider the deadline: what is most urgent?
 
 {% elif mode == "recommend" %}
-## Задача: Рекомендации для раздела {{ section }}
+## Task: Recommendations for Section {{ section }}
 
-Для раздела {{ section }} ({{ section_title }}):
-1. Оцени текущие источники — достаточно ли их, какого они качества?
-2. Какие типы источников отсутствуют (методологические, эмпирические, обзорные)?
-3. Какие reference gaps наиболее приоритетны для этого раздела?
-4. Какие pending источники обработать первыми?
-5. Предложи порядок чтения с обоснованием.
+For section {{ section }} ({{ section_title }}):
+1. Assess current sources — are they sufficient, what quality?
+2. What source types are missing (methodological, empirical, review)?
+3. Which reference gaps are highest priority for this section?
+4. Which pending sources should be processed first?
+5. Suggest a reading order with rationale.
 
 {% if section_summaries %}
-### AI-аннотации текущих источников раздела
+### AI Annotations of Current Section Sources
 
 {{ section_summaries }}
 {% endif %}
 
 {% elif mode == "audit" %}
-## Задача: Глубокий аудит качества
+## Task: Deep Quality Audit
 
-Проведи аудит библиотеки по следующим критериям:
-1. **Дубли**: источники с перекрывающейся тематикой (одно и то же но разные авторы)
-2. **Устаревшие**: источники старше 10 лет на ключевых позициях (разделы НР1/НР2)
-3. **Перекос**: все источники раздела от одной исследовательской группы
-4. **Низкое качество на ключевых позициях**: quality < 3 в разделах с высоким приоритетом
-5. **Несоответствия**: источник назначен в раздел, но его тематика не соответствует
+Audit the library on the following criteria:
+1. **Duplicates**: sources with overlapping topics (same thing, different authors)
+2. **Outdated**: sources older than 10 years in key positions
+3. **Bias**: all sources in a section from one research group
+4. **Low quality in key positions**: quality < 3 in high-priority sections
+5. **Mismatches**: source assigned to a section but its topic doesn't match
 
-Для каждого найденного проблемного места укажи severity (high/medium/low) и конкретное действие.
+For each issue found, specify severity (high/medium/low) and a concrete action.
 {% endif %}
 
-## Данные библиотеки
+## Library Data
 
-### Статистика обработки
+### Processing Statistics
 
-- Всего: {{ summary.total }} источников
-- Обработано: {{ summary.completed }}
-- В ожидании: {{ summary.pending }}
-{% if summary.failed > 0 %}- Ошибки: {{ summary.failed }}{% endif %}
-- Фрагментов: {{ summary.fragments_total }}
-- Среднее качество: {{ summary.avg_quality }}/5
-- Среднее фрагментов/источник: {{ summary.avg_fragments }}
+- Total: {{ summary.total }} sources
+- Processed: {{ summary.completed }}
+- Pending: {{ summary.pending }}
+{% if summary.failed > 0 %}- Failed: {{ summary.failed }}{% endif %}
+- Fragments: {{ summary.fragments_total }}
+- Average quality: {{ summary.avg_quality }}/5
+- Average fragments/source: {{ summary.avg_fragments }}
 
-### Покрытие по главам
+### Coverage by Chapter
 
 {% for ch in range(1, 5) %}
-Глава {{ ch }}: {{ chapters[ch] | default("?") }} источников
+Chapter {{ ch }}: {{ chapters[ch] | default("?") }} sources
 {% endfor %}
 
 {% if summary.zero_sections %}
-### Разделы без источников
+### Sections Without Sources
 {{ summary.zero_sections | join(", ") }}
 {% endif %}
 
-### Распределение по качеству
+### Quality Distribution
 
 {% for q in range(5, 0, -1) %}
-{% if quality_data.get(q) %}Quality {{ q }}: {{ quality_data[q] | length }} источников{% endif %}
+{% if quality_data.get(q) %}Quality {{ q }}: {{ quality_data[q] | length }} sources{% endif %}
 {% endfor %}
 
 {% if ref_gaps %}
@@ -92,40 +92,40 @@
 {% endif %}
 
 {% if sources_compact %}
-### Источники{% if sources_omitted %} (показаны {{ sources_shown }} из {{ sources_total }}{% if sources_omitted_detail %}, {{ sources_omitted_detail }}{% endif %}){% endif %}
+### Sources{% if sources_omitted %} (showing {{ sources_shown }} of {{ sources_total }}{% if sources_omitted_detail %}, {{ sources_omitted_detail }}{% endif %}){% endif %}
 
 {{ sources_compact }}
 {% endif %}
 
-## Формат ответа (JSON)
+## Response Format (JSON)
 
 ```json
 {
-  "overall_health": "Нарративная оценка здоровья библиотеки (2-4 предложения)",
+  "overall_health": "Narrative assessment of library health (2-4 sentences)",
   "chapter_assessments": [
     {
       "chapter": 1,
       "sources": 25,
       "quality_avg": 3.5,
-      "verdict": "Хорошо покрыта, но не хватает свежих методологических работ"
+      "verdict": "Well covered, but lacking recent methodological works"
     }
   ],
   "critical_issues": [
-    "Раздел 2.3.1 имеет только 2 источника при дедлайне через 25 дней"
+    "Section 2.3.1 has only 2 sources with deadline in 25 days"
   ],
   "recommendations": [
     {
-      "action": "Найти и обработать 3 источника по AMSR2 валидации для раздела 2.3.1",
+      "action": "Find and process 3 sources on validation for section 2.3.1",
       "priority": "high",
-      "reason": "Критический раздел для НР1, ближайший дедлайн"
+      "reason": "Critical section, nearest deadline"
     }
   ],
 {% if mode == "recommend" %}
   "section_detail": {
-    "current_sources_assessment": "Оценка текущих источников раздела",
-    "missing_types": ["Тип1", "Тип2"],
+    "current_sources_assessment": "Assessment of current section sources",
+    "missing_types": ["Type1", "Type2"],
     "reading_order": [
-      {"citekey_or_ref": "Author2021", "reason": "Закрывает главный reference gap"}
+      {"citekey_or_ref": "Author2021", "reason": "Closes the main reference gap"}
     ]
   },
 {% endif %}
@@ -134,12 +134,12 @@
     {
       "type": "outdated",
       "severity": "high",
-      "details": "Smith2010 (quality=2) назначен в ключевой раздел 2.3.1 для НР1"
+      "details": "Smith2010 (quality=2) assigned to key section 2.3.1"
     }
   ],
 {% endif %}
-  "report_text": "Краткое резюме: основные выводы и ключевые рекомендации (3-5 абзацев)"
+  "report_text": "Brief summary: main conclusions and key recommendations (3-5 paragraphs)"
 }
 ```
 
-Отвечай ТОЛЬКО валидным JSON. Поле report_text — краткое резюме (НЕ полный отчёт, структурированные данные уже есть в других полях JSON).
+Respond with ONLY valid JSON. The report_text field should be a brief summary (NOT the full report — structured data is already in other JSON fields). Respond in {{ language }}.

--- a/prompts/librarian_prune.md
+++ b/prompts/librarian_prune.md
@@ -1,38 +1,38 @@
-Библиотека перенасыщена: {{ source_count }} источников (цель: 100-120).
-Проанализируй список и предложи кандидатов на отсев.
+The library is oversaturated: {{ source_count }} sources (target: 100-120).
+Analyze the list and suggest candidates for removal.
 
-## Критерии DROP (уверенный отсев)
+## DROP Criteria (confident removal)
 
-- Нет фрагментов (f=0) И нет привязки к секции (s пусто) — orphan источники
-- quality <= 2 на неприоритетных секциях
-- Дублирующее покрытие: секция уже имеет 8+ источников, этот не добавляет уникальной ценности
-- Статус pending + low quality/relevance (не стоит тратить время на обработку)
+- No fragments (f=0) AND no section assignment (s empty) — orphan sources
+- quality <= 2 in non-priority sections
+- Duplicate coverage: section already has 8+ sources, this one adds no unique value
+- Status pending + low quality/relevance (not worth processing time)
 
-## Критерии MAYBE (на усмотрение пользователя)
+## MAYBE Criteria (user's discretion)
 
-- quality 3 с малым числом фрагментов в перенасыщенной секции
-- Устаревший (>10 лет) при наличии свежего аналога в той же секции
+- quality 3 with few fragments in an oversaturated section
+- Outdated (>10 years) when a newer equivalent exists in the same section
 
-## НЕ трогать (защищённые)
+## Protected (do NOT touch)
 
-- Источники с высоким quality (4-5) в приоритетных секциях
-- Единственный или один из <=3 источников в секции
+- Sources with high quality (4-5) in priority sections
+- The only source or one of <=3 sources in a section
 
-## Источники
+## Sources
 
 {{ sources_compact }}
 
-## Формат ответа (JSON)
+## Response Format (JSON)
 
 ```json
 {
   "drop": [
-    {"citekey": "authorTitleYear", "reason": "f=0, нет секции, quality=1"}
+    {"citekey": "authorTitleYear", "reason": "f=0, no section, quality=1"}
   ],
   "maybe": [
-    {"citekey": "authorTitleYear", "reason": "quality=3, 1 фрагмент, секция 1.3 имеет 12 источников"}
+    {"citekey": "authorTitleYear", "reason": "quality=3, 1 fragment, section 1.3 has 12 sources"}
   ]
 }
 ```
 
-Отвечай ТОЛЬКО валидным JSON. Включай только реальные citekey из списка выше.
+Respond with ONLY valid JSON. Include only real citekeys from the list above. Respond in {{ language }}.

--- a/prompts/morning.md
+++ b/prompts/morning.md
@@ -1,107 +1,107 @@
-Ты — ассистент для написания кандидатской диссертации. Философия: один фокус в день, конкретное действие, связь со стратегией.
+You are a dissertation writing assistant. Philosophy: one focus per day, concrete action, tied to strategy.
 
-## Контекст диссертации
+## Dissertation Context
 
 {{ dissertation_context }}
 
-## Дедлайн текущей главы
+## Current Chapter Deadline
 
-Глава {{ current_chapter }}: {{ chapter_name }}
-Дедлайн: {{ current_deadline }}
-Дней до дедлайна: {{ days_until_deadline }}
+Chapter {{ current_chapter }}: {{ chapter_name }}
+Deadline: {{ current_deadline }}
+Days until deadline: {{ days_until_deadline }}
 
-## Текущий статус
+## Current Status
 
-- Дней без прогресса: {{ days_without_progress }}
-- Серия продуктивных дней (streak): {{ streak }}
+- Days without progress: {{ days_without_progress }}
+- Productive day streak: {{ streak }}
 {% if yesterday_plan %}
-- Вчерашний фокус: {{ yesterday_plan.dissertation_task }}
+- Yesterday's focus: {{ yesterday_plan.dissertation_task }}
 {% else %}
-- Вчера плана не было.
+- No plan was generated yesterday.
 {% endif %}
 
-## План главы (сессии)
+## Chapter Plan (sessions)
 
 {% if chapter_plan %}
 {{ chapter_plan }}
 {% else %}
-План сессий не найден.
+Session plan not found.
 {% endif %}
 
-## Состояние библиотеки
+## Library Status
 
 {{ library_summary }}
 
-## Покрытие источниками
+## Source Coverage
 
 {% for ch in range(1, 5) %}
-- Глава {{ ch }}: {{ coverage.chapters.get(ch, 0) }} источников
+- Chapter {{ ch }}: {{ coverage.chapters.get(ch, 0) }} sources
 {% endfor %}
 
-## Пробелы (разделы с < {{ min_sources }} источников)
+## Gaps (sections with < {{ min_sources }} sources)
 
 {% if gaps %}
 {% for gap in gaps %}
-- Раздел {{ gap.section }}: {{ gap.count }} источников (нужно ещё {{ min_sources - gap.count }})
+- Section {{ gap.section }}: {{ gap.count }} sources (need {{ min_sources - gap.count }} more)
 {% endfor %}
 {% else %}
-Критических пробелов нет.
+No critical gaps.
 {% endif %}
 
-## Статистика фрагментов
+## Fragment Statistics
 
-- Всего: {{ fragment_stats.total }}
+- Total: {{ fragment_stats.total }}
 {% for ch, cnt in fragment_stats.by_chapter.items() %}
-- Глава {{ ch }}: {{ cnt }} фрагментов
+- Chapter {{ ch }}: {{ cnt }} fragments
 {% endfor %}
 
-## Очередь чтения
+## Reading Queue
 
 {% if next_reading %}
-Следующая статья: {{ next_reading.citekey }}
+Next paper: {{ next_reading.citekey }}
 {% else %}
-Очередь чтения пуста.
+Reading queue is empty.
 {% endif %}
 
-## Ограничения
+## Constraints
 
 {{ writing_constraints }}
 
 ---
 
-## Задача
+## Task
 
-Сгенерируй утренний брифинг в формате JSON:
+Generate a morning briefing in JSON format:
 
 ```json
 {
-  "status_line": "Глава X | Сессия Y/Z | streak X / X дней без прогресса | до дедлайна: N дней",
+  "status_line": "Chapter X | Session Y/Z | streak X / X days without progress | deadline in: N days",
   "intervention": "NONE | FOCUS_REDIRECT | ESCALATION | CELEBRATION | DEADLINE_RISK | DEADLINE_CRITICAL",
-  "intervention_message": "Краткое сообщение интервенции (если не NONE)",
-  "focus": "ОДНО конкретное действие с объёмом и таймингом",
-  "why": "Связь со стратегией — почему именно это сегодня",
+  "intervention_message": "Brief intervention message (if not NONE)",
+  "focus": "ONE concrete action with scope and timing",
+  "why": "Strategic connection — why this today",
   "sources_needed": ["@citekey1", "@citekey2"],
-  "assistant_task": "Задача для klemma (извлечь фрагменты, обработать источники)",
-  "reading_target": "Какую статью читать и зачем",
+  "assistant_task": "Task for klemma (extract fragments, process sources)",
+  "reading_target": "Which paper to read and why",
   "strategy_suggestions": ["DEADLINE_RISK: ...", "COVERAGE_GAP: ..."],
-  "progress_summary": "Краткая оценка прогресса (1-2 предложения)"
+  "progress_summary": "Brief progress assessment (1-2 sentences)"
 }
 ```
 
-### Правила
+### Rules
 
-1. **ОДИН фокус.** Одно конкретное действие из плана сессий — не список задач
-2. **Конкретика.** «Написать раздел 1.3 — пассивное МВ зондирование, алгоритмы SIC (800 слов)» — да. «Поработать над главой» — нет
-3. **Тайминг.** Учитывай ограничения: {{ writing_constraints }}
-4. **Источники.** Укажи citekeys из плана сессии, которые нужны сегодня
-5. **Интервенции:**
-   - `NONE` — всё в порядке, продолжаем
-   - `FOCUS_REDIRECT` — 3+ дней без прогресса → вернуться к написанию
-   - `ESCALATION` — 7+ дней → пересмотреть подход
-   - `CELEBRATION` — 5+ дней streak → отметить прогресс
-   - `DEADLINE_RISK` — < 14 дней до дедлайна, прогресс недостаточный
-   - `DEADLINE_CRITICAL` — < 7 дней до дедлайна
-6. **Стратегические предложения** — только при реальных проблемах
-7. **Определи текущую сессию** из плана главы на основе покрытия и пробелов
+1. **ONE focus.** One concrete action from the session plan — not a task list
+2. **Be specific.** "Write section 1.3 — passive MW remote sensing, SIC algorithms (800 words)" — yes. "Work on chapter" — no
+3. **Timing.** Account for constraints: {{ writing_constraints }}
+4. **Sources.** List citekeys from the session plan needed today
+5. **Interventions:**
+   - `NONE` — everything is on track
+   - `FOCUS_REDIRECT` — 3+ days without progress — return to writing
+   - `ESCALATION` — 7+ days — reconsider approach
+   - `CELEBRATION` — 5+ day streak — acknowledge progress
+   - `DEADLINE_RISK` — < 14 days to deadline, insufficient progress
+   - `DEADLINE_CRITICAL` — < 7 days to deadline
+6. **Strategy suggestions** — only when real problems exist
+7. **Identify current session** from the chapter plan based on coverage and gaps
 
-Верни ТОЛЬКО валидный JSON, на русском языке.
+Respond with ONLY valid JSON. Respond in {{ language }}.

--- a/prompts/research.md
+++ b/prompts/research.md
@@ -1,80 +1,80 @@
-Ты — исследовательский аналитик для кандидатской диссертации. Твоя задача — подготовить структурированный брифинг перед написанием раздела.
+You are a research analyst for a PhD dissertation. Your task is to prepare a structured briefing before writing a section.
 
-## Контекст диссертации
+## Dissertation Context
 
 {{ dissertation_context }}
 
-## Целевой раздел
+## Target Section
 
-**Раздел {{ target_section }}** (Глава {{ chapter_num }}: {{ chapter_name }})
+**Section {{ target_section }}** (Chapter {{ chapter_num }}: {{ chapter_name }})
 
-## Текущее состояние раздела
+## Current Section State
 
-{% if section_text and section_text != "Раздел ещё не написан." %}
+{% if section_text and section_text != "Section not written yet." %}
 {{ section_text }}
 {% else %}
-Раздел ещё не написан.
+Section has not been written yet.
 {% endif %}
 
-## Черновик главы
+## Chapter Draft
 
 <chapter_draft>
 {{ full_chapter_draft }}
 </chapter_draft>
 
-## План работы по сессиям
+## Session Work Plan
 
 {% if chapter_plan %}
 {{ chapter_plan }}
 {% else %}
-План сессий не найден.
+Session plan not found.
 {% endif %}
 
-## Фрагменты из источников
+## Fragments from Sources
 
 ```json
 {{ fragments }}
 ```
 
-## Аннотации ключевых источников
+## Key Source Annotations
 
 ```json
 {{ source_summaries }}
 ```
 
-## Покрытие источниками
+## Source Coverage
 
 {% for ch in range(1, 5) %}
-- Глава {{ ch }}: {{ coverage.chapters.get(ch, 0) }} источников
+- Chapter {{ ch }}: {{ coverage.chapters.get(ch, 0) }} sources
 {% endfor %}
 
-## Пробелы (разделы с < {{ min_sources }} источников)
+## Gaps (sections with < {{ min_sources }} sources)
 
 {% if gaps %}
 {% for gap in gaps %}
-- Раздел {{ gap.section }}: {{ gap.count }} источников (нужно ещё {{ min_sources - gap.count }})
+- Section {{ gap.section }}: {{ gap.count }} sources (need {{ min_sources - gap.count }} more)
 {% endfor %}
 {% else %}
-Критических пробелов нет.
+No critical gaps.
 {% endif %}
 
-## Статистика фрагментов
+## Fragment Statistics
 
-- Всего: {{ fragment_stats.total }}
+- Total: {{ fragment_stats.total }}
 {% for ch, cnt in fragment_stats.by_chapter.items() %}
-- Глава {{ ch }}: {{ cnt }} фрагментов
+- Chapter {{ ch }}: {{ cnt }} fragments
 {% endfor %}
 
 ---
 
-## Задача
+## Task
 
-Проанализируй готовность раздела {{ target_section }} к написанию и сгенерируй исследовательский брифинг в формате JSON:
+Analyze the readiness of section {{ target_section }} for writing and generate a research briefing in JSON format:
 
 ```json
 {
-  "section_title": "Название раздела из черновика или плана",
-  "section_status": "не начат | черновик | требует доработки | почти готов",
+  "section_title": "Section title from draft or plan",
+  "section_status": "not started | draft | needs revision | nearly ready",
   "current_word_count": 0,
   "target_word_count": 1000,
   "readiness_pct": 0,
@@ -91,8 +91,8 @@
   "argument_blocks": [
     {
       "order": 1,
-      "title": "Краткое название блока аргументации",
-      "description": "Что должно быть в этом блоке: логика, содержание, связь с предыдущим разделом",
+      "title": "Brief name of argument block",
+      "description": "What should be in this block: logic, content, connection to previous section",
       "citations": ["citekey1", "citekey2"],
       "estimated_words": 300
     }
@@ -101,36 +101,36 @@
   "citation_plan": [
     {
       "citekey": "citekey1",
-      "fragment_text": "Ключевой фрагмент для цитирования (до 200 символов)",
+      "fragment_text": "Key fragment for citation (up to 200 chars)",
       "usage": "evidence",
-      "position": "При обосновании выбора метода",
+      "position": "When justifying method choice",
       "relevance": 5
     }
   ],
 
   "missing_coverage": [
-    "Не хватает источников по теме X",
-    "Нет определения термина Y"
+    "Missing sources on topic X",
+    "No definition for term Y"
   ],
 
   "writing_suggestions": [
-    "Начать раздел с определения ключевых понятий",
-    "Использовать результаты из @citekey3 для сравнения",
-    "Связать с разделом X.Y через переходный абзац"
+    "Start section with key concept definitions",
+    "Use results from @citekey3 for comparison",
+    "Connect to section X.Y with a transition paragraph"
   ]
 }
 ```
 
-### Правила
+### Rules
 
-1. **Структура аргументации** — разбей раздел на 3-6 логических блоков. Каждый блок: цель, описание, список источников
-2. **План цитирования** — для каждого источника укажи конкретный фрагмент и место в тексте. Типы: evidence, method, comparison, definition, quote
-3. **Оценка готовности** — если есть черновик, посчитай слова и определи процент готовности. Если раздел не написан — readiness_pct = 0
-4. **Целевой объём** — ориентируйся на план сессий (200-300 слов за сессию)
-5. **Пробелы** — укажи конкретные темы без источников или фрагментов
-6. **Рекомендации** — 3-5 конкретных советов по написанию с учётом контекста всей главы
-7. **Связность** — учитывай предыдущие и последующие разделы из черновика для логических переходов
-8. **Приоритет источников** — предпочитай quality >= 4, citation_priority = high, relevance >= 4
-9. **fragment_distribution** — распределение доступных фрагментов по типам (из предоставленных данных)
+1. **Argument structure** — break the section into 3-6 logical blocks. Each block: purpose, description, source list
+2. **Citation plan** — for each source, specify the concrete fragment and placement in text. Types: evidence, method, comparison, definition, quote
+3. **Readiness assessment** — if there's a draft, count words and determine readiness percentage. If section not written — readiness_pct = 0
+4. **Target volume** — follow the session plan (200-300 words per session)
+5. **Gaps** — specify concrete topics lacking sources or fragments
+6. **Recommendations** — 3-5 specific writing suggestions considering the full chapter context
+7. **Coherence** — consider previous and following sections from the draft for logical transitions
+8. **Source priority** — prefer quality >= 4, citation_priority = high, relevance >= 4
+9. **fragment_distribution** — distribution of available fragments by type (from provided data)
 
-Верни ТОЛЬКО валидный JSON, на русском языке.
+Respond with ONLY valid JSON. Respond in {{ language }}.

--- a/prompts/research_incremental.md
+++ b/prompts/research_incremental.md
@@ -1,107 +1,107 @@
-Ты — исследовательский аналитик для кандидатской диссертации. Это ПОВТОРНЫЙ анализ раздела — обнови предыдущий брифинг на основе новых данных.
+You are a research analyst for a PhD dissertation. This is a REPEAT analysis of a section — update the previous briefing based on new data.
 
-## Контекст диссертации
+## Dissertation Context
 
 {{ dissertation_context }}
 
-## Целевой раздел
+## Target Section
 
-**Раздел {{ target_section }}** (Глава {{ chapter_num }}: {{ chapter_name }})
+**Section {{ target_section }}** (Chapter {{ chapter_num }}: {{ chapter_name }})
 
-## Предыдущий брифинг
+## Previous Briefing
 
-Дата: {{ previous_date }}
+Date: {{ previous_date }}
 
 <previous_briefing>
 {{ previous_text }}
 </previous_briefing>
 
-## Что изменилось с прошлого анализа
+## What Changed Since Last Analysis
 
-### Новые источники (добавлены после прошлого запуска)
+### New Sources (added after last run)
 {% if new_citekeys %}
 {% for ck in new_citekeys %}
 - @{{ ck }}
 {% endfor %}
 {% else %}
-Новых источников нет.
+No new sources.
 {% endif %}
 
-### Новые фрагменты
-- Было: {{ previous_fragment_count }} фрагментов
-- Стало: {{ current_fragment_count }} фрагментов
-- Добавлено: {{ current_fragment_count - previous_fragment_count }}
+### New Fragments
+- Before: {{ previous_fragment_count }} fragments
+- Now: {{ current_fragment_count }} fragments
+- Added: {{ current_fragment_count - previous_fragment_count }}
 
-### Заметки автора
+### Author Notes
 
 {% if user_notes %}
 <user_notes>
 {{ user_notes }}
 </user_notes>
 {% else %}
-Автор не оставил заметок.
+Author left no notes.
 {% endif %}
 
-## Текущее состояние раздела
+## Current Section State
 
-{% if section_text and section_text != "Раздел ещё не написан." %}
+{% if section_text and section_text != "Section not written yet." %}
 {{ section_text }}
 {% else %}
-Раздел ещё не написан.
+Section has not been written yet.
 {% endif %}
 
-## Черновик главы
+## Chapter Draft
 
 <chapter_draft>
 {{ full_chapter_draft }}
 </chapter_draft>
 
-## Фрагменты из источников (обновлённые)
+## Fragments from Sources (updated)
 
 ```json
 {{ fragments }}
 ```
 
-## Аннотации ключевых источников (обновлённые)
+## Key Source Annotations (updated)
 
 ```json
 {{ source_summaries }}
 ```
 
-## Покрытие источниками
+## Source Coverage
 
 {% for ch in range(1, 5) %}
-- Глава {{ ch }}: {{ coverage.chapters.get(ch, 0) }} источников
+- Chapter {{ ch }}: {{ coverage.chapters.get(ch, 0) }} sources
 {% endfor %}
 
-## Пробелы (разделы с < {{ min_sources }} источников)
+## Gaps (sections with < {{ min_sources }} sources)
 
 {% if gaps %}
 {% for gap in gaps %}
-- Раздел {{ gap.section }}: {{ gap.count }} источников (нужно ещё {{ min_sources - gap.count }})
+- Section {{ gap.section }}: {{ gap.count }} sources (need {{ min_sources - gap.count }} more)
 {% endfor %}
 {% else %}
-Критических пробелов нет.
+No critical gaps.
 {% endif %}
 
 ---
 
-## Задача
+## Task
 
-Обнови предыдущий исследовательский брифинг для раздела {{ target_section }}. Учти:
+Update the previous research briefing for section {{ target_section }}. Consider:
 
-1. **Заметки автора** — это главный вход. Если автор написал что-то в «Что нового», учти это в первую очередь
-2. **Новые фрагменты и источники** — интегрируй в структуру аргументации и план цитирования
-3. **Изменения в черновике** — если текст раздела обновился, пересчитай readiness_pct и current_word_count
-4. **Сохрани то, что осталось актуальным** из предыдущего брифинга — не переписывай с нуля
-5. **Обнови пробелы** — возможно, часть из них закрыта новыми источниками
+1. **Author notes** — this is the primary input. If the author wrote something in "What's New", prioritize it
+2. **New fragments and sources** — integrate into argument structure and citation plan
+3. **Draft changes** — if the section text was updated, recalculate readiness_pct and current_word_count
+4. **Preserve what's still relevant** from the previous briefing — don't rewrite from scratch
+5. **Update gaps** — some may have been closed by new sources
 
-Верни обновлённый JSON в том же формате:
+Return updated JSON in the same format:
 
 ```json
 {
   "section_title": "...",
-  "section_status": "не начат | черновик | требует доработки | почти готов",
+  "section_status": "not started | draft | needs revision | nearly ready",
   "current_word_count": 0,
   "target_word_count": 1000,
   "readiness_pct": 0,
@@ -135,8 +135,8 @@
 
   "writing_suggestions": ["..."],
 
-  "update_summary": "Краткое описание изменений по сравнению с предыдущим брифингом (1-2 предложения)"
+  "update_summary": "Brief description of changes compared to previous briefing (1-2 sentences)"
 }
 ```
 
-Верни ТОЛЬКО валидный JSON, на русском языке.
+Respond with ONLY valid JSON. Respond in {{ language }}.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,25 @@
 [project]
 name = "klemma"
-version = "0.1.0"
-description = "AI academic assistant template"
+version = "0.4.1"
+description = "AI-powered CLI assistant for PhD dissertation research — manages literature, extracts citations, generates plans"
 requires-python = ">=3.11"
-readme = "CLAUDE.md"
+readme = "README.md"
 license = {text = "MIT"}
+authors = [{name = "Ilya Bolkhovsky"}]
+keywords = ["academic", "dissertation", "research", "zotero", "obsidian", "ai", "pdf", "citations"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.urls]
+Homepage = "https://github.com/bolkhovsky/klemma"
+Repository = "https://github.com/bolkhovsky/klemma"
+"Bug Reports" = "https://github.com/bolkhovsky/klemma/issues"
 
 dependencies = [
     "click==8.1.8",

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -49,6 +49,7 @@ class AIConfig(BaseModel):
     base_url: Optional[str] = None  # URL for OpenAI-compatible endpoints
     api_key_env: str = ""  # env var name for API key (e.g. "OPENAI_API_KEY")
     json_mode: bool = False  # use structured JSON mode when backend supports it
+    language: str = "ru"  # AI response language (e.g. "en", "ru", "de")
 
     @property
     def api_key(self) -> Optional[str]:

--- a/src/klemma/literature/note_factory.py
+++ b/src/klemma/literature/note_factory.py
@@ -90,12 +90,13 @@ def annotate_source(
         year=entry.year or "Unknown",
         journal=entry.container_title or "N/A",
         doi=entry.DOI or "N/A",
-        language=entry.language or "Unknown",
+        paper_language=entry.language or "Unknown",
         abstract=entry.abstract or "Not available",
         pdf_text=pdf_text,
         dissertation_context=dissertation_context,
         available_tags=", ".join(available_tags) if available_tags else "",
         library_entries=_format_library_entries(entry_lookup),
+        language=config.ai.language,
     )
 
     system = (

--- a/src/klemma/skills/agent.py
+++ b/src/klemma/skills/agent.py
@@ -34,7 +34,7 @@ def build_agent_context(
 
     # Chapter name
     focus_chapter = chapter or config.dissertation.current_chapter
-    chapter_name = config.dissertation.chapters.get(focus_chapter, f"Глава {focus_chapter}")
+    chapter_name = config.dissertation.chapters.get(focus_chapter, f"Chapter {focus_chapter}")
 
     # Focus section
     focus_section = section or config.dissertation.current_section
@@ -93,6 +93,7 @@ def build_agent_context(
         next_reading=next_reading,
         vault_path=config.obsidian.vault_path,
         today=date.today().isoformat(),
+        language=config.ai.language,
         range=range,
     )
 

--- a/src/klemma/skills/extractor.py
+++ b/src/klemma/skills/extractor.py
@@ -38,6 +38,7 @@ def extract_fragments(
         pdf_text=pdf_text,
         dissertation_context=dissertation_context,
         available_tags=", ".join(available_tags) if available_tags else "",
+        language=config.ai.language,
     )
 
     system = (

--- a/src/klemma/skills/librarian.py
+++ b/src/klemma/skills/librarian.py
@@ -46,11 +46,12 @@ def analyze_library(
     )
 
     prompt_path = resolve_prompt("librarian.md", klemma_home) if klemma_home else Path(__file__).parent.parent.parent.parent / "prompts" / "librarian.md"
+    context["language"] = config.ai.language
     user_prompt = ai.render_prompt(prompt_path, **context)
 
     system = (
-        "Ты — библиотекарь-аналитик PhD-библиотеки. "
-        "Отвечай только валидным JSON."
+        "You are a library analyst for a PhD dissertation. "
+        "Output only valid JSON."
     )
 
     data = ai.call_json(system, user_prompt, max_tokens=8192, timeout=LIBRARY_TIMEOUT)
@@ -323,9 +324,11 @@ def _run_prune_analysis(
     For >300 sources, batches per-chapter in parallel.
     """
     if len(active_sources) <= 300:
-        return _prune_batch(active_sources, entry_lookup, ai, klemma_home=klemma_home)
+        lang = config.ai.language
+        return _prune_batch(active_sources, entry_lookup, ai, klemma_home=klemma_home, language=lang)
 
     # Per-chapter parallel batching
+    lang = config.ai.language
     by_chapter: dict[int, list] = {}
     for s in active_sources:
         ch = s.get("primary_chapter") or 0
@@ -336,7 +339,7 @@ def _run_prune_analysis(
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = {
-            pool.submit(_prune_batch, sources, entry_lookup, ai, klemma_home=klemma_home): ch
+            pool.submit(_prune_batch, sources, entry_lookup, ai, klemma_home=klemma_home, language=lang): ch
             for ch, sources in by_chapter.items()
         }
         for future in as_completed(futures):
@@ -357,6 +360,7 @@ def _run_prune_analysis(
 def _prune_batch(
     sources: list[dict], entry_lookup: dict, ai: AIProvider,
     klemma_home: Optional[Path] = None,
+    language: str = "en",
 ) -> Optional[dict]:
     """Run prune on a batch of sources."""
     sources_compact = _format_sources_compact(sources, entry_lookup)
@@ -366,12 +370,13 @@ def _prune_batch(
         prompt_path,
         sources_compact=sources_compact,
         source_count=len(sources),
+        language=language,
     )
 
     system = (
-        "Ты — библиотекарь-аналитик. "
-        "Задача: отсеять нерелевантные источники. "
-        "Отвечай только валидным JSON."
+        "You are a library analyst. "
+        "Task: identify irrelevant sources for removal. "
+        "Output only valid JSON."
     )
 
     return ai.call_json(system, user_prompt, max_tokens=4096, timeout=LIBRARY_TIMEOUT)

--- a/src/klemma/skills/planner.py
+++ b/src/klemma/skills/planner.py
@@ -130,7 +130,7 @@ def generate_morning_plan(
 
     # Название главы
     chapter_name = config.dissertation.chapters.get(
-        config.dissertation.current_chapter, "Неизвестно"
+        config.dissertation.current_chapter, "Unknown"
     )
 
     # Library summary for context
@@ -157,7 +157,7 @@ def generate_morning_plan(
         days_without_progress=writing_streak["days_without_progress"],
         streak=writing_streak["streak"],
         yesterday_plan=yesterday,
-        chapter_plan=chapter_plan or "План сессий не найден.",
+        chapter_plan=chapter_plan or "Session plan not found.",
         coverage=coverage,
         gaps=gaps,
         fragment_stats=fragment_stats,
@@ -165,13 +165,14 @@ def generate_morning_plan(
         min_sources=config.dissertation.min_sources_per_section,
         writing_constraints=config.dissertation.writing_constraints,
         library_summary=lib_digest,
+        language=config.ai.language,
         range=range,
     )
 
     system = (
-        "Ты — ассистент для написания кандидатской диссертации. "
-        "Генерируй утренний брифинг по принципу «один фокус в день». "
-        "Отвечай на русском. Верни только JSON."
+        "You are a PhD dissertation writing assistant. "
+        "Generate a morning briefing following the 'one focus per day' principle. "
+        "Output only valid JSON."
     )
 
     data = ai.call_json(system, user_prompt, max_tokens=2048)

--- a/src/klemma/skills/researcher.py
+++ b/src/klemma/skills/researcher.py
@@ -506,7 +506,7 @@ def research_section(
     """
     # Определить главу
     chapter = int(section.split(".")[0])
-    chapter_name = config.dissertation.chapters.get(chapter, f"Глава {chapter}")
+    chapter_name = config.dissertation.chapters.get(chapter, f"Chapter {chapter}")
 
     # 0. Проверить предыдущий брифинг (инкрементальный режим)
     prev = _load_previous_research(section, chapter, state, vault)
@@ -608,11 +608,11 @@ def research_section(
             new_citekeys=new_citekeys,
             previous_fragment_count=prev["previous_fragment_count"],
             current_fragment_count=len(section_fragments),
-            section_text=section_text or "Раздел ещё не написан.",
+            section_text=section_text or "Section not written yet.",
             full_chapter_draft=(
                 draft_content[:30000]
                 if draft_content
-                else "Черновик главы не найден."
+                else "Chapter draft not found."
             ),
             fragments=json.dumps(
                 formatted_fragments, ensure_ascii=False, indent=2
@@ -623,13 +623,14 @@ def research_section(
             coverage=coverage,
             gaps=gaps,
             min_sources=config.dissertation.min_sources_per_section,
+            language=config.ai.language,
             range=range,
         )
 
         system = (
-            "Ты — исследовательский аналитик для кандидатской диссертации. "
-            "Это ПОВТОРНЫЙ анализ — обнови предыдущий брифинг, не переписывая с нуля. "
-            "Отвечай на русском. Верни только JSON."
+            "You are a research analyst for a PhD dissertation. "
+            "This is a REPEAT analysis — update the previous briefing, do not rewrite from scratch. "
+            "Output only valid JSON."
         )
 
         logger.info(
@@ -648,13 +649,13 @@ def research_section(
             target_section=section,
             chapter_num=chapter,
             chapter_name=chapter_name,
-            section_text=section_text or "Раздел ещё не написан.",
+            section_text=section_text or "Section not written yet.",
             full_chapter_draft=(
                 draft_content[:30000]
                 if draft_content
-                else "Черновик главы не найден."
+                else "Chapter draft not found."
             ),
-            chapter_plan=chapter_plan or "План сессий не найден.",
+            chapter_plan=chapter_plan or "Session plan not found.",
             fragments=json.dumps(
                 formatted_fragments, ensure_ascii=False, indent=2
             ),
@@ -665,13 +666,14 @@ def research_section(
             gaps=gaps,
             fragment_stats=fragment_stats,
             min_sources=config.dissertation.min_sources_per_section,
+            language=config.ai.language,
             range=range,
         )
 
         system = (
-            "Ты — исследовательский аналитик для кандидатской диссертации. "
-            "Анализируй готовность раздела и предложи структуру аргументации. "
-            "Отвечай на русском. Верни только JSON."
+            "You are a research analyst for a PhD dissertation. "
+            "Analyze section readiness and suggest an argumentation structure. "
+            "Output only valid JSON."
         )
 
     # 9. Вызов Claude

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -60,14 +60,14 @@ def test_base_call_json_delegates_to_call():
     config = AIConfig()
     base = AIProviderBase(config)
     # Override call to return JSON text
-    base.call = lambda system, user, max_tokens=8192, temperature=0.2: '{"result": 42}'
+    base.call = lambda system, user, max_tokens=8192, temperature=0.2, timeout=None: '{"result": 42}'
     assert base.call_json("sys", "usr") == {"result": 42}
 
 
 def test_base_call_json_returns_none_on_empty():
     config = AIConfig()
     base = AIProviderBase(config)
-    base.call = lambda system, user, max_tokens=8192, temperature=0.2: None
+    base.call = lambda system, user, max_tokens=8192, temperature=0.2, timeout=None: None
     assert base.call_json("sys", "usr") is None
 
 


### PR DESCRIPTION
## Summary

- **LICENSE**: MIT license file
- **CI**: GitHub Actions workflow — `ruff check` + `pytest` on Python 3.11/3.12
- **English prompts**: All 8 shipped prompt templates rewritten in English with `{{ language }}` Jinja2 directive. No hardcoded Russian in shipped prompts
- **`ai.language` config**: New field (default `"ru"`) controls AI response language at runtime. Passed to all `render_prompt()` calls
- **System prompts**: All hardcoded Russian system prompt strings in skill files replaced with English
- **pyproject.toml**: Version sync (0.4.1), authors, keywords, classifiers, project URLs
- **README_EN.md**: English README alongside Russian primary README.md
- **CONTRIBUTING.md**: Dev setup, code style, prompt language convention, PR process
- **Test fix**: Pre-existing `timeout` kwarg failures in test lambdas

## Builds on PR #8

This PR adds OSS infrastructure on top of the `~/.klemma/` extraction from #8. Together they make the repo usable by external contributors and English-speaking researchers.

## Prompt language system

- Shipped prompts are English with `Respond in {{ language }}.`
- Users override via `~/.klemma/prompts/` (e.g. Russian prompts already there)
- `ai.language: "ru"` in config controls the response language

## Test plan

- [x] `klemma --help` and `klemma status` work
- [x] All 18 tests pass
- [x] No Russian text in shipped `prompts/`
- [x] All 8 prompts use `{{ language }}`
- [x] Version 0.4.1 matches between pyproject.toml and __init__.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)