### PR TITLE
refactor: Git/NPM-style per-directory multi-tenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,13 @@ Created by `klemma init` in any directory. Navigate to project dir and run comma
 
 **Selective inheritance:** Only shared resources (`obsidian`, `zotero`, `ai`, `mcp`) are inherited from parent. Project-specific keys (`project`, `tags`, `state`, `processing`) are NOT inherited.
 
-**Prompt resolution:** `resolve_prompt(name, klemma_home)` checks project → parent project → system (`~/.klemma/prompts/`) → shipped prompts.
+**Prompt resolution:** `resolve_prompt(name, klemma_home, project_chain?)` checks project → parent project → system (`~/.klemma/prompts/`) → shipped prompts.
 
 **Context aggregation:** `load_project_context()` reads `KLEMMA.md` from all project roots in chain (parent first, child last). Falls back to `.klemma/context.md` (legacy) then config fields.
 
-**Fallbacks:** If `KLEMMA.md` is missing, tries `.klemma/context.md`, then builds from `config.project` fields. If `tags.yaml` is missing, tags are extracted from `config.tags.auto_mapping` keys.
+**Tags resolution:** `load_available_tags(klemma_home, config, project_chain?)` checks project → parent project → `config.tags.auto_mapping`.
+
+**Fallbacks:** If `KLEMMA.md` is missing, tries `.klemma/context.md`, then builds from `config.project` fields. If `tags.yaml` is missing, falls back to parent project's tags, then `config.tags.auto_mapping` keys.
 
 ### Nested projects
 ```
@@ -135,7 +137,7 @@ thesis_dir/
 Navigate into `thesis_dir/paper_ice/` and run `klemma status` — it uses the paper's DB but inherits vault/zotero from the thesis parent. AI context includes both dissertation and paper KLEMMA.md files.
 
 ### Migration from old `~/.klemma/` setup
-Run `klemma migrate` in desired project directory. Splits `~/.klemma/config.yaml` into system (AI) and project (everything else), copies context.md → KLEMMA.md, tags.yaml, DB.
+Run `klemma migrate` in desired project directory. Splits `~/.klemma/config.yaml` into system (AI + MCP) and project (everything else), copies context.md → KLEMMA.md, tags.yaml, DB.
 
 ## SQLite tables
 - `sources` — Zotero entries with processing status and dissertation metadata

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,15 @@ Klemma is a CLI tool for academic writing. It manages literature (via Zotero), e
 - **Library abstraction**: LibraryProvider protocol with LocalLibrary (BBT JSON) and MCPLibrary (zotero-mcp) backends
 - **AI abstraction**: AIProvider protocol with ClaudeClient (CLI), OpenAIClient, LiteLLMClient backends + `create_ai()` factory
 - **Context**: KlemmaContext dataclass created once per CLI command, holds config/state/vault/ai/library/tools/project
-- **Multi-project**: workspace.yaml maps project names → config files; each project gets own DB, bibliography, vault area
+- **Multi-project**: Git/NPM-style per-directory projects. `klemma init` in any dir creates `.klemma/` + `KLEMMA.md`. Nested projects inherit shared resources (vault, zotero) from parent. System config in `~/.klemma/`.
 
 ## Project structure
 ```
 src/klemma/
 ├── cli.py              — Click CLI entry point
-├── config.py           — Pydantic config models (ProjectConfig, WorkspaceConfig, KlemmaConfig) + get_klemma_home(), load helpers, resolve_prompt()
-├── context.py          — KlemmaContext dataclass (single object per CLI command, includes project)
-├── setup.py            — `klemma init` logic — scaffolds ~/.klemma/ from example files
+├── config.py           — Pydantic config models (ProjectConfig, SystemConfig, KlemmaConfig) + discover_project_root(), resolve_effective_config(), resolve_prompt()
+├── context.py          — KlemmaContext dataclass (single object per CLI command, includes project_root/project_chain)
+├── setup.py            — `klemma init` logic — init_project() (per-dir .klemma/) + init_system() (~/.klemma/)
 ├── state.py            — SQLite state manager
 ├── ai.py               — AIProvider protocol + AIProviderBase + ClaudeClient + create_ai() factory
 ├── ai_openai.py        — OpenAI-compatible backend (OpenAI, Ollama, vLLM, LM Studio)
@@ -40,8 +40,11 @@ prompts/                    — Shipped Jinja2 prompt templates (overridable via
 ├── research_incremental.md — incremental research update
 ├── librarian.md            — library analysis (3 modes)
 └── agent.md                — interactive agent system prompt
-config.example.yaml         — Template config for `klemma init`
-context.example.md          — Template dissertation context
+config.project.example.yaml — Template for per-project .klemma/config.yaml
+config.system.example.yaml  — Template for ~/.klemma/config.yaml (system defaults)
+config.example.yaml         — Legacy template config (kept for migration)
+klemma.example.md           — Template KLEMMA.md (project context)
+context.example.md          — Legacy template context (kept for migration)
 tags.example.yaml           — Template tag taxonomy
 .claude/skills/
 ├── klemma-acquire/SKILL.md — Agent skill: paper acquisition pipeline
@@ -49,8 +52,8 @@ tags.example.yaml           — Template tag taxonomy
 └── klemma-status/SKILL.md  — Agent skill: coverage & gaps check
 ```
 
-## Key commands (12)
-- `klemma init` — scaffold `~/.klemma/` with config templates (first-time setup)
+## Key commands (14)
+- `klemma init [--type paper|thesis]` — create project in current directory (.klemma/ + KLEMMA.md)
 - `klemma plan` — daily plan generation (library digest included)
 - `klemma status` — unified stats + coverage + gaps + ref-gaps (`--verbose`, `--chapter N`)
 - `klemma process [<citekeys>...]` — extract fragments from PDF; no arg = batch all pending; parallel by default
@@ -61,57 +64,78 @@ tags.example.yaml           — Template tag taxonomy
 - `klemma tools {add,list,remove,call}` — manage MCP servers (zotero, academia, etc.)
 - `klemma search "query"` — search papers via MCP (arXiv, Semantic Scholar)
 - `klemma discover -s X.X` — hybrid discovery pipeline (`--background`, `--status`, `--review`)
-- `klemma projects {list,switch,info}` — manage multiple projects (workspace mode)
-- Global options: `--project/-p <name>`, `--workspace/-w <path>`, `--config/-c <path>`
+- `klemma info` — show current project info (root, chain, config, DB)
+- `klemma tree` — show nested project tree from current root
+- `klemma migrate [--dry-run]` — migrate from old ~/.klemma/ to per-directory project
+- Global options: `--config/-c <path>`
 
 Hidden aliases (backward compat): `morning`→`plan`, `extract`→`process`, `agent`→`ask`, `stats`/`coverage`/`gaps`→`status`, `prepopulate`→`import`
 
 ## Config
 
-User data lives in `~/.klemma/` (overridable via `KLEMMA_HOME` env var):
+Two-level configuration: system (global) and project (per-directory).
+
+### System directory (`~/.klemma/`) — global defaults
 ```
 ~/.klemma/
-├── config.yaml    — main config (Zotero, Obsidian, AI, dissertation structure, MCP)
-├── context.md     — dissertation context (topic, results, chapters, key terms)
-├── tags.yaml      — tag taxonomy for fragment classification (list of strings)
-├── prompts/       — optional user overrides for shipped Jinja2 prompt templates
-└── data/
-    └── klemma.db  — SQLite database
+├── config.yaml    — AI defaults, global MCP servers
+└── prompts/       — optional global prompt overrides
 ```
+Created automatically on first `klemma init`. Override location via `KLEMMA_HOME` env var.
 
-Run `klemma init` to scaffold from `config.example.yaml`, `context.example.md`, `tags.example.yaml`.
-- `workspace.yaml` — optional: maps project names to per-project config files, shared defaults
+### Project directory (`.klemma/` in any dir) — per-project data
+```
+project_dir/
+├── KLEMMA.md          — project context for AI (visible, like CLAUDE.md)
+└── .klemma/
+    ├── config.yaml    — project config (zotero, obsidian, project, MCP overrides)
+    ├── tags.yaml      — tag taxonomy for fragment classification
+    ├── prompts/       — optional project-level prompt overrides
+    └── data/
+        └── klemma.db  — SQLite database
+```
+Created by `klemma init` in any directory. Navigate to project dir and run commands.
 
-**Config keys:**
+**Config keys (project-level):**
 - `zotero.library_json` — path to BetterBibTeX JSON export (for PDF lookup)
 - `zotero.backend` — `"local"` (default, BBT JSON) or `"mcp"` (zotero-mcp server)
 - `zotero.collection` — optional Zotero collection ID for filtering
 - `mcp.servers` — registered MCP servers (managed via `klemma tools add/remove`)
-- `project:` — optional inline ProjectConfig (type, title, chapters, scientific_results, etc.)
+- `project:` — ProjectConfig (type, title, chapters, scientific_results, etc.)
 - `ai.backend` — `"claude"` (default, CLI), `"openai"` (OpenAI-compatible API), or `"litellm"` (100+ providers)
 - `ai.base_url` — endpoint URL for OpenAI-compatible servers (Ollama, vLLM, LM Studio)
 - `ai.api_key_env` — env var name for API key (e.g. `"OPENAI_API_KEY"`)
 - `ai.json_mode` — enable structured JSON output when backend supports it
 - Requires: AI backend (`claude` CLI by default, or `pip install klemma[openai]` / `klemma[litellm]`), optionally `ZOTERO_API_KEY`
 
-**Prompt resolution:** `resolve_prompt(name, klemma_home)` checks `~/.klemma/prompts/<name>` first, then falls back to shipped `prompts/<name>`.
+**Project discovery:** `discover_project_root()` traverses up from cwd to find nearest `.klemma/` directory (like `git rev-parse --show-toplevel`).
 
-**Fallbacks:** If `context.md` is missing, context is built from `config.dissertation` fields. If `tags.yaml` is missing, tags are extracted from `config.tags.auto_mapping` keys.
+**Config merge order:** system (`~/.klemma/`) < parent project < child project < CLI `--config`.
 
-### Multi-project setup
-```yaml
-# workspace.yaml
-active: dissertation
-defaults:
-  ai: { model: opus }
-  mcp: { servers: { ... } }
-projects:
-  dissertation: ./configs/dissertation.yaml
-  ice_paper: ./configs/ice_paper.yaml
+**Selective inheritance:** Only shared resources (`obsidian`, `zotero`, `ai`, `mcp`) are inherited from parent. Project-specific keys (`project`, `tags`, `state`, `processing`) are NOT inherited.
+
+**Prompt resolution:** `resolve_prompt(name, klemma_home)` checks project → parent project → system (`~/.klemma/prompts/`) → shipped prompts.
+
+**Context aggregation:** `load_project_context()` reads `KLEMMA.md` from all project roots in chain (parent first, child last). Falls back to `.klemma/context.md` (legacy) then config fields.
+
+**Fallbacks:** If `KLEMMA.md` is missing, tries `.klemma/context.md`, then builds from `config.project` fields. If `tags.yaml` is missing, tags are extracted from `config.tags.auto_mapping` keys.
+
+### Nested projects
 ```
-Each project config is a full config.yaml with its own obsidian/state/zotero/project sections.
-Workspace defaults are deep-merged under each project config (project values win).
-Without workspace.yaml, the legacy `dissertation:` block in config.yaml is auto-wrapped into a ProjectConfig.
+thesis_dir/
+├── KLEMMA.md           — dissertation context
+├── .klemma/            — dissertation project
+├── paper_ice/
+│   ├── KLEMMA.md       — paper context (AI sees both)
+│   └── .klemma/        — paper project (inherits vault/zotero from thesis)
+└── paper_climate/
+    ├── KLEMMA.md
+    └── .klemma/
+```
+Navigate into `thesis_dir/paper_ice/` and run `klemma status` — it uses the paper's DB but inherits vault/zotero from the thesis parent. AI context includes both dissertation and paper KLEMMA.md files.
+
+### Migration from old `~/.klemma/` setup
+Run `klemma migrate` in desired project directory. Splits `~/.klemma/config.yaml` into system (AI) and project (everything else), copies context.md → KLEMMA.md, tags.yaml, DB.
 
 ## SQLite tables
 - `sources` — Zotero entries with processing status and dissertation metadata

--- a/config.project.example.yaml
+++ b/config.project.example.yaml
@@ -1,0 +1,60 @@
+# =============================================================================
+# KLEMMA PROJECT CONFIG — per-project settings
+# =============================================================================
+# This file lives in .klemma/config.yaml inside your project directory.
+# Shared resources (obsidian, zotero, ai, mcp) are inherited from parent
+# project if this is a nested project. Override only what you need.
+
+# --- Shared resources (inherited from parent if nested) ---
+
+zotero:
+  library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
+  storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
+
+obsidian:
+  vault_path: "/path/to/your/obsidian/vault"
+  notes_folder: "References"           # folder with @citekey.md notes
+  tags_folder: "Tags"                  # optional folder for tag notes
+
+ai:
+  model: "sonnet"                      # claude model: "opus", "sonnet", "haiku"
+  language: "ru"                       # AI response language
+  # Uncomment for OpenAI-compatible backends:
+  # backend: "openai"
+  # base_url: "http://localhost:11434/v1"
+  # api_key_env: "OPENAI_API_KEY"
+
+# --- Per-project settings (NOT inherited from parent) ---
+
+project:
+  type: dissertation                   # dissertation | paper | thesis
+  title: "Your project title"
+  current_focus: "1.1"
+  chapters:
+    1: "Literature review"
+    2: "Methodology"
+    3: "Results and discussion"
+  scientific_results:
+    nr1: "First scientific result"
+    nr2: "Second scientific result"
+  deadlines:
+    - chapter: "1"
+      deadline: "2026-06-01"
+      label: "Chapter 1"
+  writing_constraints: "1-2 hours/day, 200-400 words/day"
+  priority_terms:
+    - your_key_term_1
+    - your_key_term_2
+
+state:
+  db_path: "./data/klemma.db"          # relative to .klemma/
+
+tags:
+  auto_mapping:
+    - pattern: "review|survey|meta.?analysis"
+      tag: "Review"
+    - pattern: "methodology|method"
+      tag: "Methodology"
+
+mcp:
+  servers: {}

--- a/config.system.example.yaml
+++ b/config.system.example.yaml
@@ -1,0 +1,24 @@
+# =============================================================================
+# KLEMMA SYSTEM CONFIG — global defaults (~/.klemma/config.yaml)
+# =============================================================================
+# Shared settings for all klemma projects. Project-level configs override these.
+
+ai:
+  model: "sonnet"                      # default AI model: "opus", "sonnet", "haiku"
+  language: "ru"                       # default AI response language
+  timeout: 300
+  retries: 2
+  # Uncomment for OpenAI-compatible backends:
+  # backend: "openai"
+  # base_url: "http://localhost:11434/v1"
+  # api_key_env: "OPENAI_API_KEY"
+
+mcp:
+  servers: {}
+  # Global MCP servers available to all projects:
+  # servers:
+  #   zotero:
+  #     command: "uvx"
+  #     args: ["zotero-mcp"]
+  #     env:
+  #       ZOTERO_LOCAL: "true"

--- a/klemma.example.md
+++ b/klemma.example.md
@@ -1,0 +1,22 @@
+# Project Context
+
+<!-- This file describes your project for AI. It is passed as context to all
+     AI-powered commands (plan, research, process, ask, etc.).
+
+     For nested projects, context is aggregated: parent context first, then child.
+     For example, if this is a paper inside a dissertation directory, AI will see
+     the dissertation context followed by this paper's context. -->
+
+Topic: "Your project title here"
+
+Scientific Results:
+- NR1: First scientific result — what you aim to prove or build
+- NR2: Second scientific result — the methodology or framework
+
+Chapters:
+1. Literature review and domain analysis (deadline: 2026-06-01)
+2. Methodology and model design (deadline: 2026-09-01)
+3. Results and validation (deadline: 2026-11-01)
+4. Implementation and software (deadline: 2027-01-01)
+
+Key terms: term1, term2, term3, abbreviation1, abbreviation2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "click==8.1.8",
-    "pydantic==2.10.6",
+    "pydantic==2.11.10",
     "PyMuPDF==1.25.3",
     "Jinja2==3.1.6",
     "PyYAML==6.0.2",

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -4,9 +4,10 @@ Foundation layer: config, state, AI providers, vault, library abstraction, CLI e
 
 ## Modules
 
-### cli.py (~1780 lines)
+### cli.py (~1890 lines)
 Click CLI entry point. Defines 14 commands + hidden aliases.
 - `_init_components(config_path)` — creates `KlemmaContext` via Git-style project discovery
+- `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
 - Commands: `init`, `plan`, `status`, `process`, `acquire`, `research`, `library`, `ask`, `tools`, `search`, `discover`, `info`, `tree`, `migrate`
@@ -15,17 +16,17 @@ Click CLI entry point. Defines 14 commands + hidden aliases.
 `KlemmaContext` dataclass — single object per CLI command invocation.
 Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`.
 
-### config.py (~440 lines)
+### config.py (~577 lines)
 Pydantic config models + Git-style project discovery.
 Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `MCPConfig`, `MCPServerConfig`, `SystemConfig`, `ProjectConfig`.
 - `discover_project_root(start)` — traverse up from cwd to find nearest `.klemma/`
 - `discover_project_chain(start)` — find all project roots child-first, max depth 3
 - `resolve_effective_config(project_chain, config_override)` — merge: system < parent < child < CLI override
 - `load_project_context(project_chain, config)` — aggregate KLEMMA.md files parent-first
-- `ensure_system_home()` — auto-create `~/.klemma/` with minimal config on first run
+- `ensure_system_home()` — auto-create `~/.klemma/` via `init_system()` on first run
 - `get_system_home()` / `get_klemma_home()` — returns `Path(KLEMMA_HOME)` or `~/.klemma`
-- `load_available_tags(klemma_home, config)` — reads `tags.yaml`, fallback from `tags.auto_mapping`
-- `resolve_prompt(name, klemma_home)` — 4-level: project → parent → system → shipped
+- `load_available_tags(klemma_home, config, project_chain?)` — reads `tags.yaml` with parent fallback
+- `resolve_prompt(name, klemma_home, project_chain?)` — 4-level: project → parent → system → shipped
 - Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai", "mcp"}` from parent projects
 
 ### setup.py (~134 lines)

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -4,27 +4,35 @@ Foundation layer: config, state, AI providers, vault, library abstraction, CLI e
 
 ## Modules
 
-### cli.py (1480 lines)
-Click CLI entry point. Defines all 11 commands + hidden aliases.
-- `_init_components()` — creates `KlemmaContext` from config
+### cli.py (~1780 lines)
+Click CLI entry point. Defines 14 commands + hidden aliases.
+- `_init_components(config_path)` — creates `KlemmaContext` via Git-style project discovery
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
+- Commands: `init`, `plan`, `status`, `process`, `acquire`, `research`, `library`, `ask`, `tools`, `search`, `discover`, `info`, `tree`, `migrate`
 
-### context.py (35 lines)
+### context.py (~42 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.
-Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional), `klemma_home`, `dissertation_context`, `available_tags`.
+Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `tools` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`.
 
-### config.py (~200 lines)
-Pydantic config models loaded from `config.yaml`.
-Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `MCPConfig`, `MCPServerConfig`.
-- `get_klemma_home()` — returns `Path(KLEMMA_HOME)` or `~/.klemma`
-- `load_dissertation_context(klemma_home, config)` — reads `context.md`, fallback from config fields
+### config.py (~440 lines)
+Pydantic config models + Git-style project discovery.
+Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `MCPConfig`, `MCPServerConfig`, `SystemConfig`, `ProjectConfig`.
+- `discover_project_root(start)` — traverse up from cwd to find nearest `.klemma/`
+- `discover_project_chain(start)` — find all project roots child-first, max depth 3
+- `resolve_effective_config(project_chain, config_override)` — merge: system < parent < child < CLI override
+- `load_project_context(project_chain, config)` — aggregate KLEMMA.md files parent-first
+- `ensure_system_home()` — auto-create `~/.klemma/` with minimal config on first run
+- `get_system_home()` / `get_klemma_home()` — returns `Path(KLEMMA_HOME)` or `~/.klemma`
 - `load_available_tags(klemma_home, config)` — reads `tags.yaml`, fallback from `tags.auto_mapping`
-- `resolve_prompt(name, klemma_home)` — user override in `klemma_home/prompts/`, then shipped `prompts/`
+- `resolve_prompt(name, klemma_home)` — 4-level: project → parent → system → shipped
+- Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai", "mcp"}` from parent projects
 
-### setup.py (42 lines)
-`klemma init` logic — creates `~/.klemma/` from example template files.
-- `init_klemma_home(klemma_home)` — copies config.example.yaml → config.yaml, etc.
+### setup.py (~134 lines)
+`klemma init` logic — creates per-directory `.klemma/` projects and `~/.klemma/` system config.
+- `init_project(project_dir, project_type)` — creates `.klemma/`, `KLEMMA.md`, updates `.gitignore`
+- `init_system(system_home)` — creates `~/.klemma/config.yaml` (AI defaults only)
+- `init_klemma_home()` — legacy alias for `init_system()`
 
 ### state.py (1207 lines)
 SQLite state manager. Tables:

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -12,11 +12,13 @@ from rich.table import Table
 from . import __version__, get_banner
 from .ai import create_ai
 from .config import (
-    get_klemma_home,
+    discover_project_chain,
+    discover_project_root,
+    ensure_system_home,
     load_available_tags,
     load_config,
-    load_dissertation_context,
-    resolve_project,
+    load_project_context,
+    resolve_effective_config,
 )
 from .context import KlemmaContext
 from .library_provider import create_library
@@ -27,21 +29,41 @@ from .vault import VaultAdapter
 console = Console()
 
 
-def _init_components(config_path: str | None, project_name: str | None = None,
-                     workspace_path: str | None = None) -> KlemmaContext:
-    """Initialize all components from config, with optional project selection.
+def _init_components(config_path: str | None = None) -> KlemmaContext:
+    """Initialize all components by discovering project from cwd.
 
-    If config_path is None, loads from klemma_home.
+    Uses Git-style .klemma/ discovery. If config_path is given, uses it directly.
     """
-    klemma_home = get_klemma_home()
+    system_home = ensure_system_home()
 
-    cfg, project, proj_name = resolve_project(
-        config_path=config_path,
-        workspace_path=workspace_path,
-        project_name=project_name,
-    )
+    if config_path:
+        # Explicit --config: load directly, skip discovery
+        cfg = load_config(config_path)
+        project = cfg.project
+        if not project:
+            from .config import ProjectConfig, DissertationConfig
+            if cfg.dissertation and cfg.dissertation.title:
+                project = ProjectConfig.from_dissertation(cfg.dissertation)
+            else:
+                project = ProjectConfig()
+        project_root = Path(config_path).resolve().parent
+        if project_root.name == ".klemma":
+            project_root = project_root.parent
+        project_chain = [project_root]
+        klemma_home = project_root / ".klemma"
+        if not klemma_home.is_dir():
+            klemma_home = system_home
+    else:
+        # Git-style discovery: find .klemma/ by traversing up from cwd
+        project_chain = discover_project_chain()
+        if not project_chain:
+            raise click.ClickException(
+                "Not in a klemma project. Run 'klemma init' to create one here."
+            )
+        cfg, project, project_root = resolve_effective_config(project_chain)
+        klemma_home = project_root / ".klemma"
 
-    # Resolve db_path relative to klemma_home if relative
+    # Resolve db_path relative to project's .klemma/ directory
     db_path = cfg.state.db_path
     if not Path(db_path).is_absolute():
         db_path = str(klemma_home / db_path)
@@ -51,15 +73,18 @@ def _init_components(config_path: str | None, project_name: str | None = None,
     library = create_library(cfg)
     tools = ToolRegistry(cfg) if cfg.mcp.servers else None
 
-    dissertation_context = load_dissertation_context(klemma_home, cfg)
+    dissertation_context = load_project_context(project_chain, cfg)
     available_tags = load_available_tags(klemma_home, cfg)
 
     return KlemmaContext(
         config=cfg, state=state, vault=vault, library=library, tools=tools,
-        project=project, project_name=proj_name,
+        project=project, project_name=project_root.name,
         klemma_home=klemma_home,
         dissertation_context=dissertation_context,
         available_tags=available_tags,
+        project_root=project_root,
+        project_chain=project_chain,
+        system_home=system_home,
     )
 
 
@@ -260,43 +285,40 @@ def _print_ref_gaps_table(state: StateManager, limit: int = 20):
 
 @click.group(invoke_without_command=True)
 @click.version_option(version=__version__)
-@click.option("--config", "-c", default=None, help="Config file path (default: ~/.klemma/config.yaml)")
-@click.option("--project", "-p", default=None, help="Project name (from workspace.yaml)")
-@click.option("--workspace", "-w", default=None, help="Workspace file path")
+@click.option("--config", "-c", default=None, help="Config file path (override project config)")
 @click.pass_context
-def main(ctx, config, project, workspace):
+def main(ctx, config):
     """Klemma — AI academic assistant.
 
     Run a subcommand or use --help for usage info.
+    Uses Git-style project discovery: run 'klemma init' in your project directory.
     """
     ctx.ensure_object(dict)
     ctx.obj["config_path"] = config
-    ctx.obj["project_name"] = project
-    ctx.obj["workspace_path"] = workspace
-
-    # Check klemma_home exists for all commands except init
-    klemma_home = get_klemma_home()
-    if (
-        ctx.invoked_subcommand is not None
-        and ctx.invoked_subcommand != "init"
-        and config is None
-        and not (klemma_home / "config.yaml").exists()
-    ):
-        console.print(
-            f"[yellow]Config not found at {klemma_home / 'config.yaml'}[/yellow]\n"
-            "Run [bold]klemma init[/bold] to set up, or use --config to specify a config file."
-        )
-        ctx.exit(1)
-        return
 
     # Banner
     console.print(get_banner(cwd=str(Path.cwd())))
 
+    # Check for project (skip for init/info/tree/migrate)
+    skip_check = {"init", "info", "tree", "migrate"}
+    if (
+        ctx.invoked_subcommand is not None
+        and ctx.invoked_subcommand not in skip_check
+        and config is None
+        and discover_project_root() is None
+    ):
+        console.print(
+            "[yellow]Not in a klemma project.[/yellow]\n"
+            "Run [bold]klemma init[/bold] to create a project here, "
+            "or use --config to specify a config file."
+        )
+        ctx.exit(1)
+        return
+
     if ctx.invoked_subcommand is not None:
         # Print status line for CLI subcommands
         try:
-            kctx = _init_components(config, project_name=project,
-                                    workspace_path=workspace)
+            kctx = _init_components(config)
             _print_status_line(kctx.state, project_name=kctx.project_name)
         except Exception:
             pass
@@ -306,16 +328,46 @@ def main(ctx, config, project, workspace):
 
 
 @main.command()
+@click.option("--type", "-t", "project_type", default="dissertation",
+              type=click.Choice(["dissertation", "paper", "thesis"]),
+              help="Project type")
+@click.option("--global-only", is_flag=True, help="Only create/update ~/.klemma/ system config")
 @click.pass_context
-def init(ctx):
-    """Initialize ~/.klemma/ with config templates."""
-    from .setup import init_klemma_home
+def init(ctx, project_type, global_only):
+    """Initialize a new klemma project in current directory.
 
-    klemma_home = get_klemma_home()
-    result = init_klemma_home(klemma_home)
+    Creates .klemma/ and KLEMMA.md in the current directory.
+    Also ensures ~/.klemma/ system config exists.
+
+    \b
+    Examples:
+      klemma init                    # dissertation project
+      klemma init --type paper       # paper project
+      klemma init --global-only      # only create system config
+    """
+    from .setup import init_project, init_system
+
+    system_home = ensure_system_home()
+
+    if global_only:
+        result = init_system(system_home)
+        if result["created"]:
+            console.print(f"[green]Created {system_home}/[/green]")
+            for name in result["created"]:
+                console.print(f"  + {name}")
+        else:
+            console.print(f"[dim]System config already exists at {system_home}/[/dim]")
+        return
+
+    # Ensure system config exists
+    init_system(system_home)
+
+    # Create project in current directory
+    project_dir = Path.cwd()
+    result = init_project(project_dir, project_type=project_type)
 
     if result["created"]:
-        console.print(f"[green]Created {klemma_home}/[/green]")
+        console.print(f"[green]Initialized klemma {project_type} project in {project_dir}/[/green]")
         for name in result["created"]:
             console.print(f"  + {name}")
     if result["skipped"]:
@@ -324,9 +376,9 @@ def init(ctx):
 
     console.print()
     console.print("[bold]Next steps:[/bold]")
-    console.print(f"  1. Edit [cyan]{klemma_home / 'config.yaml'}[/cyan] — set Zotero/Obsidian paths")
-    console.print(f"  2. Edit [cyan]{klemma_home / 'context.md'}[/cyan] — describe your dissertation")
-    console.print(f"  3. Edit [cyan]{klemma_home / 'tags.yaml'}[/cyan] — define your topic taxonomy")
+    console.print(f"  1. Edit [cyan].klemma/config.yaml[/cyan] — set Zotero/Obsidian paths")
+    console.print(f"  2. Edit [cyan]KLEMMA.md[/cyan] — describe your project")
+    console.print(f"  3. Edit [cyan].klemma/tags.yaml[/cyan] — define your topic taxonomy")
     console.print("  4. Run [bold]klemma status[/bold] to verify")
 
 
@@ -335,8 +387,7 @@ def init(ctx):
 def plan(ctx):
     """Daily plan — focus, recommendations, deadlines."""
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -413,8 +464,7 @@ def process(ctx, citekeys, serial):
     Without arguments: process all pending sources.
     """
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -573,8 +623,7 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
 def status(ctx, verbose, chapter):
     """Unified status: processing, coverage, gaps, reference gaps."""
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state = kctx.config, kctx.state
     project = kctx.project
     _sync_sections(kctx, quiet=True)
@@ -706,8 +755,7 @@ def research(ctx, section, no_save, force, enrich):
     Example: klemma research --section 1.3.2
     """
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     project = kctx.project
     _sync_sections(kctx)
@@ -883,8 +931,7 @@ def import_vault(ctx, with_queue):
     and syncs source metadata and section assignments with the database.
     """
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     project = kctx.project
 
@@ -938,8 +985,7 @@ def ask(ctx, query, section, chapter):
     Example: klemma ask "What are the main ice forecast validation methods?"
     """
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -985,8 +1031,7 @@ def library(ctx, section, audit):
         return
 
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     _sync_sections(kctx)
     ai = _init_ai(cfg)
@@ -1112,8 +1157,7 @@ def library(ctx, section, audit):
 def prune(ctx, chapter, verdict, clear_key):
     """Browse and manage prune verdicts from library analysis."""
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     state = kctx.state
 
     if clear_key and (chapter is not None or verdict is not None):
@@ -1285,7 +1329,8 @@ def search(ctx, query, source, limit):
     Example: klemma search "AMSR2 sea ice forecast validation"
     """
     config_path = ctx.obj["config_path"]
-    cfg = load_config(config_path)
+    kctx = _init_components(config_path)
+    cfg = kctx.config
 
     if "academia" not in cfg.mcp.servers:
         console.print("[red]Academia MCP server not configured.[/red]")
@@ -1329,8 +1374,7 @@ def discover(ctx, section, show_status, review, background):
       klemma discover --review            # review pending results
     """
     config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path, project_name=ctx.obj["project_name"],
-                            workspace_path=ctx.obj["workspace_path"])
+    kctx = _init_components(config_path)
     cfg, state = kctx.config, kctx.state
 
     if show_status:
@@ -1353,14 +1397,19 @@ def discover(ctx, section, show_status, review, background):
         )
         return
 
+    # Resolve config_path for subprocess/discovery
+    effective_config = config_path
+    if not effective_config and kctx.project_root:
+        effective_config = str(kctx.project_root / ".klemma" / "config.yaml")
+
     if background:
         import subprocess as sp
 
-        log_path = Path.home() / ".klemma" / f"discovery_{section}.log"
+        log_path = (kctx.project_root or Path.home()) / f".klemma/discovery_{section}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         sp.Popen(
             [sys.executable, "-m", "klemma.tools.discovery",
-             "--section", section, "--config", config_path],
+             "--section", section, "--config", effective_config],
             stdout=open(log_path, "w"),
             stderr=sp.STDOUT,
         )
@@ -1372,7 +1421,7 @@ def discover(ctx, section, show_status, review, background):
     from .tools.discovery import run_discovery
 
     with console.status(f"Discovering papers for section {section}", spinner="earth"):
-        result = run_discovery(section=section, config_path=config_path)
+        result = run_discovery(section=section, config_path=effective_config)
 
     console.print(
         f"[green]Done:[/green] searched {result['searched']}, "
@@ -1458,15 +1507,15 @@ def tools():
 @click.option("--command", "-cmd", required=True, help="Command to launch server (e.g. uvx, python3)")
 @click.option("--args", "-a", multiple=True, help="Arguments (repeatable)")
 @click.option("--env", "-e", multiple=True, help="Environment vars as KEY=VALUE (repeatable)")
+@click.option("--global", "is_global", is_flag=True, help="Add to global ~/.klemma/ config")
 @click.pass_context
-def tools_add(ctx, name, command, args, env):
+def tools_add(ctx, name, command, args, env, is_global):
     """Register an MCP server.
 
     Example: klemma tools add zotero --command uvx --args zotero-mcp --env ZOTERO_LOCAL=true
     """
     from .tools.registry import add_server
 
-    config_path = ctx.obj["config_path"]
     env_dict = {}
     for item in env:
         if "=" in item:
@@ -1476,8 +1525,20 @@ def tools_add(ctx, name, command, args, env):
             console.print(f"[red]Invalid env format: {item} (use KEY=VALUE)[/red]")
             return
 
+    if is_global:
+        config_path = str(ensure_system_home() / "config.yaml")
+    elif ctx.obj["config_path"]:
+        config_path = ctx.obj["config_path"]
+    else:
+        project_root = discover_project_root()
+        if project_root is None:
+            console.print("[red]Not in a klemma project. Use --global or 'klemma init' first.[/red]")
+            return
+        config_path = str(project_root / ".klemma" / "config.yaml")
+
     add_server(config_path, name, command, list(args), env_dict)
-    console.print(f"[green]Added MCP server '{name}'[/green]")
+    scope = "global" if is_global else "project"
+    console.print(f"[green]Added MCP server '{name}' ({scope})[/green]")
     console.print(f"  command: {command} {' '.join(args)}")
     if env_dict:
         console.print(f"  env: {env_dict}")
@@ -1489,8 +1550,8 @@ def tools_add(ctx, name, command, args, env):
 @click.pass_context
 def tools_list(ctx, probe):
     """List registered MCP servers."""
-    config_path = ctx.obj["config_path"]
-    cfg = load_config(config_path)
+    kctx = _init_components(ctx.obj["config_path"])
+    cfg = kctx.config
 
     servers = cfg.mcp.servers
     if not servers:
@@ -1522,12 +1583,23 @@ def tools_list(ctx, probe):
 
 @tools.command(name="remove")
 @click.argument("name")
+@click.option("--global", "is_global", is_flag=True, help="Remove from global ~/.klemma/ config")
 @click.pass_context
-def tools_remove(ctx, name):
+def tools_remove(ctx, name, is_global):
     """Remove an MCP server registration."""
     from .tools.registry import remove_server
 
-    config_path = ctx.obj["config_path"]
+    if is_global:
+        config_path = str(ensure_system_home() / "config.yaml")
+    elif ctx.obj["config_path"]:
+        config_path = ctx.obj["config_path"]
+    else:
+        project_root = discover_project_root()
+        if project_root is None:
+            console.print("[red]Not in a klemma project.[/red]")
+            return
+        config_path = str(project_root / ".klemma" / "config.yaml")
+
     if remove_server(config_path, name):
         console.print(f"[green]Removed MCP server '{name}'[/green]")
     else:
@@ -1544,8 +1616,8 @@ def tools_call(ctx, server, tool, args_json):
 
     Example: klemma tools call zotero zotero_search_items '{"query": "ice"}'
     """
-    config_path = ctx.obj["config_path"]
-    cfg = load_config(config_path)
+    kctx = _init_components(ctx.obj["config_path"])
+    cfg = kctx.config
 
     if server not in cfg.mcp.servers:
         console.print(f"[red]Server '{server}' not registered[/red]")
@@ -1567,113 +1639,54 @@ def tools_call(ctx, server, tool, args_json):
         console.print(result.content)
 
 
-# --- Projects: multi-project management ---
+# --- Info & Tree: project introspection ---
 
-@main.group()
-def projects():
-    """Manage multiple projects (workspace mode)."""
-    pass
-
-
-@projects.command(name="list")
+@main.command()
 @click.pass_context
-def projects_list(ctx):
-    """List all projects in the workspace."""
-    import yaml as _yaml
-
-    workspace_path = ctx.obj.get("workspace_path") or "workspace.yaml"
-    ws_path = Path(workspace_path)
-
-    if not ws_path.exists():
-        console.print("[dim]No workspace.yaml found.[/dim]")
-        console.print("[dim]Create one to manage multiple projects.[/dim]")
-        console.print("[dim]Or use --config to point at a specific project config.[/dim]")
-        return
-
-    with open(ws_path, "r", encoding="utf-8") as f:
-        ws_raw = _yaml.safe_load(f) or {}
-
-    from .config import WorkspaceConfig
-    ws = WorkspaceConfig.model_validate(ws_raw)
-
-    table = Table(title="Projects", show_edge=False, pad_edge=False)
-    table.add_column("", width=2)
-    table.add_column("Name", style="cyan")
-    table.add_column("Config Path")
-    table.add_column("Status")
-
-    for name, path in ws.projects.items():
-        marker = "[green]\u25cf[/green]" if name == ws.active else " "
-        resolved = ws_path.parent / path
-        exists = "[green]OK[/green]" if resolved.exists() else "[red]missing[/red]"
-        table.add_row(marker, name, path, exists)
-
-    console.print(table)
-    console.print(f"\n[dim]Active: {ws.active}[/dim]")
-    console.print("[dim]Switch: klemma projects switch <name>[/dim]")
-
-
-@projects.command(name="switch")
-@click.argument("name")
-@click.pass_context
-def projects_switch(ctx, name):
-    """Switch the active project in workspace.yaml."""
-    import yaml as _yaml
-
-    workspace_path = ctx.obj.get("workspace_path") or "workspace.yaml"
-    ws_path = Path(workspace_path)
-
-    if not ws_path.exists():
-        console.print(f"[red]Workspace file not found: {ws_path}[/red]")
-        return
-
-    with open(ws_path, "r", encoding="utf-8") as f:
-        ws_raw = _yaml.safe_load(f) or {}
-
-    if name not in ws_raw.get("projects", {}):
-        available = ", ".join(ws_raw.get("projects", {}).keys()) or "(none)"
-        console.print(f"[red]Project '{name}' not found. Available: {available}[/red]")
-        return
-
-    ws_raw["active"] = name
-    with open(ws_path, "w", encoding="utf-8") as f:
-        _yaml.dump(ws_raw, f, default_flow_style=False, allow_unicode=True)
-
-    console.print(f"[green]Switched to project: {name}[/green]")
-
-
-@projects.command(name="info")
-@click.argument("name", required=False)
-@click.pass_context
-def projects_info(ctx, name):
-    """Show detailed info about a project."""
+def info(ctx):
+    """Show current project info: root, parent chain, config, DB."""
     config_path = ctx.obj["config_path"]
+
+    project_chain = discover_project_chain()
+    if not project_chain and not config_path:
+        console.print("[yellow]Not in a klemma project.[/yellow]")
+        console.print("[dim]Run 'klemma init' to create a project here.[/dim]")
+        return
+
     try:
-        kctx = _init_components(
-            config_path,
-            project_name=name or ctx.obj.get("project_name"),
-            workspace_path=ctx.obj.get("workspace_path"),
-        )
+        kctx = _init_components(config_path)
     except Exception as e:
         console.print(f"[red]Error loading project: {e}[/red]")
         return
 
     project = kctx.project
-    if not project:
-        console.print("[dim]No project configuration found.[/dim]")
-        return
+    project_root = kctx.project_root or Path.cwd()
+
+    # Project info panel
+    info_parts = [f"[bold]{project.title or 'Untitled'}[/bold]"]
+    info_parts.append(f"Type: {project.type}")
+    info_parts.append(f"Root: {project_root}")
+    if project.current_focus:
+        info_parts.append(f"Focus: {project.current_focus}")
+    info_parts.append(f"Chapters: {len(project.chapters)}")
+    info_parts.append(f"DB: {kctx.config.state.db_path}")
+    if kctx.config.obsidian.vault_path:
+        info_parts.append(f"Vault: {kctx.config.obsidian.vault_path}")
 
     console.print(Panel(
-        f"[bold]{project.title or 'Untitled'}[/bold]\n"
-        f"Type: {project.type}\n"
-        f"Focus: {project.current_focus}\n"
-        f"Chapters: {len(project.chapters)}\n"
-        f"DB: {kctx.config.state.db_path}\n"
-        f"Vault: {kctx.config.obsidian.vault_path}",
+        "\n".join(info_parts),
         title=f"Project: {kctx.project_name}",
         border_style="blue",
     ))
 
+    # Parent chain
+    if len(kctx.project_chain) > 1:
+        console.print("\n[bold]Project Chain[/bold] (child → parent):")
+        for i, root in enumerate(kctx.project_chain):
+            marker = "[green]●[/green]" if i == 0 else "[dim]○[/dim]"
+            console.print(f"  {marker} {root.name} ({root})")
+
+    # Chapter structure
     if project.chapters:
         table = Table(title="Structure", show_edge=False, pad_edge=False)
         table.add_column("Ch", width=4, style="cyan")
@@ -1681,6 +1694,166 @@ def projects_info(ctx, name):
         for ch_num in sorted(project.chapters.keys()):
             table.add_row(str(ch_num), project.chapters[ch_num])
         console.print(table)
+
+
+@main.command()
+@click.pass_context
+def tree(ctx):
+    """Show nested project tree from current root."""
+    project_root = discover_project_root()
+    if project_root is None:
+        console.print("[yellow]Not in a klemma project.[/yellow]")
+        return
+
+    # Find topmost parent
+    chain = discover_project_chain()
+    top = chain[-1] if chain else project_root
+
+    console.print(f"[bold]Project Tree[/bold] (from {top})\n")
+    _print_project_tree(top, indent=0, current=project_root)
+
+
+def _print_project_tree(root: Path, indent: int = 0, current: Path | None = None):
+    """Recursively print project tree."""
+    from .config import _load_yaml
+
+    prefix = "  " * indent
+    marker = "[green]●[/green]" if root == current else "[dim]○[/dim]"
+
+    # Load project title from config
+    config_raw = _load_yaml(root / ".klemma" / "config.yaml")
+    project_raw = config_raw.get("project", {})
+    title = project_raw.get("title", "") if isinstance(project_raw, dict) else ""
+    ptype = project_raw.get("type", "") if isinstance(project_raw, dict) else ""
+
+    label = f"{root.name}"
+    if title:
+        label += f" — {title}"
+    if ptype:
+        label += f" [{ptype}]"
+
+    console.print(f"{prefix}{marker} {label}")
+
+    # Scan subdirectories for child projects
+    try:
+        for child in sorted(root.iterdir()):
+            if child.is_dir() and (child / ".klemma").is_dir() and child.name != ".klemma":
+                _print_project_tree(child, indent + 1, current)
+    except PermissionError:
+        pass
+
+
+# --- Migrate: convert old ~/.klemma/ to per-directory project ---
+
+@main.command()
+@click.option("--dry-run", is_flag=True, help="Preview changes without modifying anything")
+@click.pass_context
+def migrate(ctx, dry_run):
+    """Migrate from ~/.klemma/ centralized config to per-directory project.
+
+    Splits the old ~/.klemma/config.yaml into:
+    - ~/.klemma/config.yaml (system: AI settings only)
+    - .klemma/config.yaml (project: everything else)
+    Also copies context.md → KLEMMA.md, tags.yaml, and DB.
+    """
+    import shutil
+
+    import yaml as _yaml
+
+    system_home = ensure_system_home()
+    old_config_path = system_home / "config.yaml"
+
+    if not old_config_path.exists():
+        console.print(f"[yellow]No config found at {old_config_path}[/yellow]")
+        return
+
+    # Check if already in a project
+    if discover_project_root() is not None:
+        console.print("[yellow]Already in a klemma project (.klemma/ found).[/yellow]")
+        console.print("[dim]Migration is for converting old ~/.klemma/ setups.[/dim]")
+        return
+
+    with open(old_config_path, "r", encoding="utf-8") as f:
+        old_raw = _yaml.safe_load(f) or {}
+
+    # Check this looks like a full project config (has obsidian: section)
+    if "obsidian" not in old_raw:
+        console.print("[dim]~/.klemma/config.yaml looks like a system config already (no obsidian: section).[/dim]")
+        console.print("[dim]Just run 'klemma init' to create a project.[/dim]")
+        return
+
+    project_dir = Path.cwd()
+    klemma_dir = project_dir / ".klemma"
+
+    # Split config
+    system_keys = {"ai"}
+    system_raw = {k: v for k, v in old_raw.items() if k in system_keys}
+    project_raw = {k: v for k, v in old_raw.items() if k not in system_keys}
+
+    # Files to copy
+    copies = []
+    old_context = system_home / "context.md"
+    if old_context.exists():
+        copies.append((old_context, project_dir / "KLEMMA.md"))
+    old_tags = system_home / "tags.yaml"
+    if old_tags.exists():
+        copies.append((old_tags, klemma_dir / "tags.yaml"))
+    old_db = system_home / "data" / "klemma.db"
+    if old_db.exists():
+        copies.append((old_db, klemma_dir / "data" / "klemma.db"))
+    old_prompts = system_home / "prompts"
+    if old_prompts.is_dir() and any(old_prompts.iterdir()):
+        copies.append((old_prompts, klemma_dir / "prompts"))
+
+    if dry_run:
+        console.print("[bold]Dry run — no changes will be made:[/bold]\n")
+        console.print(f"  Rewrite {old_config_path} → system config (ai only)")
+        console.print(f"  Create  {klemma_dir / 'config.yaml'} → project config")
+        for src, dst in copies:
+            console.print(f"  Copy    {src} → {dst}")
+        return
+
+    # Execute
+    klemma_dir.mkdir(parents=True, exist_ok=True)
+    (klemma_dir / "data").mkdir(exist_ok=True)
+
+    # Write project config
+    project_config_path = klemma_dir / "config.yaml"
+    with open(project_config_path, "w", encoding="utf-8") as f:
+        _yaml.dump(project_raw, f, default_flow_style=False, allow_unicode=True)
+    console.print(f"  [green]+ {project_config_path}[/green]")
+
+    # Rewrite system config
+    with open(old_config_path, "w", encoding="utf-8") as f:
+        f.write("# Klemma global config — AI defaults\n")
+        _yaml.dump(system_raw, f, default_flow_style=False, allow_unicode=True)
+    console.print(f"  [green]~ {old_config_path} (system only)[/green]")
+
+    # Copy files
+    for src, dst in copies:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_dir():
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src, dst)
+        console.print(f"  [green]+ {dst}[/green]")
+
+    # .gitignore
+    gitignore = project_dir / ".gitignore"
+    ignore_line = ".klemma/data/"
+    if gitignore.exists():
+        content = gitignore.read_text(encoding="utf-8")
+        if ignore_line not in content:
+            with open(gitignore, "a", encoding="utf-8") as f:
+                if not content.endswith("\n"):
+                    f.write("\n")
+                f.write(f"{ignore_line}\n")
+    else:
+        gitignore.write_text(f"# Klemma data\n{ignore_line}\n", encoding="utf-8")
+
+    console.print(f"\n[green]Migration complete.[/green]")
+    console.print(f"[dim]Project created in {project_dir}/[/dim]")
+    console.print(f"[dim]System config at {system_home}/[/dim]")
 
 
 # --- Backward-compatible aliases ---

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -36,32 +36,28 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
     """
     system_home = ensure_system_home()
 
-    if config_path:
-        # Explicit --config: load directly, skip discovery
-        cfg = load_config(config_path)
-        project = cfg.project
-        if not project:
-            from .config import ProjectConfig, DissertationConfig
-            if cfg.dissertation and cfg.dissertation.title:
-                project = ProjectConfig.from_dissertation(cfg.dissertation)
-            else:
-                project = ProjectConfig()
-        project_root = Path(config_path).resolve().parent
-        if project_root.name == ".klemma":
-            project_root = project_root.parent
-        project_chain = [project_root]
+    # Git-style discovery: find .klemma/ by traversing up from cwd
+    project_chain = discover_project_chain()
+
+    if project_chain:
+        # Discovered project — merge config with system defaults and inheritance
+        cfg, project, project_root = resolve_effective_config(
+            project_chain, config_override=config_path,
+        )
+        klemma_home = project_root / ".klemma"
+    elif config_path:
+        # No project found, but explicit --config given — use it with system defaults
+        cfg, project, project_root = resolve_effective_config(
+            [], config_override=config_path,
+        )
         klemma_home = project_root / ".klemma"
         if not klemma_home.is_dir():
             klemma_home = system_home
+        project_chain = [project_root]
     else:
-        # Git-style discovery: find .klemma/ by traversing up from cwd
-        project_chain = discover_project_chain()
-        if not project_chain:
-            raise click.ClickException(
-                "Not in a klemma project. Run 'klemma init' to create one here."
-            )
-        cfg, project, project_root = resolve_effective_config(project_chain)
-        klemma_home = project_root / ".klemma"
+        raise click.ClickException(
+            "Not in a klemma project. Run 'klemma init' to create one here."
+        )
 
     # Resolve db_path relative to project's .klemma/ directory
     db_path = cfg.state.db_path
@@ -74,7 +70,7 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
     tools = ToolRegistry(cfg) if cfg.mcp.servers else None
 
     dissertation_context = load_project_context(project_chain, cfg)
-    available_tags = load_available_tags(klemma_home, cfg)
+    available_tags = load_available_tags(klemma_home, cfg, project_chain=project_chain)
 
     return KlemmaContext(
         config=cfg, state=state, vault=vault, library=library, tools=tools,
@@ -86,6 +82,15 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
         project_chain=project_chain,
         system_home=system_home,
     )
+
+
+def _get_context(ctx) -> KlemmaContext:
+    """Get KlemmaContext from cache (set in main()) or initialize fresh."""
+    if "kctx" in ctx.obj:
+        return ctx.obj["kctx"]
+    kctx = _init_components(ctx.obj["config_path"])
+    ctx.obj["kctx"] = kctx
+    return kctx
 
 
 def _init_ai(cfg):
@@ -315,10 +320,11 @@ def main(ctx, config):
         ctx.exit(1)
         return
 
-    if ctx.invoked_subcommand is not None:
-        # Print status line for CLI subcommands
+    if ctx.invoked_subcommand is not None and ctx.invoked_subcommand not in skip_check:
+        # Initialize once and cache for subcommands to reuse
         try:
             kctx = _init_components(config)
+            ctx.obj["kctx"] = kctx
             _print_status_line(kctx.state, project_name=kctx.project_name)
         except Exception:
             pass
@@ -386,8 +392,7 @@ def init(ctx, project_type, global_only):
 @click.pass_context
 def plan(ctx):
     """Daily plan — focus, recommendations, deadlines."""
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -463,8 +468,7 @@ def process(ctx, citekeys, serial):
     With CITEKEY(s): process specified sources (parallel when >1).
     Without arguments: process all pending sources.
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -622,8 +626,7 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
 @click.pass_context
 def status(ctx, verbose, chapter):
     """Unified status: processing, coverage, gaps, reference gaps."""
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state = kctx.config, kctx.state
     project = kctx.project
     _sync_sections(kctx, quiet=True)
@@ -754,8 +757,7 @@ def research(ctx, section, no_save, force, enrich):
 
     Example: klemma research --section 1.3.2
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     project = kctx.project
     _sync_sections(kctx)
@@ -930,8 +932,7 @@ def import_vault(ctx, with_queue):
     Scans @*.md files in the vault's notes folder, reads YAML frontmatter,
     and syncs source metadata and section assignments with the database.
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     project = kctx.project
 
@@ -984,8 +985,7 @@ def ask(ctx, query, section, chapter):
 
     Example: klemma ask "What are the main ice forecast validation methods?"
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     ai = _init_ai(cfg)
 
@@ -1030,8 +1030,7 @@ def library(ctx, section, audit):
     if ctx.invoked_subcommand is not None:
         return
 
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state, vault = kctx.config, kctx.state, kctx.vault
     _sync_sections(kctx)
     ai = _init_ai(cfg)
@@ -1156,8 +1155,7 @@ def library(ctx, section, audit):
 @click.pass_context
 def prune(ctx, chapter, verdict, clear_key):
     """Browse and manage prune verdicts from library analysis."""
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     state = kctx.state
 
     if clear_key and (chapter is not None or verdict is not None):
@@ -1235,8 +1233,7 @@ def acquire(ctx, url, title, authors, year, journal, volume, issue, section, bat
     from .literature.zotero import ZoteroLibrary
     from .skills.acquirer import PaperMetadata, acquire_paper, load_batch
 
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state = kctx.config, kctx.state
 
     # Validate Zotero config
@@ -1328,8 +1325,7 @@ def search(ctx, query, source, limit):
 
     Example: klemma search "AMSR2 sea ice forecast validation"
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg = kctx.config
 
     if "academia" not in cfg.mcp.servers:
@@ -1373,9 +1369,9 @@ def discover(ctx, section, show_status, review, background):
       klemma discover --status            # show all discoveries
       klemma discover --review            # review pending results
     """
-    config_path = ctx.obj["config_path"]
-    kctx = _init_components(config_path)
+    kctx = _get_context(ctx)
     cfg, state = kctx.config, kctx.state
+    config_path = ctx.obj["config_path"]
 
     if show_status:
         _discover_status(state)
@@ -1407,12 +1403,14 @@ def discover(ctx, section, show_status, review, background):
 
         log_path = (kctx.project_root or Path.home()) / f".klemma/discovery_{section}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_file = open(log_path, "w")  # noqa: SIM115
         sp.Popen(
             [sys.executable, "-m", "klemma.tools.discovery",
              "--section", section, "--config", effective_config],
-            stdout=open(log_path, "w"),
+            stdout=log_file,
             stderr=sp.STDOUT,
         )
+        log_file.close()  # child process inherits the fd
         console.print(f"[green]Discovery started in background for section {section}[/green]")
         console.print(f"[dim]Log: {log_path}[/dim]")
         console.print("[dim]Review results: klemma discover --review[/dim]")
@@ -1550,7 +1548,7 @@ def tools_add(ctx, name, command, args, env, is_global):
 @click.pass_context
 def tools_list(ctx, probe):
     """List registered MCP servers."""
-    kctx = _init_components(ctx.obj["config_path"])
+    kctx = _get_context(ctx)
     cfg = kctx.config
 
     servers = cfg.mcp.servers
@@ -1616,7 +1614,7 @@ def tools_call(ctx, server, tool, args_json):
 
     Example: klemma tools call zotero zotero_search_items '{"query": "ice"}'
     """
-    kctx = _init_components(ctx.obj["config_path"])
+    kctx = _get_context(ctx)
     cfg = kctx.config
 
     if server not in cfg.mcp.servers:
@@ -1645,16 +1643,14 @@ def tools_call(ctx, server, tool, args_json):
 @click.pass_context
 def info(ctx):
     """Show current project info: root, parent chain, config, DB."""
-    config_path = ctx.obj["config_path"]
-
     project_chain = discover_project_chain()
-    if not project_chain and not config_path:
+    if not project_chain and not ctx.obj["config_path"]:
         console.print("[yellow]Not in a klemma project.[/yellow]")
         console.print("[dim]Run 'klemma init' to create a project here.[/dim]")
         return
 
     try:
-        kctx = _init_components(config_path)
+        kctx = _get_context(ctx)
     except Exception as e:
         console.print(f"[red]Error loading project: {e}[/red]")
         return
@@ -1786,7 +1782,7 @@ def migrate(ctx, dry_run):
     klemma_dir = project_dir / ".klemma"
 
     # Split config
-    system_keys = {"ai"}
+    system_keys = {"ai", "mcp"}
     system_raw = {k: v for k, v in old_raw.items() if k in system_keys}
     project_raw = {k: v for k, v in old_raw.items() if k not in system_keys}
 

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -16,7 +16,6 @@ from .config import (
     discover_project_root,
     ensure_system_home,
     load_available_tags,
-    load_config,
     load_project_context,
     resolve_effective_config,
 )
@@ -382,9 +381,9 @@ def init(ctx, project_type, global_only):
 
     console.print()
     console.print("[bold]Next steps:[/bold]")
-    console.print(f"  1. Edit [cyan].klemma/config.yaml[/cyan] — set Zotero/Obsidian paths")
-    console.print(f"  2. Edit [cyan]KLEMMA.md[/cyan] — describe your project")
-    console.print(f"  3. Edit [cyan].klemma/tags.yaml[/cyan] — define your topic taxonomy")
+    console.print("  1. Edit [cyan].klemma/config.yaml[/cyan] — set Zotero/Obsidian paths")
+    console.print("  2. Edit [cyan]KLEMMA.md[/cyan] — describe your project")
+    console.print("  3. Edit [cyan].klemma/tags.yaml[/cyan] — define your topic taxonomy")
     console.print("  4. Run [bold]klemma status[/bold] to verify")
 
 
@@ -1847,7 +1846,7 @@ def migrate(ctx, dry_run):
     else:
         gitignore.write_text(f"# Klemma data\n{ignore_line}\n", encoding="utf-8")
 
-    console.print(f"\n[green]Migration complete.[/green]")
+    console.print("\n[green]Migration complete.[/green]")
     console.print(f"[dim]Project created in {project_dir}/[/dim]")
     console.print(f"[dim]System config at {system_home}/[/dim]")
 

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -1,4 +1,10 @@
-"""Configuration loader with Pydantic validation."""
+"""Configuration loader with Pydantic validation.
+
+Supports Git/NPM-style per-directory projects:
+- System config: ~/.klemma/config.yaml (AI defaults, global MCP)
+- Project config: .klemma/config.yaml (per-project settings)
+- Context: KLEMMA.md next to .klemma/ (project context for AI)
+"""
 
 import logging
 import os
@@ -13,10 +19,86 @@ logger = logging.getLogger(__name__)
 # Shipped prompts directory (relative to this file → repo root / prompts)
 _SHIPPED_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
 
+# Config keys inherited from parent project (shared resources)
+_INHERITED_KEYS = {"obsidian", "zotero", "ai", "mcp"}
 
-def get_klemma_home() -> Path:
-    """Return klemma home directory (~/.klemma/ or KLEMMA_HOME env var)."""
+
+# --- System home ---
+
+
+def get_system_home() -> Path:
+    """Return klemma system directory (~/.klemma/ or KLEMMA_HOME env var)."""
     return Path(os.environ.get("KLEMMA_HOME", "~/.klemma")).expanduser()
+
+
+# Backward-compatible alias
+get_klemma_home = get_system_home
+
+
+def ensure_system_home() -> Path:
+    """Create ~/.klemma/ with minimal config if it doesn't exist. Return path."""
+    system_home = get_system_home()
+    if not system_home.exists():
+        system_home.mkdir(parents=True, exist_ok=True)
+        config_path = system_home / "config.yaml"
+        if not config_path.exists():
+            config_path.write_text(
+                "# Klemma global config — AI defaults, shared MCP servers\n"
+                "ai:\n"
+                "  model: sonnet\n"
+                "  language: ru\n",
+                encoding="utf-8",
+            )
+        logger.info("Created system config at %s", system_home)
+    return system_home
+
+
+# --- Project discovery (Git-style) ---
+
+
+def discover_project_root(start: Optional[Path] = None) -> Optional[Path]:
+    """Find nearest directory containing .klemma/ by traversing up from start.
+
+    Returns the directory containing .klemma/, or None if not found.
+    Like `git rev-parse --show-toplevel` but for klemma projects.
+    """
+    current = (start or Path.cwd()).resolve()
+    for _ in range(20):  # safety limit
+        if (current / ".klemma").is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return None
+
+
+def discover_project_chain(start: Optional[Path] = None) -> list[Path]:
+    """Find all project roots from current to topmost ancestor.
+
+    Returns list ordered child-first: [child_root, parent_root, grandparent_root].
+    Max nesting depth: 3.
+    """
+    chain: list[Path] = []
+    project_root = discover_project_root(start)
+    if project_root is None:
+        return []
+    chain.append(project_root)
+
+    # Look for parent projects
+    search_from = project_root.parent
+    for _ in range(2):  # max 2 more levels
+        parent_project = discover_project_root(search_from)
+        if parent_project is None or parent_project == project_root:
+            break
+        chain.append(parent_project)
+        search_from = parent_project.parent
+        project_root = parent_project
+
+    return chain
+
+
+# --- Pydantic config models ---
 
 
 class ZoteroConfig(BaseModel):
@@ -35,7 +117,7 @@ class ZoteroConfig(BaseModel):
 
 
 class ObsidianConfig(BaseModel):
-    vault_path: str
+    vault_path: str = ""
     notes_folder: str = "2 - Refs"
     tags_folder: str = "3 - Tags"
     use_cli: Optional[bool] = None
@@ -77,6 +159,8 @@ class ChapterDeadline(BaseModel):
 
 
 class DissertationConfig(BaseModel):
+    """Legacy dissertation config — kept for migration from old ~/.klemma/ format."""
+
     current_chapter: int = 2
     current_section: str = "2.3.1"
     title: str = ""
@@ -89,9 +173,6 @@ class DissertationConfig(BaseModel):
     chapter_plan_pattern: str = "План_Глава{chapter}"
     writing_constraints: str = "1-1.5 ч/день, 200-300 слов/день, Pomodoro"
     chapter_draft_pattern: str = "Глава_{chapter}"
-
-
-# --- Multi-project support ---
 
 
 class ProjectConfig(BaseModel):
@@ -150,14 +231,6 @@ class ProjectConfig(BaseModel):
         )
 
 
-class WorkspaceConfig(BaseModel):
-    """Workspace configuration — maps project names to config file paths."""
-
-    active: str = "default"
-    defaults: dict[str, Any] = Field(default_factory=dict)
-    projects: dict[str, str] = Field(default_factory=dict)  # name → config path
-
-
 class PlanningConfig(BaseModel):
     dissertation_focus: str = ""
     assistant_roadmap: list[str] = Field(default_factory=list)
@@ -209,10 +282,20 @@ class MCPConfig(BaseModel):
     servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
+class SystemConfig(BaseModel):
+    """Global system configuration (~/.klemma/config.yaml).
+
+    Contains defaults that apply across all projects unless overridden.
+    """
+
+    ai: AIConfig = Field(default_factory=AIConfig)
+    mcp: MCPConfig = Field(default_factory=MCPConfig)
+
+
 class KlemmaConfig(BaseModel):
     instance: InstanceConfig = Field(default_factory=InstanceConfig)
     zotero: ZoteroConfig = Field(default_factory=ZoteroConfig)
-    obsidian: ObsidianConfig
+    obsidian: ObsidianConfig = Field(default_factory=ObsidianConfig)
     ai: AIConfig = Field(default_factory=AIConfig)
     state: StateConfig = Field(default_factory=StateConfig)
     dissertation: DissertationConfig = Field(default_factory=DissertationConfig)
@@ -222,8 +305,10 @@ class KlemmaConfig(BaseModel):
     tags: TagsConfig = Field(default_factory=TagsConfig)
     export: ExportConfig = Field(default_factory=ExportConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
-    # Multi-project: optional project config embedded in same file
     project: Optional[ProjectConfig] = None
+
+
+# --- Config loading and merging ---
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
@@ -237,21 +322,28 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+def _load_yaml(path: Path) -> dict:
+    """Load a YAML file, returning empty dict if missing or empty."""
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
 def load_config(config_path: str | Path | None = None) -> KlemmaConfig:
     """Load and validate configuration from YAML file.
 
-    If config_path is None, uses get_klemma_home() / "config.yaml".
+    If config_path is None, uses get_system_home() / "config.yaml".
     Supports both legacy single-project configs and new project-aware configs.
     """
     if config_path is None:
-        path = get_klemma_home() / "config.yaml"
+        path = get_system_home() / "config.yaml"
     else:
         path = Path(config_path)
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
 
-    with open(path, "r", encoding="utf-8") as f:
-        raw = yaml.safe_load(f) or {}
+    raw = _load_yaml(path)
 
     # Migration: Zotero fields were originally under instance:
     if "zotero" not in raw and "instance" in raw:
@@ -264,117 +356,136 @@ def load_config(config_path: str | Path | None = None) -> KlemmaConfig:
     return KlemmaConfig.model_validate(raw)
 
 
-def load_workspace(
-    workspace_path: str | Path = "workspace.yaml",
-    project_name: Optional[str] = None,
-) -> tuple[KlemmaConfig, ProjectConfig, str]:
-    """Load workspace and resolve a project config.
+def resolve_effective_config(
+    project_chain: list[Path],
+    config_override: Optional[str | Path] = None,
+) -> tuple[KlemmaConfig, ProjectConfig, Path]:
+    """Resolve effective config by merging: system → parent → child → CLI override.
 
-    Returns (config, project, project_name).
+    project_chain is child-first: [child_root, parent_root].
 
-    The workspace.yaml points to per-project config files.
-    Shared defaults from workspace are merged under each project config.
+    Selective inheritance: only shared resource keys (obsidian, zotero, ai, mcp)
+    are inherited from parent. Project structure (project, tags, state, etc.)
+    is always per-project.
+
+    Returns (merged_config, project_config, active_project_root).
     """
-    ws_path = Path(workspace_path)
-    if not ws_path.exists():
-        raise FileNotFoundError(f"Workspace file not found: {ws_path}")
+    # 1. System defaults
+    system_raw = _load_yaml(get_system_home() / "config.yaml")
 
-    with open(ws_path, "r", encoding="utf-8") as f:
-        ws_raw = yaml.safe_load(f) or {}
+    # 2. Project chain: parent first, child last (child wins)
+    #    Only inherit shared resource keys from parents
+    merged: dict[str, Any] = {}
+    for root in reversed(project_chain):  # parent first
+        project_raw = _load_yaml(root / ".klemma" / "config.yaml")
+        if root == project_chain[0]:
+            # Active (child) project: merge everything
+            merged = _deep_merge(merged, project_raw)
+        else:
+            # Parent project: only inherit shared resource keys
+            inherited = {k: v for k, v in project_raw.items() if k in _INHERITED_KEYS}
+            merged = _deep_merge(merged, inherited)
 
-    ws = WorkspaceConfig.model_validate(ws_raw)
-    name = project_name or ws.active
+    # 3. System provides defaults for unset keys
+    effective = _deep_merge(system_raw, merged)
 
-    if name not in ws.projects:
-        available = ", ".join(ws.projects.keys()) or "(none)"
-        raise ValueError(f"Project '{name}' not found in workspace. Available: {available}")
+    # 4. CLI --config override wins over everything
+    if config_override:
+        override_raw = _load_yaml(Path(config_override))
+        effective = _deep_merge(effective, override_raw)
 
-    # Resolve project config path (relative to workspace file)
-    project_config_path = ws_path.parent / ws.projects[name]
-    if not project_config_path.exists():
-        raise FileNotFoundError(
-            f"Project config not found: {project_config_path} (for project '{name}')"
-        )
+    cfg = KlemmaConfig.model_validate(effective)
+    project_root = project_chain[0]
 
-    with open(project_config_path, "r", encoding="utf-8") as f:
-        proj_raw = yaml.safe_load(f) or {}
-
-    # Merge workspace defaults under project config (project values win)
-    merged = _deep_merge(ws.defaults, proj_raw)
-
-    # Load the merged config as KlemmaConfig
-    cfg = KlemmaConfig.model_validate(merged)
-
-    # Extract ProjectConfig: prefer explicit 'project:' block, else synthesize from 'dissertation:'
-    if "project" in merged and merged["project"]:
-        project = ProjectConfig.model_validate(merged["project"])
-    else:
-        project = ProjectConfig.from_dissertation(cfg.dissertation)
-
-    return cfg, project, name
-
-
-def resolve_project(
-    config_path: str | Path | None = None,
-    workspace_path: Optional[str | Path] = None,
-    project_name: Optional[str] = None,
-) -> tuple[KlemmaConfig, ProjectConfig, str]:
-    """Unified entry point: resolve config + project from either workspace or direct config.
-
-    Priority:
-    1. If workspace_path is given and exists, use workspace mode
-    2. If workspace.yaml exists in cwd, use workspace mode
-    3. Fall back to direct config mode (legacy)
-    """
-    # Try workspace mode
-    ws_path = Path(workspace_path) if workspace_path else Path("workspace.yaml")
-    if ws_path.exists():
-        return load_workspace(ws_path, project_name=project_name)
-
-    # Direct config mode (legacy or new-style single project)
-    cfg = load_config(config_path)
-
-    # If config has explicit project: block, use it
+    # Extract ProjectConfig
     if cfg.project:
-        name = project_name or "default"
-        return cfg, cfg.project, name
+        project = cfg.project
+    elif cfg.dissertation and cfg.dissertation.title:
+        project = ProjectConfig.from_dissertation(cfg.dissertation)
+    else:
+        project = ProjectConfig()
 
-    # Legacy: synthesize ProjectConfig from DissertationConfig
-    project = ProjectConfig.from_dissertation(cfg.dissertation)
-    name = project_name or "default"
-    return cfg, project, name
+    return cfg, project, project_root
 
 
-def load_dissertation_context(klemma_home: Path, config: KlemmaConfig) -> str:
-    """Load dissertation context from context.md or build from config fields.
+# --- Context and tags ---
 
-    Looks for klemma_home/context.md first. If not found, builds a basic
-    context string from config.dissertation fields as fallback.
+
+def load_project_context(project_chain: list[Path], config: Optional[KlemmaConfig] = None) -> str:
+    """Load and aggregate KLEMMA.md files from project chain.
+
+    project_chain is child-first. Result: parent context first, then child.
+    Falls back to .klemma/context.md (legacy) and then config fields.
     """
-    context_path = klemma_home / "context.md"
-    if context_path.exists():
-        text = context_path.read_text(encoding="utf-8").strip()
-        if text:
-            return text
+    contexts: list[str] = []
 
-    # Fallback: build from config fields
-    parts = []
-    if config.dissertation.title:
-        parts.append(f"Topic: {config.dissertation.title}")
-    if config.dissertation.scientific_results:
+    for root in reversed(project_chain):  # parent first
+        # Try KLEMMA.md first
+        klemma_md = root / "KLEMMA.md"
+        if klemma_md.exists():
+            text = klemma_md.read_text(encoding="utf-8").strip()
+            if text:
+                contexts.append(text)
+                continue
+
+        # Legacy fallback: .klemma/context.md
+        context_md = root / ".klemma" / "context.md"
+        if context_md.exists():
+            text = context_md.read_text(encoding="utf-8").strip()
+            if text:
+                contexts.append(text)
+
+    if contexts:
+        return "\n\n---\n\n".join(contexts)
+
+    # Final fallback: build from config fields
+    if config:
+        return _build_context_from_config(config)
+    return ""
+
+
+def _build_context_from_config(config: KlemmaConfig) -> str:
+    """Build context string from config.dissertation or config.project fields."""
+    # Try project config first
+    if config.project and config.project.title:
+        p = config.project
+        parts = [f"Topic: {p.title}"]
+        if p.scientific_results:
+            parts.append("")
+            for key, val in p.scientific_results.items():
+                parts.append(f"{key.upper()}: {val}")
+        if p.chapters:
+            parts.append("")
+            parts.append("Chapters:")
+            for ch_num, ch_name in sorted(p.chapters.items()):
+                parts.append(f"{ch_num}. {ch_name}")
+        if p.priority_terms:
+            parts.append("")
+            parts.append(f"Key terms: {', '.join(p.priority_terms)}")
+        return "\n".join(parts)
+
+    # Legacy dissertation config fallback
+    d = config.dissertation
+    parts: list[str] = []
+    if d.title:
+        parts.append(f"Topic: {d.title}")
+    if d.scientific_results:
         parts.append("")
-        for key, val in config.dissertation.scientific_results.items():
+        for key, val in d.scientific_results.items():
             parts.append(f"{key.upper()}: {val}")
-    if config.dissertation.chapters:
+    if d.chapters:
         parts.append("")
         parts.append("Chapters:")
-        for ch_num, ch_name in sorted(config.dissertation.chapters.items()):
+        for ch_num, ch_name in sorted(d.chapters.items()):
             parts.append(f"{ch_num}. {ch_name}")
-    if config.dissertation.priority_terms:
+    if d.priority_terms:
         parts.append("")
-        parts.append(f"Key terms: {', '.join(config.dissertation.priority_terms)}")
-
+        parts.append(f"Key terms: {', '.join(d.priority_terms)}")
     return "\n".join(parts)
+
+
+# Keep old name as alias for backward compatibility
+load_dissertation_context = load_project_context
 
 
 def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
@@ -401,11 +512,32 @@ def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
 
 
 def resolve_prompt(name: str, klemma_home: Path) -> Path:
-    """Resolve prompt template path: user override first, then shipped.
+    """Resolve prompt template path with 4-level lookup.
 
-    Looks in klemma_home/prompts/ first, then the shipped prompts/ directory.
+    Priority: project → parent project → system (~/.klemma/) → shipped.
+    klemma_home is the active project's .klemma/ directory.
     """
+    # 1. Active project
     user_path = klemma_home / "prompts" / name
     if user_path.exists():
         return user_path
+
+    # 2. Parent projects (traverse up from project root)
+    project_root = klemma_home.parent
+    search_from = project_root.parent
+    for _ in range(2):
+        parent_root = discover_project_root(search_from)
+        if parent_root is None or parent_root == project_root:
+            break
+        parent_path = parent_root / ".klemma" / "prompts" / name
+        if parent_path.exists():
+            return parent_path
+        search_from = parent_root.parent
+
+    # 3. System-level override (~/.klemma/prompts/)
+    system_path = get_system_home() / "prompts" / name
+    if system_path.exists():
+        return system_path
+
+    # 4. Shipped prompts
     return _SHIPPED_PROMPTS_DIR / name

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -36,19 +36,15 @@ get_klemma_home = get_system_home
 
 
 def ensure_system_home() -> Path:
-    """Create ~/.klemma/ with minimal config if it doesn't exist. Return path."""
+    """Create ~/.klemma/ with system config if it doesn't exist. Return path.
+
+    Delegates to setup.init_system() for config creation to ensure
+    consistent content with 'klemma init --global-only'.
+    """
     system_home = get_system_home()
     if not system_home.exists():
-        system_home.mkdir(parents=True, exist_ok=True)
-        config_path = system_home / "config.yaml"
-        if not config_path.exists():
-            config_path.write_text(
-                "# Klemma global config — AI defaults, shared MCP servers\n"
-                "ai:\n"
-                "  model: sonnet\n"
-                "  language: ru\n",
-                encoding="utf-8",
-            )
+        from .setup import init_system
+        init_system(system_home)
         logger.info("Created system config at %s", system_home)
     return system_home
 
@@ -363,6 +359,7 @@ def resolve_effective_config(
     """Resolve effective config by merging: system → parent → child → CLI override.
 
     project_chain is child-first: [child_root, parent_root].
+    Can be empty if only config_override is given (fallback to override path).
 
     Selective inheritance: only shared resource keys (obsidian, zotero, ai, mcp)
     are inherited from parent. Project structure (project, tags, state, etc.)
@@ -395,7 +392,17 @@ def resolve_effective_config(
         effective = _deep_merge(effective, override_raw)
 
     cfg = KlemmaConfig.model_validate(effective)
-    project_root = project_chain[0]
+
+    # Determine project root
+    if project_chain:
+        project_root = project_chain[0]
+    elif config_override:
+        # No project discovered — derive root from config file location
+        project_root = Path(config_override).resolve().parent
+        if project_root.name == ".klemma":
+            project_root = project_root.parent
+    else:
+        project_root = Path.cwd()
 
     # Extract ProjectConfig
     if cfg.project:
@@ -488,12 +495,16 @@ def _build_context_from_config(config: KlemmaConfig) -> str:
 load_dissertation_context = load_project_context
 
 
-def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
-    """Load available tags from tags.yaml or extract from config.
+def load_available_tags(
+    klemma_home: Path,
+    config: KlemmaConfig,
+    project_chain: Optional[list[Path]] = None,
+) -> list[str]:
+    """Load available tags with fallback through project chain.
 
-    Looks for klemma_home/tags.yaml first. If not found, extracts unique
-    tag names from config.tags.auto_mapping as fallback.
+    Resolution order: project → parent projects → config.tags.auto_mapping.
     """
+    # 1. Active project
     tags_path = klemma_home / "tags.yaml"
     if tags_path.exists():
         with open(tags_path, "r", encoding="utf-8") as f:
@@ -501,7 +512,17 @@ def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
         if isinstance(data, list):
             return data
 
-    # Fallback: extract from auto_mapping
+    # 2. Parent projects in chain
+    if project_chain:
+        for root in project_chain[1:]:  # skip child (already checked above)
+            parent_tags = root / ".klemma" / "tags.yaml"
+            if parent_tags.exists():
+                with open(parent_tags, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+                if isinstance(data, list):
+                    return data
+
+    # 3. Fallback: extract from auto_mapping
     seen: set[str] = set()
     tags: list[str] = []
     for mapping in config.tags.auto_mapping:
@@ -511,28 +532,41 @@ def load_available_tags(klemma_home: Path, config: KlemmaConfig) -> list[str]:
     return tags
 
 
-def resolve_prompt(name: str, klemma_home: Path) -> Path:
+def resolve_prompt(
+    name: str,
+    klemma_home: Path,
+    project_chain: Optional[list[Path]] = None,
+) -> Path:
     """Resolve prompt template path with 4-level lookup.
 
     Priority: project → parent project → system (~/.klemma/) → shipped.
     klemma_home is the active project's .klemma/ directory.
+    If project_chain is given, uses it directly instead of re-discovering.
     """
     # 1. Active project
     user_path = klemma_home / "prompts" / name
     if user_path.exists():
         return user_path
 
-    # 2. Parent projects (traverse up from project root)
-    project_root = klemma_home.parent
-    search_from = project_root.parent
-    for _ in range(2):
-        parent_root = discover_project_root(search_from)
-        if parent_root is None or parent_root == project_root:
-            break
-        parent_path = parent_root / ".klemma" / "prompts" / name
-        if parent_path.exists():
-            return parent_path
-        search_from = parent_root.parent
+    # 2. Parent projects
+    if project_chain is not None:
+        # Use known chain (skip child at index 0 — already checked above)
+        for root in project_chain[1:]:
+            parent_path = root / ".klemma" / "prompts" / name
+            if parent_path.exists():
+                return parent_path
+    else:
+        # Fallback: traverse up from project root
+        project_root = klemma_home.parent
+        search_from = project_root.parent
+        for _ in range(2):
+            parent_root = discover_project_root(search_from)
+            if parent_root is None or parent_root == project_root:
+                break
+            parent_path = parent_root / ".klemma" / "prompts" / name
+            if parent_path.exists():
+                return parent_path
+            search_from = parent_root.parent
 
     # 3. System-level override (~/.klemma/prompts/)
     system_path = get_system_home() / "prompts" / name

--- a/src/klemma/context.py
+++ b/src/klemma/context.py
@@ -31,6 +31,11 @@ class KlemmaContext:
     tools: Optional[ToolRegistry] = None
     project: Optional[ProjectConfig] = None
     project_name: str = "default"
+    # Points to active project's .klemma/ dir (backward-compat with skills)
     klemma_home: Path = field(default_factory=lambda: Path.home() / ".klemma")
     dissertation_context: str = ""
     available_tags: list[str] = field(default_factory=list)
+    # New: per-directory project support
+    project_root: Optional[Path] = None  # directory containing .klemma/
+    project_chain: list[Path] = field(default_factory=list)  # child-first chain
+    system_home: Path = field(default_factory=lambda: Path.home() / ".klemma")

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -1,4 +1,9 @@
-"""Setup logic for `klemma init` — creates ~/.klemma/ with template files."""
+"""Setup logic for `klemma init` — creates .klemma/ project in current directory.
+
+Two modes:
+- init_project(): creates .klemma/ + KLEMMA.md in a project directory
+- init_system(): creates ~/.klemma/ with minimal global config
+"""
 
 import shutil
 from pathlib import Path
@@ -7,34 +12,122 @@ from pathlib import Path
 _EXAMPLES_DIR = Path(__file__).parent.parent.parent
 
 
-def init_klemma_home(klemma_home: Path) -> dict:
-    """Create klemma_home directory with template files.
+def init_project(project_dir: Path, project_type: str = "dissertation") -> dict:
+    """Create .klemma/ project in project_dir + KLEMMA.md.
 
-    Returns dict with keys: created (list of file names), skipped (list of file names).
+    Returns dict with keys: created (list of file names), skipped (list).
     """
     created: list[str] = []
     skipped: list[str] = []
 
-    klemma_home.mkdir(parents=True, exist_ok=True)
-    (klemma_home / "data").mkdir(exist_ok=True)
+    klemma_dir = project_dir / ".klemma"
+    klemma_dir.mkdir(parents=True, exist_ok=True)
+    (klemma_dir / "data").mkdir(exist_ok=True)
 
-    templates = {
-        "config.yaml": _EXAMPLES_DIR / "config.example.yaml",
-        "context.md": _EXAMPLES_DIR / "context.example.md",
-        "tags.yaml": _EXAMPLES_DIR / "tags.example.yaml",
-    }
-
-    for target_name, source_path in templates.items():
-        target = klemma_home / target_name
-        if target.exists():
-            skipped.append(target_name)
-            continue
-
-        if source_path.exists():
-            shutil.copy2(source_path, target)
+    # Project config
+    config_target = klemma_dir / "config.yaml"
+    if config_target.exists():
+        skipped.append(".klemma/config.yaml")
+    else:
+        source = _EXAMPLES_DIR / "config.project.example.yaml"
+        if source.exists():
+            text = source.read_text(encoding="utf-8")
+            text = text.replace("type: dissertation", f"type: {project_type}")
+            config_target.write_text(text, encoding="utf-8")
         else:
-            # Create minimal placeholder if example file not found
-            target.write_text(f"# {target_name} — edit this file\n", encoding="utf-8")
-        created.append(target_name)
+            config_target.write_text(
+                f"# Klemma project config\n"
+                f"project:\n"
+                f"  type: {project_type}\n"
+                f"  title: \"\"\n",
+                encoding="utf-8",
+            )
+        created.append(".klemma/config.yaml")
+
+    # Tags
+    tags_target = klemma_dir / "tags.yaml"
+    if tags_target.exists():
+        skipped.append(".klemma/tags.yaml")
+    else:
+        source = _EXAMPLES_DIR / "tags.example.yaml"
+        if source.exists():
+            shutil.copy2(source, tags_target)
+        else:
+            tags_target.write_text("# Project tags\n- Review\n- Methodology\n", encoding="utf-8")
+        created.append(".klemma/tags.yaml")
+
+    # KLEMMA.md context file (in project root, visible to user)
+    klemma_md = project_dir / "KLEMMA.md"
+    if klemma_md.exists():
+        skipped.append("KLEMMA.md")
+    else:
+        source = _EXAMPLES_DIR / "klemma.example.md"
+        if source.exists():
+            shutil.copy2(source, klemma_md)
+        else:
+            klemma_md.write_text(
+                f"# Project Context\n\n"
+                f"Type: {project_type}\n"
+                f"Title: \"\"\n\n"
+                f"<!-- Describe your project here. This context is passed to AI. -->\n",
+                encoding="utf-8",
+            )
+        created.append("KLEMMA.md")
+
+    # .gitignore: exclude DB but keep config in VCS
+    gitignore = project_dir / ".gitignore"
+    ignore_line = ".klemma/data/"
+    if gitignore.exists():
+        content = gitignore.read_text(encoding="utf-8")
+        if ignore_line not in content:
+            with open(gitignore, "a", encoding="utf-8") as f:
+                if not content.endswith("\n"):
+                    f.write("\n")
+                f.write(f"{ignore_line}\n")
+            created.append(".gitignore (updated)")
+    else:
+        gitignore.write_text(f"# Klemma data (SQLite DB)\n{ignore_line}\n", encoding="utf-8")
+        created.append(".gitignore")
 
     return {"created": created, "skipped": skipped}
+
+
+def init_system(system_home: Path) -> dict:
+    """Create ~/.klemma/ system directory with global config.
+
+    Returns dict with keys: created, skipped.
+    """
+    created: list[str] = []
+    skipped: list[str] = []
+
+    system_home.mkdir(parents=True, exist_ok=True)
+
+    config_target = system_home / "config.yaml"
+    if config_target.exists():
+        skipped.append("config.yaml")
+    else:
+        source = _EXAMPLES_DIR / "config.system.example.yaml"
+        if source.exists():
+            shutil.copy2(source, config_target)
+        else:
+            config_target.write_text(
+                "# Klemma global config — AI defaults, shared MCP servers\n"
+                "ai:\n"
+                "  model: sonnet\n"
+                "  language: ru\n"
+                "\n"
+                "mcp:\n"
+                "  servers: {}\n",
+                encoding="utf-8",
+            )
+        created.append("config.yaml")
+
+    (system_home / "prompts").mkdir(exist_ok=True)
+
+    return {"created": created, "skipped": skipped}
+
+
+# Legacy alias (kept for migration)
+def init_klemma_home(klemma_home: Path) -> dict:
+    """Legacy: create klemma_home with template files. Use init_project() instead."""
+    return init_system(klemma_home)

--- a/src/klemma/tools/CLAUDE.md
+++ b/src/klemma/tools/CLAUDE.md
@@ -28,7 +28,8 @@ Hybrid discovery pipeline for finding new literature:
 ## Data flows
 
 ### MCP tool integration
-`klemma tools add <name> --command <cmd> --args <args>` → `registry.add_server()` writes to `config.yaml`.
+`klemma tools add <name> --command <cmd> --args <args>` → writes to project `.klemma/config.yaml` (or `~/.klemma/config.yaml` with `--global` flag).
+`klemma tools remove <name>` → removes from project config (or global with `--global`).
 `klemma tools call <server> <tool> <args>` → `registry.call()` → `client.call_tool()` → MCP stdio.
 
 ### Paper search

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Current test suite
 - `test_ai.py` (112 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (118 lines) — `OpenAIClient` with mocked openai SDK
-- `test_project_discovery.py` (~500 lines) — 35 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, setup, and deep merge
+- `test_project_discovery.py` (~590 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
 
 ## Patterns
 - pytest + `unittest.mock` (`patch`, `MagicMock`)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Current test suite
 - `test_ai.py` (112 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (118 lines) — `OpenAIClient` with mocked openai SDK
+- `test_project_discovery.py` (~500 lines) — 35 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, setup, and deep merge
 
 ## Patterns
 - pytest + `unittest.mock` (`patch`, `MagicMock`)

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -1,12 +1,8 @@
 """Tests for Git-style project discovery, config merging, and context aggregation."""
 
-import os
-import textwrap
 from pathlib import Path
 
-import pytest
 import yaml
-
 
 # --- Discovery tests ---
 

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -1,0 +1,480 @@
+"""Tests for Git-style project discovery, config merging, and context aggregation."""
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# --- Discovery tests ---
+
+
+class TestDiscoverProjectRoot:
+    def test_finds_klemma_dir(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        from klemma.config import discover_project_root
+
+        result = discover_project_root(tmp_path)
+        assert result == tmp_path
+
+    def test_finds_klemma_dir_from_subdirectory(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        subdir = tmp_path / "src" / "analysis"
+        subdir.mkdir(parents=True)
+        from klemma.config import discover_project_root
+
+        result = discover_project_root(subdir)
+        assert result == tmp_path
+
+    def test_returns_none_when_no_project(self, tmp_path):
+        subdir = tmp_path / "empty" / "dir"
+        subdir.mkdir(parents=True)
+        from klemma.config import discover_project_root
+
+        result = discover_project_root(subdir)
+        assert result is None
+
+    def test_finds_nearest_klemma_dir(self, tmp_path):
+        """When nested, finds the nearest (child) .klemma/ first."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+
+        from klemma.config import discover_project_root
+
+        result = discover_project_root(child)
+        assert result == child
+
+    def test_uses_cwd_when_no_start(self, tmp_path, monkeypatch):
+        (tmp_path / ".klemma").mkdir()
+        monkeypatch.chdir(tmp_path)
+        from klemma.config import discover_project_root
+
+        result = discover_project_root()
+        assert result == tmp_path
+
+
+class TestDiscoverProjectChain:
+    def test_single_project(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        from klemma.config import discover_project_chain
+
+        chain = discover_project_chain(tmp_path)
+        assert chain == [tmp_path]
+
+    def test_nested_projects(self, tmp_path):
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+
+        from klemma.config import discover_project_chain
+
+        chain = discover_project_chain(child)
+        assert chain == [child, parent]
+
+    def test_deeply_nested_max_depth(self, tmp_path):
+        """Max 3 levels of nesting."""
+        l1 = tmp_path / "l1"
+        l2 = l1 / "l2"
+        l3 = l2 / "l3"
+        l4 = l3 / "l4"
+        for d in [l1, l2, l3, l4]:
+            (d / ".klemma").mkdir(parents=True)
+
+        from klemma.config import discover_project_chain
+
+        chain = discover_project_chain(l4)
+        assert len(chain) == 3  # max depth
+        assert chain[0] == l4  # child first
+
+    def test_no_project_returns_empty(self, tmp_path):
+        subdir = tmp_path / "no_project"
+        subdir.mkdir()
+        from klemma.config import discover_project_chain
+
+        chain = discover_project_chain(subdir)
+        assert chain == []
+
+
+# --- Config merging tests ---
+
+
+def _write_config(path: Path, data: dict):
+    """Helper: write YAML config."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f)
+
+
+class TestResolveEffectiveConfig:
+    def test_single_project(self, tmp_path):
+        _write_config(tmp_path / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "project": {"type": "dissertation", "title": "Test"},
+        })
+        from klemma.config import resolve_effective_config
+
+        cfg, project, root = resolve_effective_config([tmp_path])
+        assert project.title == "Test"
+        assert cfg.obsidian.vault_path == "/vault"
+        assert root == tmp_path
+
+    def test_child_inherits_shared_from_parent(self, tmp_path):
+        """Child inherits vault, zotero, ai, mcp from parent."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+
+        _write_config(parent / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/shared_vault", "notes_folder": "Refs"},
+            "zotero": {"library_json": "/shared_bbt.json"},
+            "ai": {"model": "opus"},
+        })
+        _write_config(child / ".klemma" / "config.yaml", {
+            "project": {"type": "paper", "title": "Paper 1"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, project, root = resolve_effective_config([child, parent])
+        assert project.title == "Paper 1"
+        assert cfg.obsidian.vault_path == "/shared_vault"
+        assert cfg.zotero.library_json == "/shared_bbt.json"
+        assert cfg.ai.model == "opus"
+        assert root == child
+
+    def test_child_overrides_shared(self, tmp_path):
+        """Child can override inherited values."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+
+        _write_config(parent / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/parent_vault"},
+            "ai": {"model": "opus"},
+        })
+        _write_config(child / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/child_vault"},
+            "project": {"type": "paper", "title": "Paper 1"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, _, _ = resolve_effective_config([child, parent])
+        assert cfg.obsidian.vault_path == "/child_vault"
+        assert cfg.ai.model == "opus"  # inherited
+
+    def test_project_not_inherited(self, tmp_path):
+        """project:, tags:, state: are NOT inherited from parent."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+
+        _write_config(parent / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "project": {"type": "dissertation", "title": "Thesis", "chapters": {1: "Ch1", 2: "Ch2"}},
+            "state": {"db_path": "./data/thesis.db"},
+        })
+        _write_config(child / ".klemma" / "config.yaml", {
+            "project": {"type": "paper", "title": "Paper"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, project, _ = resolve_effective_config([child, parent])
+        # Project should be from child, not parent
+        assert project.title == "Paper"
+        assert project.type == "paper"
+        assert len(project.chapters) == 0  # not inherited
+        # state is also not inherited (uses default)
+        assert cfg.state.db_path == "./data/klemma.db"
+
+    def test_system_provides_defaults(self, tmp_path, monkeypatch):
+        """System config provides defaults for unset keys."""
+        system_home = tmp_path / "system"
+        system_home.mkdir()
+        _write_config(system_home / "config.yaml", {
+            "ai": {"model": "haiku", "language": "en"},
+        })
+        monkeypatch.setenv("KLEMMA_HOME", str(system_home))
+
+        project = tmp_path / "project"
+        _write_config(project / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "project": {"type": "paper", "title": "Test"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, _, _ = resolve_effective_config([project])
+        # AI from system defaults, overridden by project
+        assert cfg.ai.model == "haiku"  # from system (project didn't set ai)
+
+    def test_cli_override_wins(self, tmp_path):
+        """CLI --config override wins over everything."""
+        _write_config(tmp_path / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "ai": {"model": "sonnet"},
+        })
+        override = tmp_path / "override.yaml"
+        _write_config(override, {
+            "ai": {"model": "opus"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, _, _ = resolve_effective_config([tmp_path], config_override=override)
+        assert cfg.ai.model == "opus"
+
+    def test_db_path_stays_per_project(self, tmp_path):
+        """Each project's db_path is resolved relative to its own .klemma/."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+
+        _write_config(parent / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "state": {"db_path": "./data/thesis.db"},
+        })
+        _write_config(child / ".klemma" / "config.yaml", {
+            "state": {"db_path": "./data/paper.db"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, _, root = resolve_effective_config([child, parent])
+        # state is NOT inherited, so child's db_path is used
+        assert cfg.state.db_path == "./data/paper.db"
+        assert root == child
+
+
+# --- Context aggregation tests ---
+
+
+class TestLoadProjectContext:
+    def test_single_klemma_md(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        (tmp_path / "KLEMMA.md").write_text("# My Dissertation\nTopic: ice forecasting")
+
+        from klemma.config import load_project_context
+
+        result = load_project_context([tmp_path])
+        assert "My Dissertation" in result
+        assert "ice forecasting" in result
+
+    def test_nested_parent_first(self, tmp_path):
+        """Parent context appears first, child second."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+        (parent / "KLEMMA.md").write_text("# Dissertation\nBig picture")
+        (child / "KLEMMA.md").write_text("# Paper 1\nSpecific topic")
+
+        from klemma.config import load_project_context
+
+        result = load_project_context([child, parent])
+        # Parent should come first
+        assert result.index("Dissertation") < result.index("Paper 1")
+        assert "---" in result  # separator
+
+    def test_missing_klemma_md_skipped(self, tmp_path):
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+        # Only parent has KLEMMA.md
+        (parent / "KLEMMA.md").write_text("# Dissertation")
+
+        from klemma.config import load_project_context
+
+        result = load_project_context([child, parent])
+        assert "Dissertation" in result
+
+    def test_legacy_context_md_fallback(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        (tmp_path / ".klemma" / "context.md").write_text("Legacy context")
+
+        from klemma.config import load_project_context
+
+        result = load_project_context([tmp_path])
+        assert "Legacy context" in result
+
+    def test_fallback_to_config_fields(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        # No KLEMMA.md, no context.md — build from config
+
+        from klemma.config import KlemmaConfig, load_project_context
+
+        cfg = KlemmaConfig.model_validate({
+            "obsidian": {"vault_path": "/v"},
+            "project": {"type": "dissertation", "title": "My Topic", "chapters": {1: "Intro"}},
+        })
+
+        result = load_project_context([tmp_path], config=cfg)
+        assert "My Topic" in result
+
+
+# --- Prompt resolution tests ---
+
+
+class TestResolvePrompt:
+    def test_shipped_prompt_used_when_no_overrides(self, tmp_path):
+        klemma_home = tmp_path / ".klemma"
+        klemma_home.mkdir()
+        from klemma.config import resolve_prompt
+
+        result = resolve_prompt("extract.md", klemma_home)
+        # Should fall back to shipped prompts
+        assert "prompts" in str(result)
+
+    def test_project_prompt_overrides_shipped(self, tmp_path):
+        klemma_home = tmp_path / ".klemma"
+        (klemma_home / "prompts").mkdir(parents=True)
+        (klemma_home / "prompts" / "extract.md").write_text("custom")
+
+        from klemma.config import resolve_prompt
+
+        result = resolve_prompt("extract.md", klemma_home)
+        assert result == klemma_home / "prompts" / "extract.md"
+
+    def test_system_prompt_overrides_shipped(self, tmp_path, monkeypatch):
+        system_home = tmp_path / "system_home"
+        (system_home / "prompts").mkdir(parents=True)
+        (system_home / "prompts" / "extract.md").write_text("global override")
+        monkeypatch.setenv("KLEMMA_HOME", str(system_home))
+
+        # Project .klemma/ without prompt override
+        project = tmp_path / "project"
+        klemma_home = project / ".klemma"
+        klemma_home.mkdir(parents=True)
+
+        from klemma.config import resolve_prompt
+
+        result = resolve_prompt("extract.md", klemma_home)
+        assert result == system_home / "prompts" / "extract.md"
+
+
+# --- Tags tests ---
+
+
+class TestLoadAvailableTags:
+    def test_loads_from_yaml(self, tmp_path):
+        klemma_home = tmp_path / ".klemma"
+        klemma_home.mkdir()
+        (klemma_home / "tags.yaml").write_text("- Review\n- Methodology\n- Dataset")
+
+        from klemma.config import KlemmaConfig, load_available_tags
+
+        cfg = KlemmaConfig.model_validate({"obsidian": {"vault_path": "/v"}})
+        tags = load_available_tags(klemma_home, cfg)
+        assert tags == ["Review", "Methodology", "Dataset"]
+
+    def test_fallback_to_auto_mapping(self, tmp_path):
+        klemma_home = tmp_path / ".klemma"
+        klemma_home.mkdir()
+
+        from klemma.config import KlemmaConfig, load_available_tags
+
+        cfg = KlemmaConfig.model_validate({
+            "obsidian": {"vault_path": "/v"},
+            "tags": {"auto_mapping": [
+                {"pattern": "review", "tag": "Review"},
+                {"pattern": "method", "tag": "Method"},
+            ]},
+        })
+        tags = load_available_tags(klemma_home, cfg)
+        assert tags == ["Review", "Method"]
+
+
+# --- Init tests ---
+
+
+class TestInitProject:
+    def test_creates_klemma_dir(self, tmp_path):
+        from klemma.setup import init_project
+
+        result = init_project(tmp_path)
+        assert (tmp_path / ".klemma").is_dir()
+        assert (tmp_path / ".klemma" / "config.yaml").exists()
+        assert (tmp_path / ".klemma" / "tags.yaml").exists()
+        assert (tmp_path / ".klemma" / "data").is_dir()
+        assert (tmp_path / "KLEMMA.md").exists()
+        assert (tmp_path / ".gitignore").exists()
+        assert ".klemma/config.yaml" in result["created"]
+        assert "KLEMMA.md" in result["created"]
+
+    def test_does_not_overwrite_existing(self, tmp_path):
+        (tmp_path / ".klemma").mkdir()
+        (tmp_path / ".klemma" / "data").mkdir()
+        (tmp_path / ".klemma" / "config.yaml").write_text("existing")
+        (tmp_path / "KLEMMA.md").write_text("existing context")
+
+        from klemma.setup import init_project
+
+        result = init_project(tmp_path)
+        assert ".klemma/config.yaml" in result["skipped"]
+        assert "KLEMMA.md" in result["skipped"]
+        assert (tmp_path / ".klemma" / "config.yaml").read_text() == "existing"
+
+    def test_project_type_in_config(self, tmp_path):
+        from klemma.setup import init_project
+
+        init_project(tmp_path, project_type="paper")
+        config_text = (tmp_path / ".klemma" / "config.yaml").read_text()
+        assert "paper" in config_text
+
+    def test_gitignore_updated(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("*.pyc\n")
+        from klemma.setup import init_project
+
+        init_project(tmp_path)
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".klemma/data/" in content
+        assert "*.pyc" in content
+
+
+class TestInitSystem:
+    def test_creates_system_dir(self, tmp_path):
+        system_home = tmp_path / ".klemma"
+        from klemma.setup import init_system
+
+        result = init_system(system_home)
+        assert system_home.is_dir()
+        assert (system_home / "config.yaml").exists()
+        assert "config.yaml" in result["created"]
+
+    def test_does_not_overwrite(self, tmp_path):
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        (system_home / "config.yaml").write_text("existing")
+
+        from klemma.setup import init_system
+
+        result = init_system(system_home)
+        assert "config.yaml" in result["skipped"]
+
+
+# --- Deep merge tests ---
+
+
+class TestDeepMerge:
+    def test_basic_merge(self):
+        from klemma.config import _deep_merge
+
+        result = _deep_merge({"a": 1, "b": 2}, {"b": 3, "c": 4})
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge(self):
+        from klemma.config import _deep_merge
+
+        base = {"ai": {"model": "sonnet", "timeout": 300}}
+        override = {"ai": {"model": "opus"}}
+        result = _deep_merge(base, override)
+        assert result == {"ai": {"model": "opus", "timeout": 300}}
+
+    def test_override_wins(self):
+        from klemma.config import _deep_merge
+
+        result = _deep_merge({"x": {"a": 1}}, {"x": "replaced"})
+        assert result == {"x": "replaced"}

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -478,3 +478,140 @@ class TestDeepMerge:
 
         result = _deep_merge({"x": {"a": 1}}, {"x": "replaced"})
         assert result == {"x": "replaced"}
+
+
+# --- Config override with empty chain tests ---
+
+
+class TestResolveEffectiveConfigOverride:
+    def test_config_override_with_empty_chain(self, tmp_path, monkeypatch):
+        """When no project found but --config given, still merges system defaults."""
+        system_home = tmp_path / "system"
+        system_home.mkdir()
+        _write_config(system_home / "config.yaml", {
+            "ai": {"model": "haiku", "language": "en"},
+        })
+        monkeypatch.setenv("KLEMMA_HOME", str(system_home))
+
+        override = tmp_path / "custom" / ".klemma" / "config.yaml"
+        _write_config(override, {
+            "obsidian": {"vault_path": "/vault"},
+            "project": {"type": "paper", "title": "Standalone"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, project, root = resolve_effective_config([], config_override=override)
+        assert project.title == "Standalone"
+        assert cfg.ai.model == "haiku"  # from system defaults
+        assert cfg.ai.language == "en"
+        assert root == tmp_path / "custom"
+
+    def test_config_override_with_chain_merges_all(self, tmp_path, monkeypatch):
+        """--config override works together with project chain and system defaults."""
+        system_home = tmp_path / "system"
+        system_home.mkdir()
+        _write_config(system_home / "config.yaml", {
+            "ai": {"model": "haiku", "timeout": 300},
+        })
+        monkeypatch.setenv("KLEMMA_HOME", str(system_home))
+
+        project = tmp_path / "project"
+        _write_config(project / ".klemma" / "config.yaml", {
+            "obsidian": {"vault_path": "/vault"},
+            "ai": {"model": "sonnet"},
+        })
+
+        override = tmp_path / "override.yaml"
+        _write_config(override, {
+            "ai": {"model": "opus"},
+        })
+
+        from klemma.config import resolve_effective_config
+
+        cfg, _, _ = resolve_effective_config([project], config_override=override)
+        assert cfg.ai.model == "opus"  # override wins
+        assert cfg.ai.timeout == 300  # system default preserved
+        assert cfg.obsidian.vault_path == "/vault"  # project preserved
+
+
+# --- Tags inheritance tests ---
+
+
+class TestTagsInheritance:
+    def test_tags_from_parent_when_child_has_none(self, tmp_path):
+        """Child without tags.yaml falls back to parent's tags."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+        (parent / ".klemma" / "tags.yaml").write_text("- Review\n- Theory\n- Method")
+
+        from klemma.config import KlemmaConfig, load_available_tags
+
+        cfg = KlemmaConfig.model_validate({"obsidian": {"vault_path": "/v"}})
+        tags = load_available_tags(child / ".klemma", cfg, project_chain=[child, parent])
+        assert tags == ["Review", "Theory", "Method"]
+
+    def test_child_tags_override_parent(self, tmp_path):
+        """Child with own tags.yaml does not inherit from parent."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma").mkdir(parents=True)
+        (child / ".klemma").mkdir(parents=True)
+        (parent / ".klemma" / "tags.yaml").write_text("- Review\n- Theory")
+        (child / ".klemma" / "tags.yaml").write_text("- Dataset\n- Algorithm")
+
+        from klemma.config import KlemmaConfig, load_available_tags
+
+        cfg = KlemmaConfig.model_validate({"obsidian": {"vault_path": "/v"}})
+        tags = load_available_tags(child / ".klemma", cfg, project_chain=[child, parent])
+        assert tags == ["Dataset", "Algorithm"]
+
+    def test_no_chain_falls_back_to_auto_mapping(self, tmp_path):
+        """Without project_chain, falls back to auto_mapping as before."""
+        klemma_home = tmp_path / ".klemma"
+        klemma_home.mkdir()
+
+        from klemma.config import KlemmaConfig, load_available_tags
+
+        cfg = KlemmaConfig.model_validate({
+            "obsidian": {"vault_path": "/v"},
+            "tags": {"auto_mapping": [
+                {"pattern": "review", "tag": "Review"},
+            ]},
+        })
+        tags = load_available_tags(klemma_home, cfg)
+        assert tags == ["Review"]
+
+
+# --- Prompt resolution with project_chain tests ---
+
+
+class TestResolvePromptWithChain:
+    def test_parent_prompt_override(self, tmp_path):
+        """When child has no prompt but parent does, parent wins over system."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma" / "prompts").mkdir(parents=True)
+        (child / ".klemma" / "prompts").mkdir(parents=True)
+        (parent / ".klemma" / "prompts" / "extract.md").write_text("parent prompt")
+
+        from klemma.config import resolve_prompt
+
+        result = resolve_prompt("extract.md", child / ".klemma", project_chain=[child, parent])
+        assert result == parent / ".klemma" / "prompts" / "extract.md"
+
+    def test_child_prompt_wins_over_parent(self, tmp_path):
+        """Child prompt overrides parent prompt."""
+        parent = tmp_path / "thesis"
+        child = parent / "paper1"
+        (parent / ".klemma" / "prompts").mkdir(parents=True)
+        (child / ".klemma" / "prompts").mkdir(parents=True)
+        (parent / ".klemma" / "prompts" / "extract.md").write_text("parent")
+        (child / ".klemma" / "prompts" / "extract.md").write_text("child")
+
+        from klemma.config import resolve_prompt
+
+        result = resolve_prompt("extract.md", child / ".klemma", project_chain=[child, parent])
+        assert result == child / ".klemma" / "prompts" / "extract.md"


### PR DESCRIPTION
## Summary

- Replaces centralized `~/.klemma/` workspace with Git-style per-directory `.klemma/` projects
- `klemma init` creates project in current directory; `~/.klemma/` becomes system-only (AI defaults, global MCP)
- Nested projects inherit shared resources (vault, zotero, ai, mcp) from parent; project-specific keys stay per-project
- New commands: `klemma info`, `klemma tree`, `klemma migrate`; removed: `projects {list,switch,info}`, `--project/-p`, `--workspace/-w`
- Context (`KLEMMA.md`) aggregated from project chain (parent first, child last)
- Prompt and tags resolution: project → parent → system → shipped/auto_mapping

### Review fixes (second commit)
- Cache `KlemmaContext` in `ctx.obj` — eliminates double initialization on every command
- Unify `--config` path through `resolve_effective_config` — was bypassing system defaults
- Migration now splits both `ai` and `mcp` to system config
- `ensure_system_home()` delegates to `init_system()` for consistent config
- Tags inherit through project chain (like prompts)
- Fix file handle leak in `discover --background`

## Test plan
- [x] All 60 tests pass (`pytest tests/`)
- [ ] `klemma init` in clean directory → verify system + project config created
- [ ] `klemma status` in existing project → verify single init (no double load)
- [ ] `klemma migrate --dry-run` → verify mcp goes to system config
- [ ] `klemma --config path/config.yaml status` → verify inheritance works
- [ ] Nested project: child inherits vault/zotero/tags from parent


🤖 Generated with [Claude Code](https://claude.com/claude-code)