### PR TITLE
Interactive init wizard + paper project bootstrapping

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -143,15 +143,20 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
         })
 
     # 2. Discover new Zotero entries not in DB + detect renames
+    # Papers: explicit-only model — skip auto-registration from BBT JSON or vault
+    project = ctx.project
+    auto_register = not project or project.type != "paper"
+
+    # Load existing DB source IDs (needed for paper filtering + new entry detection)
+    with state._conn() as conn:
+        cur = conn.execute("SELECT id FROM sources")
+        existing = {row["id"] for row in cur.fetchall()}
+
     new_entries = []
     renames = []
     if ctx.library:
         entry_lookup = ctx.library.entries
         vault_citekeys = {vd["citekey"] for vd in vault_data}
-
-        with state._conn() as conn:
-            cur = conn.execute("SELECT id FROM sources")
-            existing = {row["id"] for row in cur.fetchall()}
 
         # Rename detection via immutable Zotero itemKey
         db_zotero_keys = state.get_zotero_key_map()  # {itemKey: old_citekey}
@@ -166,7 +171,7 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
                     existing.add(citekey)
                     renames.append((old_ck, citekey))
                     continue
-            if citekey not in vault_citekeys:
+            if auto_register and citekey not in vault_citekeys:
                 classification = auto_classify(entry, cfg)
                 new_entries.append((citekey, classification))
 
@@ -211,6 +216,10 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
             state.populate_zotero_keys(backfill)
 
     # 3. Sync to DB
+    # Papers: only sync vault notes for sources already registered in DB
+    if not auto_register:
+        vault_data = [vd for vd in vault_data if vd["citekey"] in existing]
+
     result = state.sync_source_sections(vault_data, new_entries)
 
     if not quiet:
@@ -337,17 +346,23 @@ def main(ctx, config):
               type=click.Choice(["dissertation", "paper", "thesis"]),
               help="Project type")
 @click.option("--global-only", is_flag=True, help="Only create/update ~/.klemma/ system config")
+@click.option("--no-input", is_flag=True, help="Skip interactive prompts, use defaults")
+@click.option("--force", is_flag=True, help="Re-run wizard even if project exists (prefills from current config)")
 @click.pass_context
-def init(ctx, project_type, global_only):
+def init(ctx, project_type, global_only, no_input, force):
     """Initialize a new klemma project in current directory.
 
     Creates .klemma/ and KLEMMA.md in the current directory.
     Also ensures ~/.klemma/ system config exists.
 
+    Runs an interactive setup wizard by default. Use --no-input to skip prompts.
+
     \b
     Examples:
-      klemma init                    # dissertation project
+      klemma init                    # interactive setup
       klemma init --type paper       # paper project
+      klemma init --no-input         # skip prompts, use defaults
+      klemma init --force            # re-run wizard, prefill from existing config
       klemma init --global-only      # only create system config
     """
     from .setup import init_project, init_system
@@ -367,24 +382,252 @@ def init(ctx, project_type, global_only):
     # Ensure system config exists
     init_system(system_home)
 
-    # Create project in current directory
     project_dir = Path.cwd()
-    result = init_project(project_dir, project_type=project_type)
+    config_path = project_dir / ".klemma" / "config.yaml"
+
+    # Load existing config as prefill for --force
+    prefill = None
+    if force and config_path.exists():
+        prefill = _load_prefill(config_path)
+        # Remove existing files so init_project recreates them
+        config_path.unlink()
+        klemma_md = project_dir / "KLEMMA.md"
+        if klemma_md.exists():
+            klemma_md.unlink()
+
+    # Check if config already exists (skip wizard unless --force)
+    if not force and config_path.exists():
+        no_input = True
+
+    values = None
+    if not no_input:
+        values = _interactive_init(project_type, prefill=prefill)
+        project_type = values.project_type
+
+    result = init_project(project_dir, project_type=project_type, values=values)
 
     if result["created"]:
-        console.print(f"[green]Initialized klemma {project_type} project in {project_dir}/[/green]")
+        console.print(f"\n[green]Initialized klemma {project_type} project in {project_dir}/[/green]")
         for name in result["created"]:
             console.print(f"  + {name}")
     if result["skipped"]:
         for name in result["skipped"]:
             console.print(f"  [dim]~ {name} (already exists, skipped)[/dim]")
 
+    # Paper: discover relevant sources from vault + BBT JSON
+    if (
+        values
+        and project_type == "paper"
+        and (values.keywords or values.description)
+        and values.vault_path
+        and values.zotero_library_json
+    ):
+        _discover_paper_sources(project_dir, values)
+
     console.print()
-    console.print("[bold]Next steps:[/bold]")
-    console.print("  1. Edit [cyan].klemma/config.yaml[/cyan] — set Zotero/Obsidian paths")
-    console.print("  2. Edit [cyan]KLEMMA.md[/cyan] — describe your project")
-    console.print("  3. Edit [cyan].klemma/tags.yaml[/cyan] — define your topic taxonomy")
-    console.print("  4. Run [bold]klemma status[/bold] to verify")
+    console.print("Run [bold]klemma status[/bold] to verify.")
+
+
+def _load_prefill(config_path: Path) -> dict:
+    """Read existing .klemma/config.yaml and return values for prefilling the wizard."""
+    import yaml as _yaml
+
+    try:
+        raw = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+
+    project = raw.get("project", {}) if isinstance(raw.get("project"), dict) else {}
+    ai = raw.get("ai", {}) if isinstance(raw.get("ai"), dict) else {}
+    obsidian = raw.get("obsidian", {}) if isinstance(raw.get("obsidian"), dict) else {}
+    zotero = raw.get("zotero", {}) if isinstance(raw.get("zotero"), dict) else {}
+
+    return {
+        "project_type": project.get("type", "dissertation"),
+        "title": project.get("title", ""),
+        "description": project.get("description", ""),
+        "keywords": project.get("priority_terms", []),
+        "language": ai.get("language", "ru"),
+        "vault_path": obsidian.get("vault_path", ""),
+        "notes_folder": obsidian.get("notes_folder", "References"),
+        "tags_folder": obsidian.get("tags_folder", "Tags"),
+        "zotero_storage": zotero.get("storage_path", ""),
+        "zotero_library_json": zotero.get("library_json", ""),
+    }
+
+
+def _discover_paper_sources(project_dir: Path, values):
+    """Scan vault + BBT JSON for sources matching paper keywords, register matches."""
+    from .discovery import discover_relevant_sources
+    from .library_provider import LocalLibrary
+
+    library = LocalLibrary(Path(values.zotero_library_json))
+    if not library.entries:
+        return
+
+    matches = discover_relevant_sources(
+        vault_path=Path(values.vault_path),
+        notes_folder=values.notes_folder,
+        library_entries=library.entries,
+        keywords=values.keywords,
+        description=values.description,
+    )
+
+    if not matches:
+        click.echo("\n  No matching sources found in vault.")
+        click.echo("  Add sources later with: klemma process <citekey>")
+        return
+
+    total_in_vault = 0
+    notes_dir = Path(values.vault_path) / values.notes_folder
+    if notes_dir.is_dir():
+        total_in_vault = sum(1 for f in notes_dir.iterdir() if f.name.startswith("@"))
+
+    click.echo("\n  Scanning vault for relevant sources...")
+    click.echo(f"  Found {len(matches)} matching sources (of {total_in_vault} in vault):")
+
+    shown = matches[:10]
+    for m in shown:
+        title_short = m["title"][:60] + "..." if len(m["title"]) > 60 else m["title"]
+        click.echo(f"    @{m['citekey']} — {title_short}")
+    if len(matches) > 10:
+        click.echo(f"    ... and {len(matches) - 10} more")
+
+    if not click.confirm("  Include these sources?", default=True):
+        click.echo("  Skipped. Add sources later with: klemma process <citekey>")
+        return
+
+    # Register sources in the project's DB
+    from .config import resolve_effective_config
+    from .state import StateManager
+
+    cfg, project_cfg, project_root = resolve_effective_config()
+    klemma_dir = project_dir / ".klemma"
+    db_path = klemma_dir / "data" / "klemma.db"
+    state = StateManager(str(db_path))
+
+    citekeys = [m["citekey"] for m in matches]
+    state.register_sources(citekeys)
+    click.echo(f"  {len(citekeys)} sources registered.")
+
+
+def _interactive_init(project_type: str, prefill: dict | None = None):
+    """Run interactive setup wizard, return collected values.
+
+    If prefill is provided (from --force), uses those values as defaults.
+    """
+    from .discovery import (
+        detect_language,
+        discover_bbt_json,
+        discover_obsidian_vault,
+        discover_zotero_storage,
+    )
+    from .setup import InitValues
+
+    pf = prefill or {}
+
+    click.echo("\nKlemma project setup\n")
+
+    # --- Project basics ---
+    project_type = click.prompt(
+        "  Project type",
+        type=click.Choice(["dissertation", "paper", "thesis"], case_sensitive=False),
+        default=pf.get("project_type", project_type),
+    )
+    title = click.prompt(
+        "  Project title",
+        default=pf.get("title", ""),
+        show_default=bool(pf.get("title")),
+    )
+
+    # Paper-specific: description and keywords are essential for source discovery
+    description = ""
+    keywords: list[str] = []
+    if project_type == "paper":
+        description = click.prompt(
+            "  Research description (1-2 sentences)",
+            default=pf.get("description", ""),
+            show_default=bool(pf.get("description")),
+        )
+        kw_default = ", ".join(pf["keywords"]) if pf.get("keywords") else ""
+        kw_str = click.prompt(
+            "  Keywords (comma-separated)",
+            default=kw_default,
+            show_default=bool(kw_default),
+        )
+        keywords = [k.strip() for k in kw_str.split(",") if k.strip()] if kw_str else []
+
+    language = click.prompt(
+        "  AI language",
+        default=pf.get("language", detect_language()),
+    )
+
+    # --- Auto-discovery (prefill overrides discovery) ---
+    click.echo("\n  Detecting paths...")
+
+    values = InitValues(
+        project_type=project_type,
+        title=title,
+        description=description,
+        keywords=keywords,
+        language=language,
+    )
+
+    # Obsidian vault
+    prefill_vault = pf.get("vault_path", "")
+    vault = discover_obsidian_vault()
+    discovered_vault = str(vault) if vault else ""
+    # Use prefill if available, otherwise use discovery
+    effective_vault = prefill_vault or discovered_vault
+
+    if effective_vault:
+        click.echo(f"  + Obsidian vault: {effective_vault}")
+        if not click.confirm("    Use this path?", default=True):
+            vault_str = click.prompt("    Obsidian vault path", default="")
+            values.vault_path = vault_str
+        else:
+            values.vault_path = effective_vault
+    else:
+        vault_str = click.prompt(
+            "  ? Obsidian vault not found. Path (empty to skip)",
+            default="",
+            show_default=False,
+        )
+        values.vault_path = vault_str
+
+    # Zotero storage
+    prefill_storage = pf.get("zotero_storage", "")
+    storage = discover_zotero_storage()
+    effective_storage = prefill_storage or (str(storage) if storage else "")
+
+    if effective_storage:
+        click.echo(f"  + Zotero storage: {effective_storage}")
+        values.zotero_storage = effective_storage
+    else:
+        storage_str = click.prompt(
+            "  ? Zotero storage not found. Path (empty to skip)",
+            default="",
+            show_default=False,
+        )
+        values.zotero_storage = storage_str
+
+    # BBT JSON
+    prefill_bbt = pf.get("zotero_library_json", "")
+    bbt = discover_bbt_json()
+    effective_bbt = prefill_bbt or (str(bbt) if bbt else "")
+
+    if effective_bbt:
+        click.echo(f"  + BBT JSON export: {effective_bbt}")
+        values.zotero_library_json = effective_bbt
+    else:
+        bbt_str = click.prompt(
+            "  ? BBT JSON export not found. Path (empty to skip)",
+            default="",
+            show_default=False,
+        )
+        values.zotero_library_json = bbt_str
+
+    return values
 
 
 @main.command()
@@ -647,33 +890,57 @@ def status(ctx, verbose, chapter):
     console.print(f"Processing: {' | '.join(parts)}  [dim]({total} total, {frag_stats.get('total', 0)} fragments)[/dim]")
     console.print()
 
-    # --- Coverage by chapter (dynamic from project config) ---
-    chapter_numbers = project.chapter_numbers if project else list(range(1, 5))
-    table = Table(title="Coverage by Chapter", show_edge=False, pad_edge=False)
-    table.add_column("Chapter", style="cyan")
-    table.add_column("Sources", justify="right", width=8)
-    for ch in chapter_numbers:
-        if chapter and ch != chapter:
-            continue
-        count = cov["chapters"].get(ch, 0)
-        style = "green" if count >= 10 else "yellow" if count >= 5 else "red"
-        name = (project.chapters.get(ch, "") if project
-                else cfg.dissertation.chapters.get(ch, ""))
-        table.add_row(f"Ch {ch}: {name}", f"[{style}]{count}[/{style}]")
-    console.print(table)
+    # --- Coverage (chapter-based for dissertation/thesis, simple for paper) ---
+    has_chapters = project and project.chapters and project.type != "paper"
 
-    # --- Sections (verbose or filtered by chapter) ---
-    if (verbose or chapter) and cov["sections"]:
-        console.print()
-        sec_table = Table(title="Coverage by Section", show_edge=False, pad_edge=False)
-        sec_table.add_column("Section", style="cyan")
-        sec_table.add_column("Sources", justify="right", width=8)
-        for sec, count in sorted(cov["sections"].items()):
-            if chapter and not sec.startswith(f"{chapter}."):
+    if has_chapters:
+        chapter_numbers = project.chapter_numbers
+        table = Table(title="Coverage by Chapter", show_edge=False, pad_edge=False)
+        table.add_column("Chapter", style="cyan")
+        table.add_column("Sources", justify="right", width=8)
+        for ch in chapter_numbers:
+            if chapter and ch != chapter:
                 continue
-            style = "green" if count >= 3 else "yellow" if count >= 1 else "red"
-            sec_table.add_row(sec, f"[{style}]{count}[/{style}]")
-        console.print(sec_table)
+            count = cov["chapters"].get(ch, 0)
+            style = "green" if count >= 10 else "yellow" if count >= 5 else "red"
+            name = project.chapters.get(ch, "")
+            table.add_row(f"Ch {ch}: {name}", f"[{style}]{count}[/{style}]")
+        console.print(table)
+
+        # Sections (verbose or filtered by chapter)
+        if (verbose or chapter) and cov["sections"]:
+            console.print()
+            sec_table = Table(title="Coverage by Section", show_edge=False, pad_edge=False)
+            sec_table.add_column("Section", style="cyan")
+            sec_table.add_column("Sources", justify="right", width=8)
+            for sec, count in sorted(cov["sections"].items()):
+                if chapter and not sec.startswith(f"{chapter}."):
+                    continue
+                style = "green" if count >= 3 else "yellow" if count >= 1 else "red"
+                sec_table.add_row(sec, f"[{style}]{count}[/{style}]")
+            console.print(sec_table)
+    elif not project or project.type == "paper":
+        # Paper: show section coverage if any, no chapter structure
+        if cov["sections"]:
+            sec_table = Table(title="Coverage by Section", show_edge=False, pad_edge=False)
+            sec_table.add_column("Section", style="cyan")
+            sec_table.add_column("Sources", justify="right", width=8)
+            for sec, count in sorted(cov["sections"].items()):
+                style = "green" if count >= 3 else "yellow" if count >= 1 else "red"
+                sec_table.add_row(sec, f"[{style}]{count}[/{style}]")
+            console.print(sec_table)
+    else:
+        # Fallback: legacy dissertation config
+        chapter_numbers = list(range(1, 5))
+        table = Table(title="Coverage by Chapter", show_edge=False, pad_edge=False)
+        table.add_column("Chapter", style="cyan")
+        table.add_column("Sources", justify="right", width=8)
+        for ch in chapter_numbers:
+            count = cov["chapters"].get(ch, 0)
+            style = "green" if count >= 10 else "yellow" if count >= 5 else "red"
+            name = cfg.dissertation.chapters.get(ch, "")
+            table.add_row(f"Ch {ch}: {name}", f"[{style}]{count}[/{style}]")
+        console.print(table)
 
     # --- Top gaps ---
     min_sources = (project.min_sources_per_section if project

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -181,6 +181,7 @@ class ProjectConfig(BaseModel):
 
     type: str = "dissertation"  # dissertation | paper | thesis
     title: str = ""
+    description: str = ""  # 1-2 sentence research description (used for source discovery)
     current_focus: str = ""  # e.g. "2.3.1" for dissertation, "methods" for paper
     chapters: dict[int, str] = Field(default_factory=dict)
     scientific_results: dict[str, str] = Field(default_factory=dict)

--- a/src/klemma/discovery.py
+++ b/src/klemma/discovery.py
@@ -1,0 +1,218 @@
+"""Auto-discovery of external tool paths for `klemma init` interactive setup."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def discover_obsidian_vault() -> Optional[Path]:
+    """Find Obsidian vault by searching common locations for .obsidian/ dir."""
+    home = Path.home()
+    candidates = [
+        home / "Documents" / "Obsidian Vault",
+        home / "Obsidian Vault",
+        home / "Obsidian",
+    ]
+    # Check known candidates first
+    for path in candidates:
+        if (path / ".obsidian").is_dir():
+            return path
+
+    # Scan ~/Documents/ one level deep
+    docs = home / "Documents"
+    if docs.is_dir():
+        try:
+            for child in docs.iterdir():
+                if child.is_dir() and (child / ".obsidian").is_dir():
+                    return child
+        except PermissionError:
+            pass
+
+    # macOS: check Obsidian app config for vault list
+    obsidian_config = home / "Library" / "Application Support" / "obsidian" / "obsidian.json"
+    if obsidian_config.is_file():
+        try:
+            data = json.loads(obsidian_config.read_text(encoding="utf-8"))
+            vaults = data.get("vaults", {})
+            for vault_info in vaults.values():
+                vault_path = Path(vault_info.get("path", ""))
+                if vault_path.is_dir() and (vault_path / ".obsidian").is_dir():
+                    return vault_path
+        except (json.JSONDecodeError, KeyError, PermissionError):
+            pass
+
+    return None
+
+
+def discover_zotero_storage() -> Optional[Path]:
+    """Check if ~/Zotero/storage exists (default Zotero data dir)."""
+    storage = Path.home() / "Zotero" / "storage"
+    return storage if storage.is_dir() else None
+
+
+def discover_bbt_json() -> Optional[Path]:
+    """Search common locations for BetterBibTeX JSON exports."""
+    home = Path.home()
+    search_dirs = [
+        home / "Zotero",
+        home / "research",
+        home / "Documents",
+    ]
+    for search_dir in search_dirs:
+        result = _find_bbt_in_dir(search_dir, max_depth=2)
+        if result:
+            return result
+    return None
+
+
+def _find_bbt_in_dir(directory: Path, max_depth: int = 2) -> Optional[Path]:
+    """Recursively search a directory for BBT JSON files up to max_depth."""
+    if not directory.is_dir():
+        return None
+    try:
+        pattern = "*.json" if max_depth <= 1 else "**/*.json"
+        candidates = []
+        for f in directory.glob(pattern):
+            if f.name.startswith("."):
+                continue
+            # Limit depth
+            rel = f.relative_to(directory)
+            if len(rel.parts) > max_depth:
+                continue
+            candidates.append(f)
+        # Sort by modification time (newest first)
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for f in candidates:
+            if _is_bbt_json(f):
+                return f
+    except PermissionError:
+        pass
+    return None
+
+
+def _is_bbt_json(path: Path) -> bool:
+    """Quick check if a JSON file looks like a BBT export."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            head = fh.read(500)
+        return '"citationKey"' in head or '"citekey"' in head or '"itemType"' in head
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def discover_relevant_sources(
+    vault_path: Path,
+    notes_folder: str,
+    library_entries: dict,
+    keywords: list[str],
+    description: str = "",
+) -> list[dict]:
+    """Find sources matching keywords by scanning vault notes and BBT entries.
+
+    Matching strategy (score each source):
+    - Keyword in vault note tags → +3
+    - Keyword in BBT entry title → +2
+    - Keyword in BBT entry abstract → +1
+    - Keyword in BBT entry keywords field → +2
+
+    Args:
+        vault_path: Path to Obsidian vault
+        notes_folder: Subfolder with @citekey.md notes
+        library_entries: {citekey: ZoteroEntry} from BBT JSON
+        keywords: User-provided keywords for matching
+        description: Optional research description (words used as extra keywords)
+
+    Returns:
+        Sorted list of {citekey, title, score} with score > 0.
+    """
+    if not keywords and not description:
+        return []
+
+    # Build search terms: explicit keywords + words from description (3+ chars)
+    terms = [k.lower() for k in keywords]
+    if description:
+        for word in description.split():
+            w = word.strip(".,;:!?()\"'").lower()
+            if len(w) >= 4 and w not in terms:
+                terms.append(w)
+
+    if not terms:
+        return []
+
+    # Scan vault note tags
+    vault_tags: dict[str, list[str]] = {}  # citekey → [tags]
+    notes_dir = vault_path / notes_folder
+    if notes_dir.is_dir():
+        try:
+            for note in notes_dir.iterdir():
+                if not note.name.startswith("@") or not note.name.endswith(".md"):
+                    continue
+                citekey = note.stem.lstrip("@")
+                tags = _extract_vault_tags(note)
+                if tags:
+                    vault_tags[citekey] = tags
+        except PermissionError:
+            pass
+
+    # Score each BBT entry
+    results = []
+    for citekey, entry in library_entries.items():
+        score = 0
+        title_lower = (getattr(entry, "title", "") or "").lower()
+        abstract_lower = (getattr(entry, "abstract", "") or "").lower()
+        kw_field = (getattr(entry, "keywords", "") or "").lower()
+        note_tags = [t.lower() for t in vault_tags.get(citekey, [])]
+
+        for term in terms:
+            if any(term in tag for tag in note_tags):
+                score += 3
+            if term in title_lower:
+                score += 2
+            if term in kw_field:
+                score += 2
+            if term in abstract_lower:
+                score += 1
+
+        if score > 0:
+            results.append({
+                "citekey": citekey,
+                "title": getattr(entry, "title", "") or citekey,
+                "score": score,
+            })
+
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results
+
+
+def _extract_vault_tags(note_path: Path) -> list[str]:
+    """Extract tags from vault note YAML frontmatter."""
+    try:
+        text = note_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not text.startswith("---"):
+        return []
+    end = text.find("---", 3)
+    if end == -1:
+        return []
+    try:
+        import yaml
+        fm = yaml.safe_load(text[3:end]) or {}
+        tags = fm.get("tags", [])
+        return tags if isinstance(tags, list) else []
+    except Exception:
+        return []
+
+
+def detect_language() -> str:
+    """Detect 2-letter language code from system locale."""
+    for var in ("LANG", "LC_ALL", "LC_MESSAGES"):
+        val = os.environ.get(var, "")
+        if val and len(val) >= 2:
+            code = val[:2].lower()
+            if code.isalpha():
+                return code
+    return "ru"

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -6,14 +6,119 @@ Two modes:
 """
 
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
+
+import yaml
 
 # Example files shipped with the package (repo root)
 _EXAMPLES_DIR = Path(__file__).parent.parent.parent
 
 
-def init_project(project_dir: Path, project_type: str = "dissertation") -> dict:
+@dataclass
+class InitValues:
+    """Values collected by the interactive wizard (or auto-discovery)."""
+
+    project_type: str = "dissertation"
+    title: str = ""
+    description: str = ""
+    keywords: list[str] = None  # type: ignore[assignment]
+    language: str = "ru"
+    vault_path: str = ""
+    notes_folder: str = "References"
+    tags_folder: str = "Tags"
+    zotero_storage: str = ""
+    zotero_library_json: str = ""
+
+    def __post_init__(self):
+        if self.keywords is None:
+            self.keywords = []
+
+
+def _build_project_config(values: InitValues) -> dict:
+    """Build config dict from wizard values."""
+    cfg: dict = {}
+
+    # Zotero (only if paths provided)
+    zotero: dict = {}
+    if values.zotero_library_json:
+        zotero["library_json"] = values.zotero_library_json
+    if values.zotero_storage:
+        zotero["storage_path"] = values.zotero_storage
+    if zotero:
+        cfg["zotero"] = zotero
+
+    # Obsidian (only if vault provided)
+    if values.vault_path:
+        obsidian: dict = {"vault_path": values.vault_path}
+        if values.notes_folder:
+            obsidian["notes_folder"] = values.notes_folder
+        if values.tags_folder:
+            obsidian["tags_folder"] = values.tags_folder
+        cfg["obsidian"] = obsidian
+
+    # AI
+    cfg["ai"] = {"model": "sonnet", "language": values.language}
+
+    # Project
+    project: dict = {"type": values.project_type}
+    if values.title:
+        project["title"] = values.title
+    if values.description:
+        project["description"] = values.description
+    if values.keywords:
+        project["priority_terms"] = values.keywords
+    cfg["project"] = project
+
+    # State
+    cfg["state"] = {"db_path": "./data/klemma.db"}
+
+    # MCP
+    cfg["mcp"] = {"servers": {}}
+
+    return cfg
+
+
+def _build_klemma_md(values: InitValues) -> str:
+    """Build KLEMMA.md content from wizard values."""
+    title = values.title or "Your project title here"
+    lines = [
+        "# Project Context\n",
+        "<!-- This file describes your project for AI. It is passed as context to all",
+        "     AI-powered commands (plan, research, process, ask, etc.).",
+        "",
+        "     For nested projects, context is aggregated: parent context first, then child.",
+        "     For example, if this is a paper inside a dissertation directory, AI will see",
+        "     the dissertation context followed by this paper's context. -->\n",
+        f'Topic: "{title}"\n',
+    ]
+
+    if values.description:
+        lines.append(f"Description: {values.description}\n")
+
+    lines.append("Scientific Results:")
+    lines.append("- NR1: First scientific result")
+    lines.append("- NR2: Second scientific result\n")
+
+    if values.keywords:
+        lines.append(f"Key terms: {', '.join(values.keywords)}")
+    else:
+        lines.append("Key terms: term1, term2, term3")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def init_project(
+    project_dir: Path,
+    project_type: str = "dissertation",
+    values: Optional[InitValues] = None,
+) -> dict:
     """Create .klemma/ project in project_dir + KLEMMA.md.
+
+    If values is provided (interactive mode), writes config from discovered/prompted
+    values. Otherwise falls back to example template (--no-input / legacy).
 
     Returns dict with keys: created (list of file names), skipped (list).
     """
@@ -29,19 +134,25 @@ def init_project(project_dir: Path, project_type: str = "dissertation") -> dict:
     if config_target.exists():
         skipped.append(".klemma/config.yaml")
     else:
-        source = _EXAMPLES_DIR / "config.project.example.yaml"
-        if source.exists():
-            text = source.read_text(encoding="utf-8")
-            text = text.replace("type: dissertation", f"type: {project_type}")
+        if values:
+            values.project_type = project_type
+            cfg = _build_project_config(values)
+            text = yaml.dump(cfg, default_flow_style=False, allow_unicode=True, sort_keys=False)
             config_target.write_text(text, encoding="utf-8")
         else:
-            config_target.write_text(
-                f"# Klemma project config\n"
-                f"project:\n"
-                f"  type: {project_type}\n"
-                f"  title: \"\"\n",
-                encoding="utf-8",
-            )
+            source = _EXAMPLES_DIR / "config.project.example.yaml"
+            if source.exists():
+                text = source.read_text(encoding="utf-8")
+                text = text.replace("type: dissertation", f"type: {project_type}")
+                config_target.write_text(text, encoding="utf-8")
+            else:
+                config_target.write_text(
+                    f"# Klemma project config\n"
+                    f"project:\n"
+                    f"  type: {project_type}\n"
+                    f"  title: \"\"\n",
+                    encoding="utf-8",
+                )
         created.append(".klemma/config.yaml")
 
     # Tags
@@ -61,17 +172,20 @@ def init_project(project_dir: Path, project_type: str = "dissertation") -> dict:
     if klemma_md.exists():
         skipped.append("KLEMMA.md")
     else:
-        source = _EXAMPLES_DIR / "klemma.example.md"
-        if source.exists():
-            shutil.copy2(source, klemma_md)
+        if values:
+            klemma_md.write_text(_build_klemma_md(values), encoding="utf-8")
         else:
-            klemma_md.write_text(
-                f"# Project Context\n\n"
-                f"Type: {project_type}\n"
-                f"Title: \"\"\n\n"
-                f"<!-- Describe your project here. This context is passed to AI. -->\n",
-                encoding="utf-8",
-            )
+            source = _EXAMPLES_DIR / "klemma.example.md"
+            if source.exists():
+                shutil.copy2(source, klemma_md)
+            else:
+                klemma_md.write_text(
+                    f"# Project Context\n\n"
+                    f"Type: {project_type}\n"
+                    f"Title: \"\"\n\n"
+                    f"<!-- Describe your project here. This context is passed to AI. -->\n",
+                    encoding="utf-8",
+                )
         created.append("KLEMMA.md")
 
     # .gitignore: exclude DB but keep config in VCS

--- a/tests/test_interactive_init.py
+++ b/tests/test_interactive_init.py
@@ -1,0 +1,313 @@
+"""Tests for interactive init wizard: discovery functions and init_project with values."""
+
+import yaml
+
+
+class TestDiscoverObsidianVault:
+    def test_finds_vault_in_documents(self, tmp_path, monkeypatch):
+        vault = tmp_path / "Documents" / "Obsidian Vault"
+        (vault / ".obsidian").mkdir(parents=True)
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_obsidian_vault
+
+        result = discover_obsidian_vault()
+        assert result == vault
+
+    def test_finds_vault_in_documents_subdir(self, tmp_path, monkeypatch):
+        vault = tmp_path / "Documents" / "MyNotes"
+        (vault / ".obsidian").mkdir(parents=True)
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_obsidian_vault
+
+        result = discover_obsidian_vault()
+        assert result == vault
+
+    def test_returns_none_when_no_vault(self, tmp_path, monkeypatch):
+        (tmp_path / "Documents").mkdir()
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_obsidian_vault
+
+        result = discover_obsidian_vault()
+        assert result is None
+
+
+class TestDiscoverZoteroStorage:
+    def test_finds_storage(self, tmp_path, monkeypatch):
+        storage = tmp_path / "Zotero" / "storage"
+        storage.mkdir(parents=True)
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_zotero_storage
+
+        result = discover_zotero_storage()
+        assert result == storage
+
+    def test_returns_none_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_zotero_storage
+
+        result = discover_zotero_storage()
+        assert result is None
+
+
+class TestDiscoverBbtJson:
+    def test_finds_bbt_export(self, tmp_path, monkeypatch):
+        zotero = tmp_path / "Zotero"
+        zotero.mkdir()
+        bbt_file = zotero / "My Library.json"
+        bbt_file.write_text('[{"itemType": "journalArticle", "citationKey": "smith2024"}]')
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_bbt_json
+
+        result = discover_bbt_json()
+        assert result == bbt_file
+
+    def test_returns_none_when_no_zotero(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_bbt_json
+
+        result = discover_bbt_json()
+        assert result is None
+
+    def test_skips_non_bbt_json(self, tmp_path, monkeypatch):
+        zotero = tmp_path / "Zotero"
+        zotero.mkdir()
+        (zotero / "settings.json").write_text('{"setting": true}')
+        monkeypatch.setattr("klemma.discovery.Path.home", lambda: tmp_path)
+
+        from klemma.discovery import discover_bbt_json
+
+        result = discover_bbt_json()
+        assert result is None
+
+
+class TestDetectLanguage:
+    def test_detects_from_lang(self, monkeypatch):
+        monkeypatch.setenv("LANG", "en_US.UTF-8")
+        monkeypatch.delenv("LC_ALL", raising=False)
+        monkeypatch.delenv("LC_MESSAGES", raising=False)
+
+        from klemma.discovery import detect_language
+
+        assert detect_language() == "en"
+
+    def test_detects_russian(self, monkeypatch):
+        monkeypatch.setenv("LANG", "ru_RU.UTF-8")
+        monkeypatch.delenv("LC_ALL", raising=False)
+        monkeypatch.delenv("LC_MESSAGES", raising=False)
+
+        from klemma.discovery import detect_language
+
+        assert detect_language() == "ru"
+
+    def test_defaults_to_ru(self, monkeypatch):
+        monkeypatch.delenv("LANG", raising=False)
+        monkeypatch.delenv("LC_ALL", raising=False)
+        monkeypatch.delenv("LC_MESSAGES", raising=False)
+
+        from klemma.discovery import detect_language
+
+        assert detect_language() == "ru"
+
+
+class TestInitProjectWithValues:
+    def test_creates_valid_yaml_config(self, tmp_path):
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(
+            project_type="paper",
+            title="Test Paper",
+            language="en",
+            vault_path="/tmp/vault",
+            zotero_storage="/tmp/Zotero/storage",
+            zotero_library_json="/tmp/Zotero/lib.json",
+        )
+        result = init_project(tmp_path, project_type="paper", values=values)
+
+        assert ".klemma/config.yaml" in result["created"]
+
+        config_path = tmp_path / ".klemma" / "config.yaml"
+        cfg = yaml.safe_load(config_path.read_text())
+
+        assert cfg["project"]["type"] == "paper"
+        assert cfg["project"]["title"] == "Test Paper"
+        assert cfg["ai"]["language"] == "en"
+        assert cfg["zotero"]["library_json"] == "/tmp/Zotero/lib.json"
+        assert cfg["zotero"]["storage_path"] == "/tmp/Zotero/storage"
+        assert cfg["obsidian"]["vault_path"] == "/tmp/vault"
+
+    def test_creates_klemma_md_with_title(self, tmp_path):
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(title="My Paper on Ice")
+        init_project(tmp_path, values=values)
+
+        md = (tmp_path / "KLEMMA.md").read_text()
+        assert "My Paper on Ice" in md
+
+    def test_omits_empty_paths(self, tmp_path):
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(title="Minimal")
+        init_project(tmp_path, values=values)
+
+        cfg = yaml.safe_load((tmp_path / ".klemma" / "config.yaml").read_text())
+        assert "zotero" not in cfg
+        assert "obsidian" not in cfg
+
+    def test_no_values_uses_template(self, tmp_path):
+        from klemma.setup import init_project
+
+        init_project(tmp_path, project_type="thesis")
+
+        cfg_text = (tmp_path / ".klemma" / "config.yaml").read_text()
+        # Template has placeholder paths
+        assert "type: thesis" in cfg_text
+
+    def test_paper_with_description_and_keywords(self, tmp_path):
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(
+            project_type="paper",
+            title="Ice Sheet Paper",
+            description="Analysis of ice sheet dynamics under warming",
+            keywords=["ice sheets", "climate", "GrIS"],
+        )
+        init_project(tmp_path, project_type="paper", values=values)
+
+        cfg = yaml.safe_load((tmp_path / ".klemma" / "config.yaml").read_text())
+        assert cfg["project"]["description"] == "Analysis of ice sheet dynamics under warming"
+        assert cfg["project"]["priority_terms"] == ["ice sheets", "climate", "GrIS"]
+
+        md = (tmp_path / "KLEMMA.md").read_text()
+        assert "Analysis of ice sheet dynamics" in md
+        assert "ice sheets, climate, GrIS" in md
+
+
+class TestDiscoverRelevantSources:
+    def _make_entry(self, title="", abstract="", keywords=""):
+        """Create a mock ZoteroEntry-like object."""
+
+        class FakeEntry:
+            pass
+
+        e = FakeEntry()
+        e.title = title
+        e.abstract = abstract
+        e.keywords = keywords
+        return e
+
+    def test_matches_by_title(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        entries = {
+            "smith2024": self._make_entry(title="Ice sheet dynamics in Greenland"),
+            "jones2023": self._make_entry(title="Machine learning review"),
+        }
+        # No vault notes
+        (tmp_path / "References").mkdir()
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="References",
+            library_entries=entries,
+            keywords=["ice sheet"],
+        )
+        assert len(results) == 1
+        assert results[0]["citekey"] == "smith2024"
+
+    def test_matches_by_abstract(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        entries = {
+            "doe2024": self._make_entry(
+                title="A Study", abstract="Climate change impacts on polar regions"
+            ),
+        }
+        (tmp_path / "Refs").mkdir()
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="Refs",
+            library_entries=entries,
+            keywords=["climate"],
+        )
+        assert len(results) == 1
+
+    def test_matches_by_vault_tags(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        # Create vault note with tags
+        refs = tmp_path / "References"
+        refs.mkdir()
+        (refs / "@paper2024.md").write_text(
+            "---\ntags:\n  - glaciology\n  - ice\n---\nSome content\n"
+        )
+
+        entries = {
+            "paper2024": self._make_entry(title="Unrelated Title"),
+        }
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="References",
+            library_entries=entries,
+            keywords=["glaciology"],
+        )
+        assert len(results) == 1
+        assert results[0]["score"] >= 3  # vault tag match
+
+    def test_returns_empty_without_keywords(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="Refs",
+            library_entries={"a": self._make_entry(title="Something")},
+            keywords=[],
+        )
+        assert results == []
+
+    def test_scores_sorted_descending(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        entries = {
+            "weak": self._make_entry(abstract="ice sheet mentioned once"),
+            "strong": self._make_entry(
+                title="Ice sheet dynamics", abstract="ice sheet retreat analysis"
+            ),
+        }
+        (tmp_path / "Refs").mkdir()
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="Refs",
+            library_entries=entries,
+            keywords=["ice sheet"],
+        )
+        assert len(results) == 2
+        assert results[0]["citekey"] == "strong"
+        assert results[0]["score"] > results[1]["score"]
+
+    def test_uses_description_words(self, tmp_path):
+        from klemma.discovery import discover_relevant_sources
+
+        entries = {
+            "a": self._make_entry(title="Greenland ice sheet modeling"),
+        }
+        (tmp_path / "Refs").mkdir()
+
+        results = discover_relevant_sources(
+            vault_path=tmp_path,
+            notes_folder="Refs",
+            library_entries=entries,
+            keywords=[],
+            description="Modeling ice sheet dynamics in Greenland",
+        )
+        assert len(results) == 1


### PR DESCRIPTION
## Summary

- **Interactive setup wizard** for `klemma init` — auto-discovers Obsidian vault, Zotero storage, and BBT JSON export; prompts for project type, title, language
- **Paper-specific bootstrapping** — papers prompt for research description + keywords, then keyword-match against vault notes and BBT entries to discover relevant sources (instead of importing all 244)
- **Explicit-only source model for papers** — `_sync_sections` skips auto-registration from BBT JSON and vault notes not already in the DB, so `klemma status` only shows explicitly registered sources
- **Adaptive status display** — papers show section coverage (no chapter table); dissertations/theses keep chapter-based layout
- **`--force` flag** — re-run wizard with values prefilled from existing config (deletes old config/KLEMMA.md, recreates)
- **`--no-input` flag** — skip interactive prompts, use template defaults
- New `discovery.py` module with `discover_relevant_sources()` keyword scorer (+3 vault tags, +2 title/keywords, +1 abstract)

## New files

- `src/klemma/discovery.py` — auto-discovery functions + keyword-based source matcher
- `tests/test_interactive_init.py` — 22 tests for discovery, init values, paper source matching

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/` — 84 passed
- [ ] Manual: `klemma init --type paper` in a new dir — prompts for description/keywords, discovers matching vault notes
- [ ] Manual: `klemma status` on paper — shows only registered sources, not 244
- [ ] Manual: `klemma init --force` — re-runs wizard with prefilled values

🤖 Generated with [Claude Code](https://claude.com/claude-code)