### PR TITLE
fix: discover_project_root skips ~/.klemma/ system home

### DIFF
--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -57,10 +57,15 @@ def discover_project_root(start: Optional[Path] = None) -> Optional[Path]:
 
     Returns the directory containing .klemma/, or None if not found.
     Like `git rev-parse --show-toplevel` but for klemma projects.
+
+    Skips the system home directory (~/.klemma/) — that's the global config,
+    not a project.
     """
     current = (start or Path.cwd()).resolve()
+    system_home = get_system_home().resolve()
     for _ in range(20):  # safety limit
-        if (current / ".klemma").is_dir():
+        klemma_dir = current / ".klemma"
+        if klemma_dir.is_dir() and klemma_dir.resolve() != system_home:
             return current
         parent = current.parent
         if parent == current:

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -53,6 +53,38 @@ class TestDiscoverProjectRoot:
         assert result == tmp_path
 
 
+    def test_skips_system_home_directory(self, tmp_path, monkeypatch):
+        """discover_project_root must not treat ~/.klemma/ (system home) as a project."""
+        # Simulate: tmp_path acts as $HOME, has .klemma/ (system dir)
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        # Start search from a subdirectory under tmp_path (no project .klemma/)
+        subdir = tmp_path / "projects" / "myproject"
+        subdir.mkdir(parents=True)
+
+        from klemma.config import discover_project_root
+
+        monkeypatch.setattr("klemma.config.get_system_home", lambda: system_home)
+
+        result = discover_project_root(subdir)
+        assert result is None  # should NOT find tmp_path as a project
+
+    def test_finds_project_even_when_system_home_exists(self, tmp_path, monkeypatch):
+        """A real project .klemma/ should still be found even with system home present."""
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        # Create a real project below
+        project = tmp_path / "projects" / "diss"
+        (project / ".klemma").mkdir(parents=True)
+
+        from klemma.config import discover_project_root
+
+        monkeypatch.setattr("klemma.config.get_system_home", lambda: system_home)
+
+        result = discover_project_root(project)
+        assert result == project
+
+
 class TestDiscoverProjectChain:
     def test_single_project(self, tmp_path):
         (tmp_path / ".klemma").mkdir()


### PR DESCRIPTION
## Summary
- `discover_project_root()` was treating `~/.klemma/` (system config dir) as a project, blocking `klemma migrate` from any directory under `~/`
- Fix: compare each found `.klemma/` against `get_system_home()` and skip the match
- Added 2 tests for the new behavior (62 total pass)

## Test plan
- [x] `pytest tests/` — 62 pass
- [x] `klemma migrate --dry-run` from non-project dir no longer reports false positive
- [x] Real migration tested: `~/research/dissertation/` successfully created

🤖 Generated with [Claude Code](https://claude.com/claude-code)