### PR TITLE
modernize: phase 0 — citation intents, embeddings, MCP tools, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Klemma — AI Academic Assistant
 
 ## What is this
-Klemma is a CLI tool for academic writing. It manages literature (via Zotero), extracts citation fragments from PDFs (via Claude AI), generates research briefings, daily plans, and tracks coverage. Supports multiple concurrent projects (dissertation, papers, theses) with separate databases and bibliographies.
+Klemma is a CLI tool for academic writing. It manages literature (via Zotero), extracts citation fragments from PDFs (via Claude AI) with citation intent classification, generates research briefings, daily plans, semantic search via SPECTER embeddings, citation graph analysis, and tracks coverage. Supports multiple concurrent projects (dissertation, papers, theses) with separate databases and bibliographies.
 
 ## Architecture
 - **CLI mode**: `klemma <command>` — all commands are headless CLI
@@ -10,31 +10,39 @@ Klemma is a CLI tool for academic writing. It manages literature (via Zotero), e
 - **Report output**: All AI reports (outline, research, library) save to `project_root/` directly. Only `@citekey.md` bibliography notes go to vault `notes_folder`.
 - **Library abstraction**: LocalLibrary backend (BBT JSON)
 - **AI abstraction**: AIProvider protocol with ClaudeClient (CLI), OpenAIClient, LiteLLMClient backends + `create_ai()` factory
-- **Context**: KlemmaContext dataclass created once per CLI command, holds config/state/vault/ai/library/project
+- **Embeddings**: EmbeddingProvider protocol with SemanticScholar (free S2 API), LocalSPECTER (sentence-transformers), OpenAI backends + `create_embeddings()` factory
+- **Context**: KlemmaContext dataclass created once per CLI command, holds config/state/vault/ai/embeddings/library/project
 - **Multi-project**: Git/NPM-style per-directory projects. `klemma init` in any dir creates `.klemma/` + `KLEMMA.md`. Nested projects inherit shared resources (vault, zotero) from parent. System config in `~/.klemma/`.
 
 ## Project structure
 ```
 src/klemma/
-├── cli.py              — Click CLI entry point
-├── config.py           — Pydantic config models (ProjectConfig, SystemConfig, KlemmaConfig) + discover_project_root(), resolve_effective_config(), resolve_prompt()
-├── context.py          — KlemmaContext dataclass (single object per CLI command, includes project_root/project_chain)
-├── setup.py            — `klemma init` logic — init_project() (per-dir .klemma/) + init_system() (~/.klemma/)
-├── state.py            — SQLite state manager
-├── ai.py               — AIProvider protocol + AIProviderBase + ClaudeClient + create_ai() factory
-├── ai_openai.py        — OpenAI-compatible backend (OpenAI, Ollama, vLLM, LM Studio)
-├── ai_litellm.py       — LiteLLM universal backend (100+ providers)
-├── vault.py            — Obsidian adapter (CLI/file I/O, update_section)
-├── library_provider.py — LibraryProvider protocol + LocalLibrary (BBT JSON)
+├── cli.py              — Click CLI entry point (2274 lines)
+├── config.py           — Pydantic config models + discover_project_root(), resolve_effective_config(), resolve_prompt() (635 lines)
+├── context.py          — KlemmaContext dataclass (single object per CLI command) (41 lines)
+├── setup.py            — `klemma init` logic — init_project() + init_system() (263 lines)
+├── state.py            — SQLite state manager (1599 lines)
+├── ai.py               — AIProvider protocol + ClaudeClient + create_ai() factory (249 lines)
+├── ai_openai.py        — OpenAI-compatible backend (105 lines)
+├── ai_litellm.py       — LiteLLM universal backend (70 lines)
+├── embeddings.py       — EmbeddingProvider protocol + 3 backends + cosine_similarity (257 lines)
+├── discovery.py        — Auto-discovery for klemma init (Obsidian vault, Zotero, BBT JSON) (260 lines)
+├── vault.py            — Obsidian adapter (CLI/file I/O, update_section) (249 lines)
+├── library_provider.py — LibraryProvider protocol + LocalLibrary (BBT JSON) (86 lines)
 ├── skills/             — AI skills (planner, extractor, researcher, librarian, agent, acquirer, outliner, work_context)
-└── literature/         — PDF extraction, models, note_factory
+├── literature/         — PDF extraction, models, note_factory
+└── tools/              — MCP tool infrastructure (567 lines)
+    ├── client.py       — MCPClient for stdio transport (129 lines)
+    ├── registry.py     — ToolRegistry for multi-server routing (99 lines)
+    └── specter_server.py — SPECTER MCP server + citation intent comparison (339 lines)
 prompts/                    — Shipped Jinja2 prompt templates (overridable via ~/.klemma/prompts/)
 ├── morning.md              — daily plans
-├── extract.md              — fragment extraction
-├── annotate.md             — vault note AI annotation
+├── extract.md              — fragment extraction (scaffold prompting + citation intent)
+├── annotate.md             — vault note AI annotation (+ citation intent in key_references)
 ├── research.md             — research briefing (first run)
 ├── research_incremental.md — incremental research update
 ├── librarian.md            — library analysis (3 modes)
+├── librarian_prune.md      — prune recommendation generation
 ├── agent.md                — interactive agent system prompt
 ├── outline.md              — project outline generation
 └── outline_incremental.md  — incremental outline update
@@ -50,15 +58,18 @@ tags.example.yaml           — Template tag taxonomy
 └── klemma-status/SKILL.md  — Agent skill: coverage & gaps check
 ```
 
-## Key commands (12)
+## Key commands (14)
 - `klemma init [--type paper|thesis]` — create project in current directory (.klemma/ + KLEMMA.md)
 - `klemma outline [-p "directive"] [--fresh] [--scan-only]` — AI-generate project structure; incremental on repeat, `-p` for custom directive, `--fresh` for full regeneration
 - `klemma plan` — daily plan generation (library digest included)
-- `klemma status` — unified stats + coverage + gaps + ref-gaps (`--verbose`, `--chapter N`)
-- `klemma process [<citekeys>...]` — extract fragments from PDF; no arg = batch all pending; parallel by default
+- `klemma status` — unified stats + coverage + gaps + ref-gaps (`--verbose` adds: intent coverage matrix, embedding stats, citation graph stats; `--chapter N` to filter)
+- `klemma process [<citekeys>...]` — extract fragments from PDF with citation intent classification; no arg = batch all pending; parallel by default; auto-embeds if embeddings configured
+- `klemma embed [<citekey>] [--dry-run] [--backend]` — generate SPECTER/OpenAI embeddings for semantic search; no arg = backfill all completed sources
+- `klemma similar <citekey|section> [-k N]` — find semantically similar sources by embedding cosine similarity; section mode shows cross-section recommendations
 - `klemma acquire <url> [--batch file.json]` — download PDF locally → register in DB
 - `klemma research -s 1.3.2` — research briefing for a section
-- `klemma library [-s 2.3] [--audit]` — AI library analysis (status / recommend / audit)
+- `klemma library [-s 2.3] [--audit]` — AI library analysis (status / recommend / audit); audit includes co-citation analysis, author network, prune recommendations
+- `klemma library prune [-c N] [-v drop|maybe] [--clear KEY]` — browse/clear prune recommendations from audit
 - `klemma ask "query"` — interactive research agent with full dissertation context
 - `klemma info` — show current project info (root, chain, config, DB)
 - `klemma tree` — show nested project tree from current root
@@ -100,13 +111,18 @@ Created by `klemma init` in any directory. Navigate to project dir and run comma
 - `ai.base_url` — endpoint URL for OpenAI-compatible servers (Ollama, vLLM, LM Studio)
 - `ai.api_key_env` — env var name for API key (e.g. `"OPENAI_API_KEY"`)
 - `ai.json_mode` — enable structured JSON output when backend supports it
+- `embeddings.backend` — `"s2"` (Semantic Scholar, free), `"local"` (sentence-transformers), `"openai"`, or `""` (disabled)
+- `embeddings.model` — model name (backend-specific, e.g. `"allenai/specter2"`)
+- `embeddings.throttle` — seconds between S2 API requests (default: 3.1)
+- `embeddings.api_key_env` — env var for API key (OpenAI backend)
 - Requires: AI backend (`claude` CLI by default, or `pip install klemma[openai]` / `klemma[litellm]`)
+- Optional: `pip install klemma[embeddings]` for semantic search, `pip install klemma[mcp]` for MCP tools
 
 **Project discovery:** `discover_project_root()` traverses up from cwd to find nearest `.klemma/` directory (like `git rev-parse --show-toplevel`).
 
 **Config merge order:** system (`~/.klemma/`) < parent project < child project < CLI `--config`.
 
-**Selective inheritance:** Only shared resources (`obsidian`, `zotero`, `ai`) are inherited from parent. Project-specific keys (`project`, `tags`, `state`, `processing`) are NOT inherited.
+**Selective inheritance:** Only shared resources (`obsidian`, `zotero`, `ai`, `embeddings`) are inherited from parent. Project-specific keys (`project`, `tags`, `state`, `processing`) are NOT inherited.
 
 **Prompt resolution:** `resolve_prompt(name, klemma_home, project_chain?)` checks project → parent project → system (`~/.klemma/prompts/`) → shipped prompts.
 
@@ -134,12 +150,15 @@ Navigate into `thesis_dir/paper_ice/` and run `klemma status` — it uses the pa
 Run `klemma migrate` in desired project directory. Splits `~/.klemma/config.yaml` into system (AI) and project (everything else), copies context.md → KLEMMA.md, tags.yaml, DB.
 
 ## SQLite tables
-- `sources` — Zotero entries with processing status and dissertation metadata
+Schema versioned via `PRAGMA user_version` (currently v3). Migrations in `state.py:_migrate_schema()`.
+- `sources` — Zotero entries with processing status, dissertation metadata, `embedding` BLOB (float32), `embedding_model` TEXT
 - `source_sections` — junction table: source_id × section (multi-section support)
-- `fragments` — extracted citation fragments mapped to chapters/sections
-- `reference_gaps` — missing references found in source bibliographies (status: open/resolved)
+- `fragments` — extracted citation fragments mapped to chapters/sections; `citation_intent` (background/method/result_comparison)
+- `reference_gaps` — missing references from bibliographies (status: open/resolved); `citation_intent`, intent-weighted scoring
+- `citation_links` — citation graph: source_id → target (title_hash for dedup, citation_intent, in_library flag)
 - `daily_plans` — generated daily plans
 - `reading_queue` — prioritized reading list
+- `prune_verdicts` — library audit recommendations (drop/maybe)
 
 ## Module documentation
 
@@ -155,11 +174,13 @@ Detailed documentation for each subsystem lives in its directory, loaded increme
 ## Development
 ```bash
 pip install -e ".[dev]"
-pip install -e ".[openai]"     # OpenAI / Ollama / vLLM / LM Studio backend
-pip install -e ".[litellm]"    # LiteLLM universal backend (100+ providers)
-pip install -e ".[all-ai]"     # all AI backends
-klemma init                    # scaffold ~/.klemma/ with config templates
-# edit ~/.klemma/config.yaml, context.md, tags.yaml for your project
+pip install -e ".[openai]"           # OpenAI / Ollama / vLLM / LM Studio backend
+pip install -e ".[litellm]"          # LiteLLM universal backend (100+ providers)
+pip install -e ".[embeddings]"       # semantic search (S2/OpenAI backends)
+pip install -e ".[local-embeddings]" # offline SPECTER2 (sentence-transformers)
+pip install -e ".[mcp]"              # MCP server support
+pip install -e ".[all-ai]"           # all AI backends
+klemma init                          # scaffold ~/.klemma/ with config templates
 klemma --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-AI-ассистент для работы над диссертацией. Управляет библиотекой источников (Zotero), извлекает цитируемые фрагменты из PDF (AI — Claude, OpenAI, Ollama, LiteLLM), генерирует ежедневные планы, исследовательские брифинги, анализ библиотеки и отслеживает покрытие глав диссертации.
+AI-ассистент для академического письма. Управляет библиотекой источников (Zotero), извлекает цитируемые фрагменты из PDF (AI — Claude, OpenAI, Ollama, LiteLLM), классифицирует citation intent, генерирует ежедневные планы, исследовательские брифинги, анализ библиотеки, семантический поиск похожих источников и отслеживает покрытие глав. Поддерживает вложенные проекты (диссертация + статьи) с раздельными базами и наследованием ресурсов.
 
 ## Установка
 
@@ -28,233 +28,289 @@ pip install -e .
   - `pip install klemma[openai]` — OpenAI API / Ollama / vLLM / LM Studio
   - `pip install klemma[litellm]` — 100+ провайдеров через LiteLLM
 - Obsidian vault с заметками источников
+- Zotero с BetterBibTeX plugin (JSON auto-export)
+
+### Опциональные зависимости
+
+```bash
+pip install klemma[embeddings]         # семантический поиск (S2/OpenAI бэкенды)
+pip install klemma[local-embeddings]   # офлайн SPECTER2 (sentence-transformers)
+pip install klemma[mcp]                # MCP-серверы (расширяемость)
+pip install klemma[all-ai]             # все AI-бэкенды (openai + litellm)
+```
 
 ## Быстрый старт
 
 ```bash
-# 1. Сгенерировать план на день (включает дайджест библиотеки)
-klemma plan
+# 1. Инициализировать проект
+klemma init                                    # интерактивный мастер
+klemma init --type paper                       # проект-статья
 
 # 2. Посмотреть статистику, покрытие, пробелы
-klemma status              # компактный обзор
-klemma status --verbose    # полные таблицы
-klemma status --chapter 2  # фильтр по главе
+klemma status                                  # компактный обзор
+klemma status --verbose                        # полные таблицы + intent matrix
 
-# 3. Обработать источник (фрагменты + аннотация + vault note)
-klemma process anderssonSeasonalArcticSea2021   # один источник
-klemma process                                  # все pending
+# 3. Обработать источники (фрагменты + citation intent + vault note)
+klemma process                                 # все pending (параллельно)
+klemma process smithMachineLearning2020        # один источник
 
-# 4. Исследовательский брифинг по разделу
+# 4. Сгенерировать embeddings для семантического поиска
+klemma embed                                   # все sources с abstract
+klemma similar smithMachineLearning2020        # похожие источники
+klemma similar 2.3                             # похожие для раздела 2.3
+
+# 5. Исследовательский брифинг по разделу
 klemma research -s 1.3.2
 
-# 5. AI-анализ библиотеки
-klemma library             # здоровье библиотеки
-klemma library -s 2.3      # рекомендации для раздела
-klemma library --audit     # глубокий аудит качества
+# 6. AI-анализ библиотеки
+klemma library                                 # здоровье
+klemma library -s 2.3                          # рекомендации
+klemma library --audit                         # аудит + citation graph
 
-# 6. Задать вопрос агенту с полным контекстом диссертации
-klemma ask "Какие основные методы валидации прогнозов ледовой обстановки?"
+# 7. Задать вопрос агенту с контекстом проекта
+klemma ask "Какие методы валидации прогнозов ледовой обстановки?"
 
-# 7. Управление MCP-серверами (Zotero, arXiv, ...)
-klemma tools add zotero --command "uvx" --args "zotero-mcp" --env ZOTERO_LOCAL=true
-klemma tools list --probe     # подключиться и показать доступные инструменты
-
-# 8. Поиск статей через MCP (arXiv, Semantic Scholar)
-klemma tools add academia --command "python3" --args "-m academia_mcp --transport stdio"
-klemma search "AMSR2 sea ice forecast validation"
-
-# 9. Автоматический поиск новой литературы для раздела
-klemma discover -s 1.3.2              # запустить discovery pipeline
-klemma discover --status              # статус
-klemma discover --review              # просмотр найденного
+# 8. Структура проекта
+klemma outline                                 # AI-генерация outline
+klemma outline -p "Фокус на методологии"       # с директивой
 ```
 
-## Команды (9)
+## Команды (14)
+
+### `klemma init`
+Инициализация проекта в текущей директории. Создаёт `.klemma/` (config, tags, DB) и `KLEMMA.md` (контекст для AI). Интерактивный мастер обнаруживает Obsidian vault и Zotero автоматически.
+
+```bash
+klemma init                    # интерактивный мастер
+klemma init --type paper       # проект-статья (вместо диссертации)
+klemma init --no-input         # без вопросов (defaults)
+```
 
 ### `klemma plan`
-Генерирует ежедневный план через Claude: фокус дня, рекомендации по чтению, задача для ассистента, стратегические предложения. Включает дайджест библиотеки. Учитывает вчерашний план, покрытие глав, пробелы, дедлайны. План сохраняется в базу и дописывается в daily note Obsidian.
+Ежедневный план: фокус дня, рекомендации по чтению, задача для ассистента, стратегические предложения. Учитывает вчерашний план, покрытие глав, пробелы, дедлайны. План сохраняется в базу и daily note Obsidian.
 
 ### `klemma status`
-Единая команда для статистики, покрытия и пробелов. Показывает: количество обработанных/pending/failed источников, покрытие по главам, разделы с недостаточным покрытием, reference gaps (ссылки из библиографий источников, отсутствующие в нашей библиотеке).
+Единая команда для статистики, покрытия и пробелов. Показывает: обработанные/pending/failed источники, покрытие по главам, разделы с недостаточным покрытием, reference gaps с intent-weighted scoring.
 
 ```bash
-klemma status              # компактный обзор
-klemma status --verbose    # полные таблицы + детализация
-klemma status --chapter 2  # фильтр по конкретной главе
+klemma status                  # компактный обзор
+klemma status --verbose        # полные таблицы:
+                               #   intent coverage matrix (background/method/result)
+                               #   embedding stats
+                               #   citation graph stats
+klemma status --chapter 2      # фильтр по главе
 ```
 
-### `klemma process [<citekey>]`
-Полный пайплайн обработки источника: поиск PDF → извлечение текста (PyMuPDF) → AI-анализ → сохранение фрагментов в SQLite + vault-заметку.
-
-**С аргументом** — обрабатывает один указанный источник.
-**Без аргумента** — batch-режим: обрабатывает все pending источники.
+### `klemma process [<citekeys>...]`
+Полный пайплайн обработки: PDF → текст (PyMuPDF) → AI-анализ → SQLite + vault note.
 
 При обработке автоматически:
-- Создаёт vault-заметку `@citekey.md`, если она отсутствует (AI-аннотация: summary, методология, релевантность, key references)
-- Извлекает фрагменты для цитирования и маппит их на главы/разделы диссертации
-- Анализирует библиографию источника и записывает reference gaps (ссылки, отсутствующие в нашей библиотеке)
-- Авто-резолвит ранее найденные reference gaps, если соответствующие источники уже добавлены
+- Создаёт vault-заметку `@citekey.md` (AI-аннотация: summary, методология, key references)
+- Извлекает фрагменты с классификацией **citation intent** (background / method / result_comparison)
+- Записывает reference gaps (ссылки из библиографий, отсутствующие в библиотеке)
+- Строит citation graph (все ссылки в `citation_links`)
+- Авто-генерирует embedding (если настроен embeddings backend)
 
 ```bash
-klemma process anderssonSeasonalArcticSea2021   # один источник
-klemma process                                  # все pending
+klemma process                                 # batch: все pending (3 потока)
+klemma process smithML2020 jonesNLP2019        # конкретные источники
+klemma process --serial                        # последовательно (экономия API)
 ```
 
-### `klemma research -s <X.X>`
-Исследовательский брифинг: глубокий анализ готовности раздела к написанию. Автоматически извлекает фрагменты для всех источников раздела (если ещё не извлечены), собирает контекст (черновик, план сессий, фрагменты, аннотации, покрытие) и генерирует структуру аргументации с планом цитирования.
-
-При повторном запуске работает в инкрементальном режиме: читает заметки пользователя из `## ✏️ Что нового`, определяет дельту (новые источники и фрагменты) и обновляет брифинг. Заметки пользователя архивируются в `## 📋 История изменений` с таймстампом.
+### `klemma embed [<citekey>]`
+Генерация SPECTER/OpenAI embeddings для семантического поиска. Без аргумента — backfill для всех completed-источников с abstract.
 
 ```bash
-klemma research -s 1.3.2            # первый запуск: полный анализ
-klemma research -s 1.3.2            # повторный: инкрементальное обновление
-klemma research -s 1.3.2 --force    # переизвлечь все фрагменты
-klemma research -s 1.3.2 --enrich   # добавить свежие статьи через MCP (если настроен)
+klemma embed                                   # все без embeddings
+klemma embed smithMachineLearning2020          # один источник
+klemma embed --dry-run                         # сколько будет обработано
+klemma embed --backend local                   # override бэкенда
+```
+
+### `klemma similar <citekey|section>`
+Семантический поиск похожих источников по embedding cosine similarity.
+
+```bash
+klemma similar smithML2020                     # похожие на этот источник
+klemma similar 2.3                             # близкие к центроиду раздела 2.3
+klemma similar smithML2020 -k 20               # top-20 результатов
+```
+
+При поиске по разделу показывает источники из **других** разделов, семантически близкие к данному — помогает обнаружить скрытые связи.
+
+### `klemma research -s <X.X>`
+Исследовательский брифинг: глубокий анализ готовности раздела к написанию. Автоматически извлекает фрагменты, собирает контекст (черновик, фрагменты, покрытие) и генерирует структуру аргументации с планом цитирования.
+
+При повторном запуске — инкрементальный режим: читает заметки пользователя из `## ✏️ Что нового`, определяет дельту и обновляет брифинг.
+
+```bash
+klemma research -s 1.3.2                       # первый запуск: полный анализ
+klemma research -s 1.3.2                       # повторный: инкрементальное обновление
+klemma research -s 1.3.2 --force               # переизвлечь все фрагменты
+```
+
+### `klemma outline`
+AI-генерация структуры проекта на основе файлов в директории, базы данных и KLEMMA.md. Инкрементальное обновление при повторном запуске.
+
+```bash
+klemma outline                                 # AI-генерация
+klemma outline -p "Фокус на KG-подходах"       # с директивой
+klemma outline --fresh                         # полная перегенерация
+klemma outline --scan-only                     # только сканировать файлы
 ```
 
 ### `klemma library [-s <X.X>] [--audit]`
 AI-анализ библиотеки. Три режима:
 
-- **status** (по умолчанию) — общее здоровье библиотеки: покрытие по главам, оценка качества, критические проблемы
-- **recommend** (`-s 2.3`) — рекомендации по чтению для конкретного раздела: порядок чтения, оценка имеющихся источников
-- **audit** (`--audit`) — глубокий аудит качества: дублирование, устаревшие источники, пробелы в методологии
-
-Отчёт сохраняется в vault (`Library/Library_{mode}_{date}.md`).
+- **status** (по умолчанию) — здоровье: покрытие, качество, проблемы
+- **recommend** (`-s 2.3`) — рекомендации по чтению для раздела
+- **audit** (`--audit`) — глубокий аудит: дублирование, устаревшие источники, пробелы в методологии, **co-citation analysis**, **author network**, prune-рекомендации
 
 ```bash
-klemma library              # здоровье библиотеки
-klemma library -s 2.3       # рекомендации для раздела 2.3
-klemma library --audit      # глубокий аудит
+klemma library                                 # здоровье
+klemma library -s 2.3                          # рекомендации для раздела
+klemma library --audit                         # глубокий аудит
+
+klemma library prune                           # просмотр prune-рекомендаций
+klemma library prune -v drop                   # только "drop" вердикты
+klemma library prune --clear smithML2020       # очистить вердикт
 ```
 
 ### `klemma ask "query"`
-Универсальный исследовательский агент. Запускает Claude Code в интерактивном режиме с полным контекстом диссертации: структура, источники, покрытие, пробелы, статистика фрагментов, план дня, очередь чтения. Claude получает доступ к инструментам (веб-поиск, файлы, bash) и сохраняет ответ в vault (`Agent/Agent_<date>.md`).
+Интерактивный исследовательский агент с полным контекстом проекта: структура, источники, покрытие, пробелы, фрагменты, outline. Ответы сохраняются в `project_root/`.
 
 ```bash
-klemma ask "Какие основные методы валидации прогнозов ледовой обстановки?"
+klemma ask "Какие основные методы валидации прогнозов?"
 klemma ask -s 1.3.2 "Найди статьи об AMSR2"
 klemma ask -ch 2 "Сравни архитектуры IceNet и ConvLSTM"
 ```
 
-### `klemma tools {add,list,remove,call}`
-Управление MCP-серверами. Klemma использует протокол [MCP](https://modelcontextprotocol.io) для подключения внешних инструментов (Zotero, arXiv, Semantic Scholar и др.).
-
-- **add** — зарегистрировать MCP-сервер (пишет в `config.yaml → mcp.servers`)
-- **list** — показать зарегистрированные серверы; `--probe` подключается и показывает доступные tools
-- **remove** — удалить сервер из конфига
-- **call** — прямой вызов инструмента (debug/power user)
+### `klemma acquire <url>`
+Скачивание PDF и регистрация в базе. Для bulk-импорта — `--batch` с JSON-файлом.
 
 ```bash
-klemma tools add zotero --command "uvx" --args "zotero-mcp" --env ZOTERO_LOCAL=true
-klemma tools add academia --command "python3" --args "-m academia_mcp --transport stdio"
-klemma tools list --probe
-klemma tools call zotero zotero_search_items '{"query": "ice forecast"}'
-klemma tools remove academia
+klemma acquire https://arxiv.org/pdf/2101.12345.pdf
+klemma acquire <url> --title "Paper" --authors "Smith, J." --year 2023
+klemma acquire --batch papers.json             # массовый импорт
+klemma acquire <url> --no-process              # не извлекать фрагменты
 ```
 
-### `klemma search "query"`
-Поиск статей через MCP-серверы (arXiv и др.). Требует зарегистрированный `academia` сервер. Результаты выводятся в таблице; можно добавить найденные в библиотеку.
+### `klemma info`
+Текущий проект: корневая директория, цепочка проектов, конфигурация, путь к БД.
 
-```bash
-klemma search "AMSR2 sea ice forecast"
-klemma search "neural ice prediction" --limit 10
-```
+### `klemma tree`
+Дерево вложенных проектов от текущего корня.
 
-### `klemma discover -s <X.X>`
-Hybrid discovery pipeline: автоматический поиск новых статей для раздела. Работает в два этапа:
-1. **Phase 1** (детерминированный): MCP-поиск по open reference gaps и ключевым словам раздела
-2. **Phase 2** (Claude): оценка релевантности найденного (relevance 1-5, usage type, priority)
-
-Результаты сохраняются в таблицу `discoveries` в SQLite; просмотр через `--review`.
-
-```bash
-klemma discover -s 1.3.2                # запуск pipeline
-klemma discover -s 1.3.2 --background   # запуск в фоне
-klemma discover --status                # статус фоновых процессов
-klemma discover --review                # просмотр и принятие/отклонение найденного
-```
+### `klemma migrate [--dry-run]`
+Миграция из старого формата (`~/.klemma/`) в per-directory проект. Разделяет конфиг на system (AI) и project (всё остальное), копирует context.md → KLEMMA.md.
 
 ### Backward-compatible aliases
 
-Старые имена команд работают как скрытые алиасы: `morning`→`plan`, `extract`→`process`, `agent`→`ask`, `stats`/`coverage`/`gaps`→`status`, `prepopulate`→`import`.
+Старые имена работают как скрытые алиасы: `morning`→`plan`, `extract`→`process`, `agent`→`ask`, `stats`/`coverage`/`gaps`→`status`, `prepopulate`→`import`.
 
 ## Конфигурация
 
-Файл `config.yaml` в корне проекта:
+Двухуровневая: system (`~/.klemma/config.yaml`) + project (`.klemma/config.yaml`). Вложенные проекты наследуют `obsidian`, `zotero`, `ai`, `embeddings` от родителя.
+
+### Системный конфиг (`~/.klemma/config.yaml`)
 
 ```yaml
 ai:
-  backend: "claude"          # "claude" (default) | "openai" | "litellm"
-  model: "opus"              # имя модели для выбранного бэкенда
-  max_pdf_chars: 50000       # максимум символов из PDF
-  timeout: 180               # таймаут на вызов AI (сек)
+  backend: "claude"            # "claude" (default) | "openai" | "litellm"
+  model: "opus"                # имя модели
+  timeout: 180                 # таймаут AI-вызова (сек)
   # base_url: "http://localhost:11434/v1"  # для Ollama/vLLM/LM Studio
-  # api_key_env: "OPENAI_API_KEY"          # имя env-переменной для API-ключа
-  # json_mode: false                       # структурированный JSON вывод
+  # api_key_env: "OPENAI_API_KEY"          # env-переменная для API-ключа
+```
 
+### Проектный конфиг (`.klemma/config.yaml`)
+
+```yaml
 obsidian:
   vault_path: "/path/to/vault"
-  notes_folder: "2 - Refs"   # папка с заметками источников
+  notes_folder: "2 - Refs"     # папка с заметками @citekey.md
   tags_folder: "3 - Tags"
 
 zotero:
-  library_json: "/path/to/pubs-bibtex.json"   # BetterBibTeX auto-export (для PDF lookup)
-  backend: "local"                             # "local" (default) | "mcp"
+  library_json: "/path/to/bbt-export.json"   # BetterBibTeX JSON auto-export
 
-mcp:                                           # MCP-серверы (управляются через klemma tools)
-  servers:
-    zotero:
-      command: "uvx"
-      args: ["zotero-mcp"]
-      env:
-        ZOTERO_LOCAL: "true"
-    academia:
-      command: "python3"
-      args: ["-m", "academia_mcp", "--transport", "stdio"]
+embeddings:
+  backend: "s2"                # "s2" (бесплатный S2 API) | "local" | "openai" | ""
+  # model: "specter2"          # имя модели (зависит от бэкенда)
+  # throttle: 3.1              # секунды между запросами к S2 API
+  # api_key_env: "OPENAI_API_KEY"  # для OpenAI бэкенда
 
-state:
-  db_path: "./data/klemma.db" # путь к SQLite базе
-
-dissertation:
-  current_chapter: 2
-  current_section: "2.3.1"
+project:
+  type: "dissertation"         # "dissertation" | "paper" | "thesis"
+  title: "Название работы"
   chapters:
-    1: "Analysis of ice forecasting domain"
-    2: "Geoinformation validation model"
-    3: "Validation methodology"
-    4: "Algorithm & software implementation"
-  chapter_mapping:            # regex → глава/раздел
+    1: "Литературный обзор"
+    2: "Методология"
+    3: "Результаты"
+  chapter_mapping:             # regex → глава/раздел
     - pattern: "icenet|ice.?net"
       chapter: 2
       section: "2.3.1"
   min_sources_per_section: 3
+
+state:
+  db_path: "./data/klemma.db"
 ```
 
-`zotero.library_json` — путь к BetterBibTeX JSON-экспорту. Используется для надёжного нахождения PDF по citekey. PDF ищутся в 3 этапа: прямой путь из БД → BetterBibTeX lookup (citekey → attachment path) → нечёткий поиск по имени файла в Zotero storage.
+`zotero.library_json` — путь к BetterBibTeX JSON-экспорту. PDF ищутся в 3 этапа: прямой путь из БД → BetterBibTeX lookup (citekey → attachment path) → нечёткий поиск по имени файла в Zotero storage.
+
+### Embedding-бэкенды
+
+| Бэкенд | Размерность | Стоимость | Требования |
+|--------|------------|-----------|------------|
+| `s2` | 768 (SPECTER) | Бесплатно | Интернет, throttle 3.1с |
+| `local` | 768 (SPECTER2) | Бесплатно | `klemma[local-embeddings]`, GPU рекомендуется |
+| `openai` | 1536 | Платно | `klemma[openai]`, API key |
+
+## Вложенные проекты
+
+Klemma поддерживает Git/NPM-style вложенность. Каждый проект — отдельная БД, но vault и Zotero наследуются от родителя.
+
+```
+thesis_dir/
+├── KLEMMA.md           # контекст диссертации
+├── .klemma/            # БД диссертации
+├── paper_ice/
+│   ├── KLEMMA.md       # контекст статьи (AI видит оба)
+│   └── .klemma/        # БД статьи (наследует vault/zotero)
+└── paper_climate/
+    ├── KLEMMA.md
+    └── .klemma/
+```
+
+```bash
+cd thesis_dir/paper_ice/
+klemma status                  # БД статьи, vault диссертации
+klemma info                    # показать цепочку проектов
+klemma tree                    # дерево вложенности
+```
 
 ## Формат заметок Obsidian
 
-Klemma читает YAML-фронтматтер заметок `@citekey.md`:
+Klemma создаёт и читает заметки `@citekey.md` с YAML-фронтматтером:
 
 ```yaml
 ---
-citekey: "anderssonSeasonalArcticSea2021"
-title: "Seasonal Arctic sea ice forecasting..."
-author: "Tom R. Andersson..."
-year: 2021
+citekey: "smithMachineLearning2020"
+title: "Machine Learning for NLP..."
+author: "John Smith..."
+year: 2020
 quality: 5
 priority: "high"
-chapter: 2                                    # основная глава
-section: "2.3.1"                              # основной раздел
-sections: [1.4.3, 2.2.2, 2.3.1, 3.2.1]      # все релевантные разделы
-chapters: [1, 2, 3]                           # все релевантные главы
-relevance_nr1: 5
-relevance_nr2: 4
-tags: ["Sea-Ice", "Machine-Learning"]
+chapter: 2
+section: "2.3.1"
+sections: [1.4.3, 2.2.2, 2.3.1]
+chapters: [1, 2, 3]
+tags: ["NLP", "Machine-Learning"]
 ---
 ```
 
-`chapter`/`section` — основной раздел (primary). `sections`/`chapters` — все разделы, в которых источник полезен. `klemma process` создаёт vault-заметки автоматически при обработке; `klemma research` находит источники по всем секциям.
+`chapter`/`section` — primary. `sections`/`chapters` — все релевантные. `klemma process` создаёт заметки автоматически.
 
 ## Архитектура
 
@@ -262,31 +318,24 @@ tags: ["Sea-Ice", "Machine-Learning"]
 klemma (CLI)
 ├── AI Provider ─────── AI-анализ (pluggable backend)
 │   ├── ClaudeClient ── Claude Code CLI (claude -p) — default
-│   ├── OpenAIClient ── OpenAI / Ollama / vLLM / LM Studio (openai SDK)
-│   ├── LiteLLMClient ─ 100+ провайдеров (litellm SDK)
-│   ├── планирование (plan)
-│   ├── извлечение фрагментов (process)
-│   ├── research briefing
-│   ├── library analysis (status/recommend/audit)
-│   ├── interactive agent (ask)
-│   └── discovery assessment (discover phase 2)
-├── MCP Tool Layer ─── plug-and-play внешние серверы
-│   ├── ToolRegistry → MCPClient → stdio transport
-│   ├── zotero-mcp ── Zotero library (search, metadata, fulltext)
-│   └── academia-mcp ─ arXiv, Semantic Scholar, web search
-├── LibraryProvider ── абстракция библиотеки (swappable backend)
-│   ├── LocalLibrary ─ BBT JSON файл (default)
-│   └── MCPLibrary ─── zotero-mcp server
-├── Obsidian vault ─── заметки источников + research notes + daily notes + library reports
+│   ├── OpenAIClient ── OpenAI / Ollama / vLLM / LM Studio
+│   └── LiteLLMClient ─ 100+ провайдеров (litellm SDK)
+├── Embeddings ──────── семантический поиск (pluggable backend)
+│   ├── SemanticScholar ─ S2 API (768-dim SPECTER, бесплатно)
+│   ├── LocalSPECTER ──── sentence-transformers (офлайн)
+│   └── OpenAI ─────────── text-embedding-3-small (1536-dim)
+├── LibraryProvider ── BBT JSON → citekey/PDF/metadata
+├── Obsidian vault ─── @citekey.md + research notes + reports
 ├── BetterBibTeX JSON ─ citekey → PDF path mapping
-├── Zotero storage ─── PDF файлы (fallback)
+├── Zotero storage ─── PDF файлы
 ├── PyMuPDF ────────── извлечение текста из PDF
 └── SQLite
-    ├── sources ─────────── Zotero entries, metadata, processing status
-    ├── source_sections ─── junction: source × section (multi-section)
-    ├── fragments ───────── citation fragments → chapter/section mapping
-    ├── reference_gaps ──── missing refs from bibliographies (score, auto-resolve)
-    ├── discoveries ─────── found papers (hybrid pipeline: MCP search + Claude assessment)
-    ├── daily_plans ─────── generated plans
-    └── reading_queue ───── prioritized reading list
+    ├── sources ─────────── записи Zotero (+ embedding BLOB, embedding_model)
+    ├── source_sections ─── source × section (multi-section)
+    ├── fragments ───────── фрагменты для цитирования (+ citation_intent)
+    ├── reference_gaps ──── пробелы из библиографий (+ citation_intent, intent scoring)
+    ├── citation_links ──── citation graph (source → target, intent, in_library)
+    ├── daily_plans ─────── сгенерированные планы
+    ├── reading_queue ───── очередь чтения
+    └── prune_verdicts ──── результаты аудита (drop/maybe)
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,7 @@ master ← feature/outline-command (merge first)
        ← modernize/phase-3-graph (Phase 3, after Sprint 1 merge, before Sprint 2 done)
        ← modernize/phase-4-mcp (Phase 4, after Sprint 2)
        ← modernize/phase-5-advanced (Phase 5, after all)
+       ← modernize/phase-6-sota (Phase 6, after Phase 4, can overlap Phase 5)
 ```
 
 Каждая фаза — отдельный PR. Внутри фазы — атомарные коммиты по шагам.
@@ -82,7 +83,7 @@ def _ensure_numpy():
 
 ---
 
-# Sprint 1: Citation Intent (Phase 0 + Phase 1)
+# Sprint 1: Citation Intent (Phase 0 + Phase 1) ✅ DONE
 
 **Ветка**: `modernize/phase-0-intents`
 **Цель**: Обогатить модель фрагментов citation intent, ввести intent-weighted scoring
@@ -269,7 +270,7 @@ def _ensure_numpy():
 
 ---
 
-# Sprint 2: SPECTER Embeddings (Phase 2)
+# Sprint 2: SPECTER Embeddings (Phase 2) ✅ DONE
 
 **Ветка**: `modernize/phase-2-embeddings` (после merge Sprint 1)
 **Цель**: Семантический поиск и scoring на базе document embeddings
@@ -437,7 +438,7 @@ def _ensure_numpy():
 
 ---
 
-# Sprint 3: Citation Graph (Phase 3)
+# Sprint 3: Citation Graph (Phase 3) ✅ DONE
 
 **Ветка**: `modernize/phase-3-graph` (после merge Sprint 1, может стартовать до окончания Sprint 2)
 **Цель**: Структурный анализ библиографического пространства
@@ -531,7 +532,7 @@ def _ensure_numpy():
 
 ---
 
-# Sprint 4: Minimal MCP (Phase 4)
+# Sprint 4: Minimal MCP (Phase 4) ✅ DONE
 
 **Ветка**: `modernize/phase-4-mcp` (после Sprint 2)
 **Цель**: Минимальная MCP-инфраструктура для extensibility демонстрации
@@ -602,6 +603,20 @@ def _ensure_numpy():
 **Что делать**:
 - При оценке кандидата передавать контрастные примеры: уже в библиотеке + отклонённые
 - Вопрос к LLM: "Добавляет ли кандидат УНИКАЛЬНУЮ ценность?"
+- SciFact-инспирированный structured verdict: `{support | extend | contrast}` — вместо бинарного "добавить/нет", LLM даёт обоснование через категорию вклада (Wadden 2020)
+
+**Тестирование**:
+- Unit: mock LLM → verify verdict parsing (support/extend/contrast)
+- Integration: `klemma library --audit` с контрастными примерами
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/skills/CLAUDE.md` (librarian/researcher verdict pattern), `prompts/CLAUDE.md` (обновлённые промпты)
+
+**Measurement**: verdict distribution → `klemma-paper/results/phase5_scifact_verdict.md`
+
+**Для статьи**: §4.4 + §5.3 — SciFact-inspired evaluation pattern
+
+**Git checkpoint**: `git commit -m "modernize: step 5.2 — contrastive eval with SciFact verdict"`
 
 ## Step 5.4: Semantic Gap Disambiguation
 
@@ -610,6 +625,15 @@ def _ensure_numpy():
 **Что делать**:
 - При >1 кандидате: SPECTER cosine → выбрать ближайшего
 - При 0 кандидатов + embeddings: fuzzy semantic match (threshold 0.85)
+
+**Тестирование**:
+- Unit: mock embeddings → verify disambiguation logic (>1 candidate, 0 candidates)
+- Unit: threshold 0.85 → edge cases
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/CLAUDE.md` (state.py resolve_gaps changes)
+
+**Git checkpoint**: `git commit -m "modernize: step 5.4 — semantic gap disambiguation"`
 
 ## Step 5.1: `klemma visualize`
 
@@ -620,12 +644,171 @@ def _ensure_numpy():
 - Citation graph: DOT export
 - Экспорт: HTML (plotly), PNG (matplotlib)
 
+**Тестирование**:
+- Unit: visualization data preparation с mock embeddings
+- Integration: `klemma visualize` → verify HTML/PNG output
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/CLAUDE.md` (новый visualization.py), `CLAUDE.md` root (новая команда `klemma visualize`), `tests/CLAUDE.md`
+
+**Для статьи**: Рис. 5 — embedding space visualization
+
+**Git checkpoint**: `git commit -m "modernize: step 5.1 — embedding/graph visualization"`
+
 ## Step 5.3: Citation Worthiness (`klemma check-draft`)
 
-**Файлы**: новый `src/klemma/skills/draft_checker.py`
+**Файлы**: новый `src/klemma/skills/draft_checker.py`, новый `prompts/check_draft.md`
 
 **Что делать**:
-- Читает черновик раздела → LLM находит утверждения без ссылок → рекомендует источники по embedding similarity
+- Dual mode: (a) citation worthiness — находит утверждения без ссылок, (b) claim verification — верифицирует утверждения по fragments
+- In-context learning: few-shot примеры из fragment DB (Dong 2024 — ICL survey)
+- Рекомендует источники по embedding similarity
+- Источники: Wadden 2020 (SciFact claim verification), Dong 2024 (ICL patterns)
+
+**Тестирование**:
+- Unit: mock LLM → verify worthiness detection + claim verification
+- Unit: ICL example selection from fragment DB
+- Integration: `klemma check-draft <section>` → human review
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/skills/CLAUDE.md` (новый draft_checker.py), `prompts/CLAUDE.md` (новый check_draft.md + переменные), `CLAUDE.md` root (команда `klemma check-draft`), `tests/CLAUDE.md`
+
+**Measurement**: worthiness precision + claim verification accuracy → `klemma-paper/results/phase5_claim_verification.md`
+
+**Для статьи**: §4.4 — citation worthiness + claim verification dual approach
+
+**Git checkpoint**: `git commit -m "modernize: step 5.3 — citation worthiness + claim verification"`
+
+---
+
+## Sprint 5 финализация
+
+**Документация**: final pass — обновить все CLAUDE.md line counts, sync `tests/CLAUDE.md`
+**Git**: `ruff check src/ tests/` → `python -m pytest tests/ -q` → PR `modernize/phase-5-advanced` → merge
+**Results**: записать в `klemma-paper/results/` (phase5_*.md файлы)
+
+---
+
+# Sprint 6: SOTA Integration (Phase 6)
+
+**Ветка**: `modernize/phase-6-sota`
+**Цель**: Интеграция SOTA методов из литературного анализа (16 источников, 2026-02-23)
+**НР**: НР1 + НР3 + §5 статьи
+**Зависимости**: Phase 2 (embeddings) + Phase 4 (MCP)
+
+**Источники**: Wang 2024 (MinerU), Lala 2023 (PaperQA), Singh 2023 (SciRepEval), Kinney 2025 (S2), Cachola 2020 (TLDR)
+
+## Step 6.1: MinerU PDF Backend (pluggable extractor)
+
+**Файлы**: `src/klemma/literature/pdf.py`, `src/klemma/config.py`
+
+**Что делать**:
+- Pluggable PDF extractor: PyMuPDF (fast, default) vs MinerU (quality, layout-aware)
+- Config: `processing.pdf_backend: "pymupdf" | "mineru"`
+- `_ensure_mineru()` lazy import pattern (как numpy)
+- Источник: Wang 2024 (MinerU — open-source PDF extraction with layout understanding)
+- НР1: quality improvement in extraction pipeline
+
+**Тестирование**:
+- Unit: mock MinerU → verify extraction interface compliance
+- Unit: fallback to PyMuPDF when MinerU unavailable
+- Integration: compare output PyMuPDF vs MinerU на 5 PDFs (A/B quality)
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/literature/CLAUDE.md` (pdf.py pluggable backend), `src/klemma/CLAUDE.md` (config.py new key `processing.pdf_backend`), `CLAUDE.md` root (new dependency `[mineru]`), `tests/CLAUDE.md`
+
+**Measurement**: extraction quality comparison (fragment count, structure preservation) → `klemma-paper/results/phase6_mineru_comparison.md`
+
+**Для статьи**: §3.3 — pluggable PDF pipeline, quality vs speed tradeoff
+
+**Git checkpoint**: `git commit -m "modernize: step 6.1 — MinerU pluggable PDF backend"`
+
+## Step 6.2: Fragment RAG для `klemma ask`
+
+**Файлы**: `src/klemma/state.py`, `src/klemma/skills/agent.py`
+
+**Что делать**:
+- Embed fragments (reuse EmbeddingProvider from Phase 2), store embedding BLOB in `fragments` table
+- `_migrate_schema()` version 4: `ALTER TABLE fragments ADD COLUMN embedding BLOB` + `embedding_model TEXT`
+- Semantic retrieval top-K fragments для agent context (вместо dump всех)
+- PaperQA pattern: focused context → better answers at lower cost
+- Источник: Lala 2023 (PaperQA — retrieval-augmented generative agent)
+- НР1 + scalability: context quality improves as library grows
+
+**Тестирование**:
+- Unit: fragment embedding save/retrieve roundtrip
+- Unit: top-K retrieval ranking (cosine similarity)
+- Unit: agent context building with RAG vs without (size comparison)
+- Integration: `klemma ask` with RAG → human review answer quality
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/CLAUDE.md` (state.py new methods + schema v4, agent.py RAG mode), `src/klemma/skills/CLAUDE.md` (agent.py description), `tests/CLAUDE.md`
+
+**Measurement**: context size reduction + response quality comparison → `klemma-paper/results/phase6_fragment_rag.md`
+
+**Для статьи**: §4.4 — RAG-based discovery, context focusing strategy
+
+**Git checkpoint**: `git commit -m "modernize: step 6.2 — fragment RAG for klemma ask"`
+
+## Step 6.3: Evaluation Framework (`klemma benchmark`)
+
+**Файлы**: новый `src/klemma/evaluation/` модуль, `src/klemma/cli.py`
+
+**Что делать**:
+- Annotated test set: 50 fragments (intent ground truth) + 20 gaps (relevance ground truth)
+- Метрики: intent accuracy, gap precision@10, embedding recall vs heuristic scoring
+- SciRepEval-инспирированный multi-format evaluation (Singh 2023)
+- Новая CLI команда: `klemma benchmark [--dataset path] [--metrics all|intent|gaps|embeddings]`
+- JSON output для reproducibility
+- **КРИТИЧЕСКИЙ для §5 статьи** — без evaluation framework нет доказательной базы
+
+**Тестирование**:
+- Unit: metric calculation functions (accuracy, precision@K, recall)
+- Unit: test set loading/validation
+- Unit: benchmark result serialization
+- Integration: `klemma benchmark` full run on annotated test set
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: создать `src/klemma/evaluation/CLAUDE.md` (new subsystem), обновить `CLAUDE.md` root (команда `klemma benchmark`, Module documentation link), `src/klemma/CLAUDE.md` (cli.py new command), `tests/CLAUDE.md`
+
+**Measurement**: baseline metrics on real data → `klemma-paper/results/phase6_evaluation_benchmark.md`
+
+**Для статьи**: §5 — evaluation methodology, reproducible benchmark results
+
+**Git checkpoint**: `git commit -m "modernize: step 6.3 — evaluation framework (klemma benchmark)"`
+
+## Step 6.4: S2 Recommendations + TLDR
+
+**Файлы**: `src/klemma/tools/specter_server.py`
+
+**Что делать**:
+- MCP tools: `recommend_papers(paper_id)` → S2 Recommendations API
+- MCP tools: `get_tldr(paper_id)` → TLDR extreme summarization
+- S2 Recommendation API: related papers based on citation graph (Kinney 2025)
+- TLDR: 1-sentence summaries для быстрого скрининга (Cachola 2020)
+- НР3: MCP extensibility демонстрация (6 tools total)
+
+**Тестирование**:
+- Unit: mock S2 API → verify recommend_papers output
+- Unit: mock S2 API → verify get_tldr output
+- Integration: MCP server with 6 tools (4 existing + 2 new)
+- `python -m pytest tests/ -q` && `ruff check src/ tests/`
+
+**Документация**: обновить `src/klemma/CLAUDE.md` (tools/ section — 6 tools total), `tests/CLAUDE.md` (test_mcp.py updates)
+
+**Measurement**: recommendation relevance (human eval 10 papers) → `klemma-paper/results/phase6_s2_recommendations.md`
+
+**Для статьи**: §3.5 — MCP tool ecosystem growth, S2 API integration depth
+
+**Git checkpoint**: `git commit -m "modernize: step 6.4 — S2 recommendations + TLDR"`
+
+---
+
+## Sprint 6 финализация
+
+**Документация**: final pass — обновить все CLAUDE.md line counts, sync `tests/CLAUDE.md`, обновить ROADMAP.md
+**Git**: `ruff check src/ tests/` → `python -m pytest tests/ -q` → PR `modernize/phase-6-sota` → merge
+**Results**: consolidated summary → `klemma-paper/results/summary.md`
 
 ---
 
@@ -652,6 +835,12 @@ klemma-paper/results/
 ├── phase3_graph_analysis.md
 ├── phase3_author_network.md
 ├── phase4_intent_accuracy.md
+├── phase5_scifact_verdict.md
+├── phase5_claim_verification.md
+├── phase6_mineru_comparison.md
+├── phase6_fragment_rag.md
+├── phase6_evaluation_benchmark.md
+├── phase6_s2_recommendations.md
 └── summary.md               — consolidated results table
 ```
 
@@ -689,7 +878,11 @@ paper_sections: ["§4.1", "§5.2"]
 | 3.1-3.3 | §4.2 + §5.2 | Citation graph stats, co-citation analysis |
 | 4.0-4.2 | §3.5 (MCP) + §5.3 | MCP architecture, intent validation |
 | 5.1 | Рис. 5 (new figure) | Embedding space visualization |
-| 5.3 | §4.4 | Citation worthiness examples |
+| 5.2-5.3 | §4.4 + §5.3 | SciFact-inspired verdict, claim verification, ICL |
+| 6.1 | §3.3 (PDF pipeline) | Pluggable extractor A/B comparison (PyMuPDF vs MinerU) |
+| 6.2 | §4.4 (discovery) | Fragment RAG vs full context — quality + cost comparison |
+| 6.3 | §5 (evaluation) | Multi-format benchmark, baseline metrics, reproducibility |
+| 6.4 | §3.5 (MCP) | S2 Recommendations + TLDR integration, tool ecosystem growth |
 
 ---
 
@@ -697,7 +890,7 @@ paper_sections: ["§4.1", "§5.2"]
 
 ## Git Checkpoint After EVERY Step
 
-После КАЖДОГО шага (0.0, 0.1, 0.2, ... 5.3) — обязательный git checkpoint:
+После КАЖДОГО шага (0.0, 0.1, 0.2, ... 6.4) — обязательный git checkpoint:
 ```bash
 git add -A
 git commit -m "modernize: step X.Y — <description>"
@@ -711,8 +904,9 @@ git push origin <branch>
 2. `python -m pytest tests/ -q` — all tests pass
 3. `klemma status` — works with new features on real project
 4. Results file committed to klemma-paper/results/
-5. Commit + push sprint branch
-6. PR review
+5. Update all CLAUDE.md files (line counts, new modules, new commands, new tests)
+6. Commit + push sprint branch
+7. PR review
 
 ## End-to-End Validation (after all sprints)
 
@@ -725,15 +919,17 @@ git push origin <branch>
 
 ## Key Metrics to Track Across All Sprints
 
-| Metric | Baseline | After Phase 0+1 | After Phase 2 | After Phase 3 |
-|--------|----------|-----------------|---------------|---------------|
-| Fragment fields | 7 | 8 (+intent) | 8 | 8 |
-| Gap scoring formula | count×quality×section | +intent_weight | +semantic | +graph |
-| Discovery method | keyword only | +intent-aware | +hybrid embedding | +co-citation |
-| DB tables | 7 | 7 | 7 | 8 (+citation_links) |
-| DB schema version | 0 | 1 | 2 | 3 |
-| Test files | 4 | 5 (+intent) | 6 (+embeddings) | 7 (+graph) |
-| LOC | 8,387 | TBD | TBD | TBD |
+| Metric | Baseline | After Phase 0+1 | After Phase 2 | After Phase 3 | After Phase 4 | After Phase 5 | After Phase 6 |
+|--------|----------|-----------------|---------------|---------------|---------------|---------------|---------------|
+| Fragment fields | 7 | 8 (+intent) | 8 | 8 | 8 | 8 | 8 (+frag embedding) |
+| Gap scoring formula | count×quality×section | +intent_weight | +semantic | +graph | +S2 validation | +contrastive+worthiness | +RAG ranking |
+| Discovery method | keyword only | +intent-aware | +hybrid embedding | +co-citation | +MCP tools | +visualization+check-draft | +RAG+S2 recs |
+| DB tables | 7 | 7 | 7 | 8 (+citation_links) | 8 | 8 | 8 |
+| DB schema version | 0 | 1 | 2 | 3 | 3 | 3 | 4 (+frag embedding) |
+| Test files | 4 | 5 (+intent) | 6 (+embeddings) | 7 (+graph) | 8 (+mcp) | 9+ | 11+ |
+| CLI commands | 12 | 12 | 14 (+embed, similar) | 14 | 14 | 16 (+visualize, check-draft) | 17 (+benchmark) |
+| MCP tools | 0 | 0 | 0 | 0 | 4 | 4 | 6 (+recommend, tldr) |
+| LOC | 8,387 | TBD | TBD | TBD | TBD | TBD | TBD |
 
 ---
 
@@ -748,6 +944,10 @@ git push origin <branch>
 | Dimension mismatch between embedding backends | MEDIUM | Store embedding_model in DB, reject cross-model cosine |
 | Sprint 2+3 merge conflicts in note_factory.py | LOW | Sprint 3 starts after Sprint 1 merge, coordinates with Sprint 2 on note_factory |
 | MCP SDK API changes since removal | LOW | Write fresh, not restore; mcp as optional dep |
+| MinerU dependency size (heavy ML model) | MEDIUM | Optional extra `[mineru]`, lazy import, fallback to PyMuPDF |
+| Evaluation dataset creation effort | MEDIUM | Start with 50 fragments MVP, grow iteratively; focus on intent + gaps |
+| Fragment RAG context window limits | LOW | Top-K with configurable K, fallback to summary mode |
+| S2 API authentication changes | LOW | Monitor S2 API status, graceful degradation if unavailable |
 
 ---
 
@@ -774,7 +974,11 @@ Sprint 4 (Phase 4): ~5 days (after Sprint 2)
 
 Sprint 5 (Phase 5): ~7-10 days (stretch goals, after all)
   5.2 → 5.4 → 5.1 → 5.3
-  PR → merge
+  Documentation update + PR → merge
+
+Sprint 6 (Phase 6): ~11 days (after Phase 4, can overlap Phase 5)
+  6.1 → 6.2 → 6.3 → 6.4
+  Documentation update + PR → merge
 ```
 
-**Total estimate**: ~30-38 days (including buffer for Sprint 5)
+**Total estimate**: ~41-49 days (including buffer for Sprints 5+6)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,483 @@
+# Klemma: Руководство пользователя
+
+## 1. Введение
+
+Klemma — AI-ассистент для академического письма. Он автоматизирует рутинную работу с литературой: извлекает цитируемые фрагменты из PDF, классифицирует их по типу (фон, метод, результат), отслеживает покрытие разделов источниками, находит пробелы в библиографии, ищет семантически похожие работы и генерирует исследовательские брифинги.
+
+**Для кого**: PhD-студенты, исследователи, научные работники — все, кто работает с большим количеством источников при написании диссертации, статьи или монографии.
+
+**Ключевые возможности**:
+- Автоматическое извлечение фрагментов из PDF с классификацией citation intent
+- Отслеживание покрытия глав/разделов источниками
+- Семантический поиск похожих источников (SPECTER embeddings)
+- Reference gap detection — какие ссылки из библиографий отсутствуют в вашей библиотеке
+- Citation graph analysis — кто кого цитирует, co-citation, author network
+- AI-powered research briefings, библиотечный аудит, ежедневное планирование
+- Вложенные проекты (диссертация + отдельные статьи)
+
+**Как работает**: Zotero (библиотека) → BetterBibTeX (JSON-экспорт) → klemma (AI-анализ PDF) → SQLite (фрагменты, статистика) + Obsidian vault (заметки).
+
+---
+
+## 2. Установка и настройка
+
+### 2.1 Требования
+
+- **Python 3.11+**
+- **Zotero** с плагином [BetterBibTeX](https://retorque.re/zotero-better-bibtex/) — для автоматического JSON-экспорта библиотеки
+- **Obsidian** vault — хранение заметок по источникам и отчётов
+- **AI-бэкенд** — Claude Code CLI (по умолчанию), или OpenAI/Ollama/LiteLLM
+
+### 2.2 Установка
+
+```bash
+pip install -e .                          # базовая
+pip install -e ".[embeddings]"            # + семантический поиск (рекомендуется)
+pip install -e ".[openai]"               # + OpenAI/Ollama бэкенд
+pip install -e ".[local-embeddings]"     # + офлайн SPECTER2
+```
+
+### 2.3 Настройка BetterBibTeX
+
+1. В Zotero: Edit → Preferences → Better BibTeX → Automatic Export
+2. Добавить экспорт: формат **Better CSL JSON**, путь — запомнить (например `~/Zotero/library.json`)
+3. Автообновление: "On Change"
+
+Этот файл klemma использует для поиска PDF по citekey.
+
+### 2.4 Инициализация проекта
+
+```bash
+cd ~/research/my-thesis/
+klemma init
+```
+
+Мастер задаст вопросы:
+- Тип проекта (dissertation / paper / thesis)
+- Путь к Obsidian vault (обнаруживается автоматически)
+- Путь к BetterBibTeX JSON
+- AI-бэкенд
+
+Создаётся:
+```
+my-thesis/
+├── KLEMMA.md          # контекст проекта для AI (редактируемый)
+└── .klemma/
+    ├── config.yaml    # конфигурация
+    ├── tags.yaml      # таксономия тегов
+    └── data/
+        └── klemma.db  # SQLite база
+```
+
+### 2.5 KLEMMA.md — контекст для AI
+
+Файл `KLEMMA.md` в корне проекта описывает ваше исследование для AI. Чем лучше заполнен, тем точнее результаты.
+
+```markdown
+# Моё исследование
+
+## Тема
+Валидация нейросетевых прогнозов ледовой обстановки
+
+## Структура
+- Глава 1: Анализ предметной области
+  - 1.1 Спутниковые данные (AMSR2, SMOS)
+  - 1.2 Существующие модели (IceNet, SEAS5)
+- Глава 2: Методология валидации
+  ...
+
+## Научные результаты
+- НР1: Модель валидации прогнозов (RMSE, skill score)
+- НР2: Сравнительный анализ нейросетей vs физических моделей
+
+## Текущий фокус
+Раздел 2.3 — архитектура IceNet и её модификации
+```
+
+### 2.6 Настройка embeddings (рекомендуется)
+
+Добавьте в `.klemma/config.yaml`:
+
+```yaml
+embeddings:
+  backend: "s2"       # бесплатный Semantic Scholar API
+```
+
+Это включает семантический поиск (`similar`), гибридное обнаружение источников и semantic gap scoring. Бэкенды:
+
+| Бэкенд | Стоимость | Требования | Качество |
+|--------|-----------|------------|----------|
+| `s2` | Бесплатно | Интернет | Хорошее (SPECTER 768-dim) |
+| `local` | Бесплатно | GPU, `[local-embeddings]` | Хорошее (SPECTER2) |
+| `openai` | Платно | API key, `[openai]` | Отличное (1536-dim) |
+
+---
+
+## 3. Основные понятия
+
+### Sources (источники)
+Записи из Zotero. Каждый источник проходит пайплайн: `pending` → `processing` → `completed`. При обработке извлекаются фрагменты и создаётся vault-заметка.
+
+### Fragments (фрагменты)
+Цитируемые отрывки из PDF, привязанные к главам/разделам. Каждый фрагмент имеет:
+- **citation_intent**: `background` (фон), `method` (методология), `result_comparison` (сравнение результатов)
+- **relevance** (1-5): насколько релевантен разделу
+- **section**: к какому разделу привязан
+
+### Coverage (покрытие)
+Количество источников на раздел. Минимальный порог задаётся в config (`min_sources_per_section: 3`). Разделы с недостаточным покрытием выделяются красным в `klemma status`.
+
+### Reference Gaps
+Ссылки из библиографий обработанных источников, отсутствующие в вашей библиотеке. Scoring учитывает citation intent:
+- **method** gaps: вес 3x (критичные — методология не покрыта)
+- **result_comparison** gaps: вес 2x (важные — нечем сравнивать)
+- **background** gaps: вес 1x (желательно, но не критично)
+
+### Embeddings
+Числовые векторы (768 или 1536 измерений), представляющие содержание статьи. Используются для поиска семантически похожих работ, даже если у них нет общих ключевых слов.
+
+### Citation Graph
+Кто кого цитирует. Строится автоматически при `process` из key_references аннотации. Позволяет анализировать co-citation (какие работы часто цитируются вместе) и author network.
+
+---
+
+## 4. Рабочие процессы
+
+### 4.1 Добавление источников
+
+**Основной путь** — через Zotero:
+1. Добавляете PDF в Zotero (вручную, через browser connector, или импортом)
+2. BetterBibTeX автоматически обновляет JSON-экспорт
+3. Источник появляется в klemma при следующей команде
+
+**Быстрое добавление** — через CLI:
+```bash
+klemma acquire https://arxiv.org/pdf/2101.12345.pdf
+klemma acquire <url> --title "Title" --authors "Smith, J." --year 2023 --section 2.3
+```
+
+**Массовый импорт**:
+```bash
+klemma acquire --batch papers.json
+```
+
+### 4.2 Обработка источников
+
+Обработка — главная операция klemma. Превращает PDF в структурированные данные.
+
+```bash
+# Обработать все pending (рекомендуется — параллельно, 3 потока)
+klemma process
+
+# Один конкретный источник
+klemma process smithMachineLearning2020
+
+# Последовательно (при лимитах API)
+klemma process --serial
+```
+
+**Что происходит при `process`**:
+1. Находит PDF (BBT lookup → Zotero storage → fuzzy search)
+2. Извлекает текст (PyMuPDF, до 50K символов)
+3. AI-анализ: scaffold prompting → фрагменты с citation intent → vault note
+4. Сохраняет фрагменты в SQLite
+5. Создаёт `@citekey.md` в Obsidian (summary, methodology, key references)
+6. Записывает reference gaps + citation links
+7. Генерирует embedding (если настроен бэкенд)
+
+**Совет**: обрабатывайте пакетами (накопите 5-10 источников, затем `klemma process`).
+
+### 4.3 Отслеживание прогресса
+
+```bash
+# Быстрая проверка
+klemma status
+```
+
+Показывает:
+- Обработано / pending / failed источников
+- Покрытие по главам (цветовая индикация)
+- Разделы с недостаточным покрытием
+- Топ reference gaps
+
+```bash
+# Детальная аналитика
+klemma status --verbose
+```
+
+Дополнительно показывает:
+- **Intent coverage matrix** — распределение background/method/result по разделам. Если раздел 2.3 имеет 0 method-фрагментов, значит методология не покрыта цитатами
+- **Embedding stats** — сколько источников имеют embeddings
+- **Citation graph stats** — количество цитатных связей, наиболее цитируемые внешние работы
+
+```bash
+# Фокус на одной главе
+klemma status --chapter 2
+```
+
+### 4.4 Работа с разделом
+
+Когда нужно написать конкретный раздел:
+
+```bash
+# 1. Глубокий анализ раздела
+klemma research -s 2.3.1
+```
+
+Генерирует research briefing:
+- Структура аргументации
+- План цитирования (какой фрагмент куда)
+- Пробелы и рекомендации
+- Связи между источниками
+
+**Инкрементальный режим**: после первого запуска briefing сохраняется в `project_root/`. При повторном запуске:
+
+1. Откройте файл, добавьте заметки в секцию `## ✏️ Что нового`
+2. Запустите `klemma research -s 2.3.1` снова
+3. Klemma определит дельту (новые источники/фрагменты) и обновит briefing
+4. Ваши заметки архивируются в `## 📋 История изменений`
+
+```bash
+# Принудительно переизвлечь все фрагменты
+klemma research -s 2.3.1 --force
+```
+
+### 4.5 Анализ библиотеки
+
+Три режима — от быстрого до глубокого:
+
+```bash
+# Общее здоровье
+klemma library
+```
+Покрытие, качество, критические проблемы.
+
+```bash
+# Рекомендации для раздела
+klemma library -s 2.3
+```
+Порядок чтения, оценка источников, что добавить.
+
+```bash
+# Глубокий аудит
+klemma library --audit
+```
+Полный анализ:
+- Дублирование и устаревшие источники
+- Пробелы в методологии
+- **Co-citation analysis**: какие работы часто цитируются вместе
+- **Author network**: исследовательские группы (авторы с 2+ работами)
+- **Prune рекомендации**: что можно убрать
+
+Просмотр prune-рекомендаций:
+```bash
+klemma library prune               # все рекомендации
+klemma library prune -v drop       # только "drop"
+klemma library prune -c 2          # для главы 2
+klemma library prune --clear key   # отменить рекомендацию
+```
+
+### 4.6 Семантический поиск
+
+Требует настроенный `embeddings.backend`.
+
+```bash
+# 1. Сгенерировать embeddings (один раз, потом инкрементально)
+klemma embed
+klemma embed --dry-run             # сколько будет обработано
+
+# 2. Найти похожие на конкретный источник
+klemma similar smithML2020
+```
+
+Результат — таблица с cosine similarity. Помогает найти работы, которые не поймал keyword-поиск.
+
+```bash
+# 3. Найти источники для раздела
+klemma similar 2.3
+```
+
+Вычисляет "центроид" раздела (среднее embedding всех привязанных источников) и ищет **похожие источники из других разделов**. Обнаруживает скрытые связи — например, статья привязана к главе 1, но семантически близка к разделу 3.2.
+
+**Гибридный поиск**: при обработке (`process`) и research-брифингах klemma автоматически комбинирует keyword-поиск (40%) + semantic similarity (60%).
+
+### 4.7 Структура проекта (outline)
+
+```bash
+# Первый запуск — AI генерирует outline из файлов + базы
+klemma outline
+
+# С директивой
+klemma outline -p "Акцент на экспериментальной части"
+
+# Полная перегенерация
+klemma outline --fresh
+```
+
+Инкрементальный режим работает аналогично `research`: добавьте заметки в `## ✏️ Что нового`, запустите повторно.
+
+### 4.8 Интерактивный агент
+
+Для сложных вопросов, требующих контекста:
+
+```bash
+klemma ask "Какие статьи используют SPECTER embeddings для citation recommendation?"
+klemma ask -s 2.3 "Сравни подходы к валидации в моих источниках"
+klemma ask -ch 1 "Найди пробелы в литературном обзоре"
+```
+
+Агент получает полный контекст проекта (outline, источники, фрагменты, покрытие, пробелы) и может использовать инструменты (веб-поиск, файлы). Ответы сохраняются в `project_root/`.
+
+---
+
+## 5. Продвинутые возможности
+
+### 5.1 Вложенные проекты
+
+Для диссертации с отдельными статьями:
+
+```bash
+cd ~/research/my-thesis/
+klemma init                         # диссертация
+
+cd paper_ice/
+klemma init --type paper            # статья (наследует vault/zotero)
+```
+
+Статья использует свою БД, но vault и Zotero диссертации. AI видит контекст обоих проектов.
+
+```bash
+klemma info                         # project chain
+klemma tree                         # дерево вложенности
+```
+
+### 5.2 AI-бэкенды
+
+```yaml
+# Claude (по умолчанию) — лучший анализ
+ai:
+  backend: "claude"
+
+# OpenAI
+ai:
+  backend: "openai"
+  model: "gpt-4o"
+  api_key_env: "OPENAI_API_KEY"
+
+# Ollama (локально)
+ai:
+  backend: "openai"
+  base_url: "http://localhost:11434/v1"
+  model: "llama3.1"
+
+# LiteLLM (100+ провайдеров)
+ai:
+  backend: "litellm"
+  model: "anthropic/claude-sonnet-4-20250514"
+```
+
+### 5.3 Кастомные промпты
+
+Промпты можно переопределить на уровне проекта или системы:
+
+```
+.klemma/prompts/extract.md          # переопределение для проекта
+~/.klemma/prompts/extract.md        # переопределение глобально
+```
+
+Доступные шаблоны: `extract.md`, `annotate.md`, `morning.md`, `research.md`, `research_incremental.md`, `librarian.md`, `agent.md`, `outline.md`, `outline_incremental.md`.
+
+### 5.4 MCP-сервер для embeddings
+
+Klemma включает SPECTER MCP-сервер для интеграции embeddings с другими инструментами:
+
+```bash
+pip install klemma[mcp]
+python -m klemma.tools.specter_server           # S2 бэкенд
+python -m klemma.tools.specter_server --local   # локальный SPECTER2
+```
+
+Предоставляет MCP tools: `embed_paper`, `find_similar`, `batch_embed`, `get_citation_intents`.
+
+---
+
+## 6. Рекомендуемый ежедневный workflow
+
+### Утро
+```bash
+klemma plan                         # план на день
+```
+
+### Работа с разделом
+```bash
+klemma research -s 2.3.1            # briefing
+# ... пишете текст, добавляете заметки ...
+klemma research -s 2.3.1            # инкрементальное обновление
+```
+
+### Добавление источников
+```bash
+# Добавляете PDF в Zotero...
+klemma process                      # обработать pending
+klemma embed                        # сгенерировать embeddings
+```
+
+### Конец дня
+```bash
+klemma status                       # проверить прогресс
+klemma similar 2.3                  # обнаружить связи
+```
+
+### Еженедельно
+```bash
+klemma library --audit              # аудит библиотеки
+klemma library prune                # просмотреть рекомендации
+klemma outline                      # обновить структуру
+```
+
+---
+
+## 7. Решение проблем
+
+### PDF не найден
+
+1. Обновлён ли BetterBibTeX JSON-экспорт? (проверить дату файла)
+2. Правильный ли `zotero.library_json` в config?
+3. PDF ищется в 3 этапа: прямой путь → BBT lookup → fuzzy search в Zotero storage
+4. Попробуйте `klemma process <citekey>` для конкретного источника — покажет путь поиска
+
+### Embeddings не работают
+
+1. Установлен ли `pip install klemma[embeddings]`?
+2. Настроен ли `embeddings.backend` в config?
+3. `s2` бэкенд: проверьте интернет-соединение (S2 API может быть rate-limited)
+4. `local` бэкенд: установлен ли `klemma[local-embeddings]`?
+5. `openai` бэкенд: задан ли `OPENAI_API_KEY`?
+6. `klemma embed --dry-run` — проверить, сколько источников готово к embedding
+
+### Источник в статусе "failed"
+
+```bash
+klemma status --verbose            # проверить error_message
+```
+
+Частые причины:
+- PDF повреждён или защищён паролем
+- AI-бэкенд недоступен (проверьте `claude --version` или API key)
+- Timeout: увеличьте `ai.timeout` в config (по умолчанию 180 сек)
+- Слишком короткий PDF: порог `processing.min_pdf_length: 500` символов
+
+### Низкое покрытие раздела
+
+1. `klemma status -ch N --verbose` — какие разделы проблемные
+2. `klemma research -s X.X` — AI найдёт пробелы
+3. `klemma library -s X.X` — рекомендации что добавить
+4. `klemma similar X.X` — семантически похожие из других разделов
+5. Reference gaps table — какие работы цитируют ваши источники, но их нет в библиотеке
+
+### Вложенные проекты не работают
+
+1. Родительская директория имеет `.klemma/`?
+2. `obsidian.vault_path` настроен в родителе?
+3. `klemma info` — проверить project chain
+4. `klemma tree` — визуализация структуры

--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -12,6 +12,7 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 | `research.md` | `skills/researcher.py` | Research briefing (initial) |
 | `research_incremental.md` | `skills/researcher.py` | Research briefing (incremental) |
 | `librarian.md` | `skills/librarian.py` | Library analysis (3 modes) |
+| `librarian_prune.md` | `skills/librarian.py` | Prune recommendation generation |
 | `agent.md` | `skills/agent.py` | System prompt for interactive agent |
 | `outline.md` | `skills/outliner.py` | Project outline generation |
 | `outline_incremental.md` | `skills/outliner.py` | Incremental outline update |
@@ -32,6 +33,9 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 
 ### librarian.md
 `mode`, `dissertation_context`, `library_summary`, `quality_tiers`, `ref_gaps`, `sources_compact`, `focus_section`, `deadline`, `days_until_deadline`
+
+### librarian_prune.md
+`source_count`, `sources_compact`
 
 ### agent.md
 `dissertation_context`, `chapters`, `scientific_results`, `priority_terms`, `current_chapter`, `chapter_name`, `current_section`, `current_deadline`, `days_until_deadline`, `sources`, `coverage`, `gaps`, `min_sources`, `fragment_stats`, `today_plan`, `next_reading`, `vault_path`, `today`, `project_root`, `outline_content`, `report_index` (list of {name, size}), `project_file_list` (list of {name, size})

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -4,21 +4,21 @@ Foundation layer: config, state, AI providers, vault, library abstraction, CLI e
 
 ## Modules
 
-### cli.py (~1890 lines)
-Click CLI entry point. Defines 11 commands + hidden aliases.
+### cli.py (2274 lines)
+Click CLI entry point. Defines 14 commands + hidden aliases.
 - `_init_components(config_path)` — creates `KlemmaContext` via Git-style project discovery
 - `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
-- Commands: `init`, `plan`, `status`, `process`, `acquire`, `research`, `library`, `ask`, `info`, `tree`, `migrate`
+- Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `outline`, `ask`, `info`, `tree`, `migrate`
 
-### context.py (~42 lines)
+### context.py (41 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.
-Holds: `config`, `state`, `vault`, `ai` (optional), `library` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`.
+Holds: `config`, `state`, `vault`, `ai` (optional), `embeddings` (optional), `library` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`.
 
-### config.py (~630 lines)
+### config.py (635 lines)
 Pydantic config models + Git-style project discovery.
-Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `DissertationConfig`, `SystemConfig`, `ProjectConfig`.
+Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `EmbeddingsConfig`, `DissertationConfig`, `SystemConfig`, `ProjectConfig`.
 - `discover_project_root(start)` — traverse up from cwd to find nearest `.klemma/`
 - `discover_project_chain(start)` — find all project roots child-first, max depth 3
 - `resolve_effective_config(project_chain, config_override)` — merge: system < parent < child < CLI override
@@ -29,27 +29,31 @@ Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `Disse
 - `resolve_prompt(name, klemma_home, project_chain?)` — 4-level: project → parent → system → shipped
 - `scan_project_files(project_root, max_chars?)` — scan .md/.tex/.bib/.txt files, returns [{name, path, size, content_preview}]
 - `update_project_config(project_root, updates)` — merge updates into .klemma/config.yaml project section
-- Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai"}` from parent projects
+- Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai", "embeddings"}` from parent projects
 
-### setup.py (~134 lines)
-`klemma init` logic — creates per-directory `.klemma/` projects and `~/.klemma/` system config.
+### setup.py (263 lines)
+`klemma init` logic — creates per-directory `.klemma/` projects and `~/.klemma/` system config. Interactive wizard with auto-discovery.
 - `init_project(project_dir, project_type)` — creates `.klemma/`, `KLEMMA.md`, updates `.gitignore`
 - `init_system(system_home)` — creates `~/.klemma/config.yaml` (AI defaults only)
 - `init_klemma_home()` — legacy alias for `init_system()`
+- Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`
 
-### state.py (1207 lines)
-SQLite state manager. Tables:
-- `sources` — Zotero entries (citekey, title, status, chapter, quality, pdf_path)
+### state.py (1599 lines)
+SQLite state manager. Schema versioned via `PRAGMA user_version` (currently v3), auto-migrates via `_migrate_schema()`.
+
+Tables:
+- `sources` — Zotero entries (citekey, title, status, chapter, quality, pdf_path, `embedding` BLOB float32, `embedding_model` TEXT)
 - `source_sections` — junction table: source_id × section (multi-section support)
-- `fragments` — extracted citation fragments (text, type, chapter, section, relevance, page)
-- `reference_gaps` — missing references from bibliographies (status: open/resolved, score)
+- `fragments` — extracted citation fragments (text, type, chapter, section, relevance, page, `citation_intent`: background/method/result_comparison)
+- `reference_gaps` — missing references from bibliographies (status: open/resolved, score, `citation_intent`, intent-weighted scoring)
+- `citation_links` — citation graph: source_id → target (title_hash MD5 for dedup, citation_intent, in_library flag)
 - `daily_plans` — generated daily plans
 - `reading_queue` — prioritized reading list
-- `prune_verdicts` — librarian audit results
+- `prune_verdicts` — librarian audit results (drop/maybe with reason)
 
-Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`), `get_coverage_stats()`, `get_gap_summary()`, `save_plan()`.
+Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`), `get_coverage_stats()`, `get_gap_summary()`, `save_plan()`, `save_citation_links()`, `get_citation_graph()`, `save_embedding()`, `get_embeddings()`, `save_prune_verdicts()`, `get_prune_verdicts()`.
 
-### ai.py (243 lines)
+### ai.py (249 lines)
 `AIProvider` protocol → `AIProviderBase` → `ClaudeClient` + `create_ai()` factory.
 - `AIProvider.call()` / `call_json()` — main interface for AI calls
 - `AIProviderBase.render_prompt()` — Jinja2 template rendering
@@ -57,24 +61,47 @@ Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`
 - `ClaudeClient` — subprocess wrapper for `claude -p --model <model>`
 - Retry logic with configurable timeout
 
-### ai_openai.py (103 lines)
+### ai_openai.py (105 lines)
 `OpenAIClient` — wraps OpenAI Python SDK. Supports structured JSON mode (`response_format`).
 Works with: OpenAI, Ollama, vLLM, LM Studio (via `base_url`).
 
-### ai_litellm.py (67 lines)
+### ai_litellm.py (70 lines)
 `LiteLLMClient` — thin wrapper around `litellm.completion()`. Model format: `provider/model`.
 
-### vault.py (250 lines)
+### vault.py (249 lines)
 `VaultAdapter` — Obsidian vault file I/O.
 - `read_note()` / `write_note()` — file read/write
 - `update_section()` — replace content between markdown heading markers
 - `get_properties()` — parse YAML frontmatter
 - `list_notes()` — enumerate vault notes
 
-### library_provider.py (195 lines)
+### library_provider.py (86 lines)
 `LibraryProvider` protocol with LocalLibrary backend:
 - `LocalLibrary` — wraps `PDFExtractor.load_entry_lookup()` (BBT JSON)
 - `create_library(config)` — factory, creates LocalLibrary from config
+
+### embeddings.py (257 lines)
+`EmbeddingProvider` runtime-checkable protocol + 3 backends + utilities.
+- `EmbeddingProvider` protocol — `dim`, `model_name`, `embed(title, abstract) → list[float] | None`
+- `SemanticScholarEmbeddings` — free S2 API (768-dim SPECTER), rate-limited (throttle param)
+- `LocalSPECTEREmbeddings` — offline sentence-transformers SPECTER2 model
+- `OpenAIEmbeddings` — text-embedding-3-small (1536-dim)
+- `create_embeddings(config)` — factory, returns provider or None if disabled
+- `cosine_similarity(a, b)` — dot-product cosine similarity for float vectors
+
+### discovery.py (260 lines)
+Auto-discovery for `klemma init` interactive wizard.
+- `discover_obsidian_vaults()` — find Obsidian vaults on disk
+- `discover_zotero_exports()` — find BetterBibTeX JSON exports
+- `discover_bbt_json()` — locate BBT auto-export JSON files
+- Used by `setup.py` for interactive project initialization
+
+### tools/ (577 lines)
+MCP tool infrastructure for embedding and citation analysis.
+- `client.py` (129) — `MCPClient` for stdio transport connection to MCP servers
+- `registry.py` (99) — `ToolRegistry` for multi-server tool routing + `ToolInfo` dataclass
+- `specter_server.py` (339) — FastMCP server with 4 tools: `embed_paper`, `find_similar`, `batch_embed`, `get_citation_intents`; also `fetch_citation_intents()` S2 API wrapper and `compare_intents()` for LLM vs S2 intent validation
+- `__main__.py` (5) — CLI entry: `python -m klemma.tools [--local]`
 
 ### app.py (124 lines)
 `KlemmaApp` — Textual TUI application. Mounts screens from `tui/` package.
@@ -92,4 +119,4 @@ Frontmatter `sections: [1.1, 1.4.1, 3.2.2]` → `source_sections` table → `get
 ## Maintaining this file
 Update when: adding/removing/renaming root-level modules in `src/klemma/`, changing key class/function signatures, adding SQLite tables to `state.py`, modifying `KlemmaContext` fields, or adding new CLI commands to `cli.py`. Line counts should be refreshed after significant changes.
 
-See: [AI Skills](skills/CLAUDE.md) | [Literature](literature/CLAUDE.md) | [TUI](tui/CLAUDE.md) | [Prompts](../../prompts/CLAUDE.md) | [Tests](../../tests/CLAUDE.md)
+See: [AI Skills](skills/CLAUDE.md) | [Literature](literature/CLAUDE.md) | [TUI](tui/CLAUDE.md) | [Prompts](../../prompts/CLAUDE.md) | [Tests](../../tests/CLAUDE.md) | [Root](../../CLAUDE.md)

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -6,20 +6,20 @@ Dissertation context and tags are loaded from `~/.klemma/` at CLI startup and pa
 
 ## Modules
 
-### planner.py (~215 lines)
+### planner.py (248 lines)
 Morning briefing generation. Gathers: deadline, streak, yesterday's plan, chapter plan, library digest, coverage stats, ref-gaps.
 - `generate_morning_plan(config, state, vault, ai, dissertation_context, klemma_home)` — full context → `prompts/morning.md` → Claude → `DailyPlan` → state + vault
 - `_get_current_deadline()` — calculate days remaining for current chapter (also used by librarian, agent)
 - `_read_chapter_plan()` — load session plan from vault
 - Intervention types: `NONE`, `REPLAN`, `BOOST`, `SKIP`
 
-### extractor.py (~205 lines)
-Fragment extraction from PDFs.
-- `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult`
-- `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze)
+### extractor.py (215 lines)
+Fragment extraction from PDFs with citation intent classification.
+- `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult` (fragments + citation_intent + citation_links)
+- `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze → save citation_links to graph)
 - `save_fragments_to_vault(citekey, fragments, vault, ..., dissertation_context, available_tags, klemma_home)` — appends to `@citekey.md`; auto-creates note if missing
 
-### researcher.py (~700 lines — largest skill)
+### researcher.py (771 lines — largest skill)
 Section research briefings. Two modes:
 - **Initial**: auto-extract fragments → collect context → `prompts/research.md` → `ResearchResult` → `project_root/Research_{section}.md`
 - **Incremental**: reads existing research note from project_root `## ✏️ Что нового` (user annotations), computes delta (new sources, fragment count), `prompts/research_incremental.md` → merged result. User notes archived to `## 📋 История изменений` with timestamp.
@@ -29,14 +29,16 @@ Section research briefings. Two modes:
 - `_save_report(section, content, project_root)` — writes report to project_root
 - `_load_section_sources()` — enrich sources with vault AI summaries
 
-### librarian.py (~260 lines)
-Library health analysis. Three modes: `status` (health), `recommend` (section-focused), `audit` (deep quality check).
+### librarian.py (522 lines)
+Library health analysis. Three modes: `status` (health), `recommend` (section-focused), `audit` (deep quality check + citation graph + prune).
 - `analyze_library(project_root=...)` — gathers context → `prompts/librarian.md` → `LibraryReport` → `project_root/Library_{mode}_{date}.md`
-- `_gather_library_context()` — summary, quality tiers, ref-gaps, sources compact list
-- `_format_sources_compact()` — compact list for prompt (citekey, author, year, title, q, ch, s, f)
-- Prune verdicts (audit mode): saved to DB with "drop" and "maybe" categories
+- `_gather_library_context()` — summary, quality tiers, ref-gaps, sources compact list, citation graph stats
+- `_format_sources_compact()` — compact list for prompt (citekey, author, year, title, q, ch, s, f, intent)
+- `_get_citation_graph_stats()` — co-citation analysis, author network, hub scores from `citation_links`
+- Prune mode: `prompts/librarian_prune.md` → AI generates drop/maybe verdicts → `state.save_prune_verdicts()`
+- `list_prune_verdicts()` / `clear_prune_verdict()` — CLI for browsing/clearing verdicts
 
-### agent.py (~155 lines)
+### agent.py (212 lines)
 Builds full project context for interactive Claude sessions.
 - `build_agent_context(project_root=...)` — gathers sources, coverage, gaps, fragments, plan, reading queue + scans project_root for reports/files → `prompts/agent.md` → system prompt
 - `_scan_project_reports(project_root)` — finds Outline/Research/Library/Agent reports + project files (.md, .tex, .bib, .pdf, .doc, .docx)
@@ -44,7 +46,7 @@ Builds full project context for interactive Claude sessions.
 - For non-Claude backends: `ai.call()` with full context → terminal output
 - Saves responses to `project_root/Agent_<date>.md`
 
-### outliner.py (~250 lines)
+### outliner.py (296 lines)
 Project outline generation from directory contents + database context. Two modes:
 - **Initial**: scan files → library context → `prompts/outline.md` → Claude → `OutlineResult` → `project_root/Outline_{name}.md`
 - **Incremental**: reads previous outline from project_root `## ✏️ Что нового` (user feedback), `prompts/outline_incremental.md` → updated outline. User notes archived to `## 📋 История изменений`.
@@ -54,7 +56,7 @@ Project outline generation from directory contents + database context. Two modes
 - `OutlineResult` dataclass: title, description, chapters, sections, scientific_results, outline_text, update_summary
 - CLI options: `-p/--prompt` (custom directive), `--fresh` (force full regeneration)
 
-### acquirer.py (258 lines)
+### acquirer.py (164 lines)
 Local-only paper acquisition pipeline: download → local storage → DB.
 - `acquire_paper()` — orchestrates full pipeline
 - `download_pdf()` — HTTP stream with validation (min 10KB, content-type check)
@@ -62,6 +64,12 @@ Local-only paper acquisition pipeline: download → local storage → DB.
 - `poll_bbt_citekey()` — polls BBT JSON export for new citekey (2s intervals, 30s timeout)
 - `load_batch()` — parse JSON batch file
 - Dataclasses: `PaperMetadata`, `AcquireResult`
+
+### work_context.py (93 lines)
+Dynamic work context builder — replaces hardcoded DISSERTATION_CONTEXT constant.
+- `build_work_context(project, language)` — generates context string from ProjectConfig fields (title, chapters, deadlines, priority terms); supports any project type (dissertation/paper/thesis)
+- `get_current_deadline(project, language)` — returns (deadline_str, days_remaining) for current focus chapter
+- Multi-language labels (ru/en) for chapter headings, deadlines, etc.
 
 ## Data flows
 

--- a/src/klemma/tools/specter_server.py
+++ b/src/klemma/tools/specter_server.py
@@ -1,9 +1,10 @@
 """SPECTER embedding MCP server for Klemma.
 
-Provides embedding tools over MCP protocol:
+Provides embedding and citation analysis tools over MCP protocol:
 - embed_paper: Embed a single paper by title + abstract
 - find_similar: Find similar papers using cosine similarity
 - batch_embed: Embed multiple papers in one call
+- get_citation_intents: Fetch citation intents from Semantic Scholar API
 
 Backends: Semantic Scholar API (default) or local sentence-transformers.
 
@@ -167,7 +168,164 @@ def create_specter_server(backend: str = "s2", **backend_kwargs):
             "failed": len(errors),
         }
 
+    @server.tool(
+        name="get_citation_intents",
+        description=(
+            "Fetch citation intents for a paper from Semantic Scholar API. "
+            "Returns how other papers cite the given paper, with intent labels "
+            "(Background, Methodology, Result) and citation contexts."
+        ),
+    )
+    def get_citation_intents(
+        paper_id: str,
+        limit: int = 100,
+    ) -> dict:
+        """Fetch citation intents from S2 API.
+
+        Args:
+            paper_id: S2 paper ID, DOI, or title query
+            limit: Maximum citations to fetch (default 100)
+
+        Returns:
+            Dict with 'citations' list and 'stats' (intent distribution).
+        """
+        return fetch_citation_intents(paper_id, limit=limit)
+
     return server
+
+
+# ---------------------------------------------------------------------------
+# S2 Citation Intents API
+# ---------------------------------------------------------------------------
+
+
+def fetch_citation_intents(paper_id: str, limit: int = 100) -> dict:
+    """Fetch citation intents from Semantic Scholar API.
+
+    Uses GET /paper/{paper_id}/citations?fields=intents,contexts,title
+
+    Args:
+        paper_id: S2 paper ID, DOI, or arXiv ID
+        limit: Max citations to return
+
+    Returns:
+        Dict with 'citations' and 'stats' keys.
+    """
+    import requests
+
+    url = f"https://api.semanticscholar.org/graph/v1/paper/{paper_id}/citations"
+    params = {
+        "fields": "intents,contexts,title",
+        "limit": min(limit, 1000),
+    }
+
+    try:
+        resp = requests.get(url, params=params, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        return {"error": str(e), "citations": [], "stats": {}}
+
+    citations = []
+    intent_counts = {"Background": 0, "Methodology": 0, "Result": 0}
+
+    for item in data.get("data", []):
+        citing = item.get("citingPaper", {})
+        intents = item.get("intents", [])
+        contexts = item.get("contexts", [])
+
+        for intent in intents:
+            if intent in intent_counts:
+                intent_counts[intent] += 1
+
+        citations.append({
+            "title": citing.get("title", ""),
+            "paperId": citing.get("paperId", ""),
+            "intents": intents,
+            "contexts": contexts[:3],  # Limit context snippets
+        })
+
+    return {
+        "citations": citations,
+        "stats": intent_counts,
+        "total": len(citations),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Intent Comparison: LLM-predicted vs S2 ground truth
+# ---------------------------------------------------------------------------
+
+# Mapping from klemma intent labels to S2 intent labels
+_KLEMMA_TO_S2 = {
+    "background": "Background",
+    "method": "Methodology",
+    "result_comparison": "Result",
+}
+
+_S2_TO_KLEMMA = {v: k for k, v in _KLEMMA_TO_S2.items()}
+
+
+def compare_intents(
+    llm_intents: dict[str, str],
+    s2_intents: dict[str, list[str]],
+) -> dict:
+    """Compare LLM-predicted citation intents against S2 ground truth.
+
+    Args:
+        llm_intents: {citekey: "background"|"method"|"result_comparison"}
+            from klemma's LLM extraction
+        s2_intents: {citekey: ["Background", "Methodology", "Result"]}
+            from S2 API (a paper can have multiple intents)
+
+    Returns:
+        Dict with accuracy metrics:
+        - total: number of papers compared
+        - matches: correct predictions
+        - accuracy: matches / total
+        - confusion: {predicted: {actual: count}}
+        - details: per-paper comparison
+    """
+    total = 0
+    matches = 0
+    confusion: dict[str, dict[str, int]] = {}
+    details = []
+
+    for citekey, llm_intent in llm_intents.items():
+        s2_labels = s2_intents.get(citekey, [])
+        if not s2_labels:
+            continue
+
+        total += 1
+        s2_mapped = _KLEMMA_TO_S2.get(llm_intent, "")
+
+        # S2 returns a list — match if LLM prediction is among them
+        is_match = s2_mapped in s2_labels
+        if is_match:
+            matches += 1
+
+        # Confusion matrix
+        predicted = llm_intent
+        for s2_label in s2_labels:
+            actual = _S2_TO_KLEMMA.get(s2_label, s2_label)
+            confusion.setdefault(predicted, {})
+            confusion[predicted].setdefault(actual, 0)
+            confusion[predicted][actual] += 1
+
+        details.append({
+            "citekey": citekey,
+            "llm_intent": llm_intent,
+            "s2_intents": s2_labels,
+            "match": is_match,
+        })
+
+    return {
+        "total": total,
+        "matches": matches,
+        "accuracy": round(matches / total, 4) if total > 0 else 0.0,
+        "confusion": confusion,
+        "details": details,
+    }
 
 
 def main():

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,14 +1,21 @@
 # Tests
 
-## Current test suite
-- `test_ai.py` (112 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
-- `test_ai_openai.py` (118 lines) — `OpenAIClient` with mocked openai SDK
-- `test_project_discovery.py` (~590 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
+## Current test suite (207 tests)
+- `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
+- `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
+- `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
+- `test_embeddings.py` (354 lines) — `EmbeddingProvider` protocol, `cosine_similarity`, `SemanticScholarEmbeddings`/`LocalSPECTEREmbeddings`/`OpenAIEmbeddings` with mocked backends, `create_embeddings()` factory
+- `test_citation_graph.py` (245 lines) — citation graph storage (`save_citation_links`, `get_citation_graph`), intent scoring for reference gaps, `_migrate_schema()` v1→v3
+- `test_mcp.py` (404 lines) — `ToolRegistry` CRUD + routing, `ToolInfo`, SPECTER MCP server creation (4 tools), embed/similar/batch tool logic via helpers, `compare_intents()` (LLM vs S2 accuracy, confusion matrix)
+- `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
+- `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
 
 ## Patterns
 - pytest + `unittest.mock` (`patch`, `MagicMock`)
 - AI backends tested with mocked subprocess (Claude) or mocked SDK (OpenAI)
 - Config fixtures use `AIConfig` Pydantic models with test values
+- MCP tests: `_MCP_AVAILABLE` flag + `@_skip_no_mcp` decorator for CI environments without mcp package
+- Tool logic tested via helper functions that replicate tool behavior (avoids running MCP server)
 - No integration tests (all mocked)
 
 ## Running
@@ -18,8 +25,9 @@ pytest tests/
 ```
 
 ## Adding tests
-- Mock external dependencies (AI CLIs, SDKs, Zotero API, MCP servers)
+- Mock external dependencies (AI CLIs, SDKs, Zotero API, MCP servers, S2 API)
 - Mirror source structure: `test_<module>.py` for `src/klemma/<module>.py`
+- For MCP-dependent tests: wrap with `@_skip_no_mcp` (requires `klemma[mcp]`)
 
 ## Maintaining this file
 Update when: adding new test files (add to "Current test suite"), changing testing patterns, or adding integration test infrastructure.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,7 +5,7 @@ import importlib.util
 import pytest
 
 from klemma.tools.registry import ToolInfo, ToolRegistry
-from klemma.tools.specter_server import create_specter_server
+from klemma.tools.specter_server import compare_intents, create_specter_server
 
 _MCP_AVAILABLE = importlib.util.find_spec("mcp") is not None
 _skip_no_mcp = pytest.mark.skipif(not _MCP_AVAILABLE, reason="requires klemma[mcp]: pip install klemma[mcp]")
@@ -140,14 +140,15 @@ class TestSpecterServerCreation:
         assert server is not None
         assert server.name == "klemma-specter"
 
-    def test_create_server_has_three_tools(self):
+    def test_create_server_has_four_tools(self):
         server = create_specter_server(backend="s2")
         tools = server._tool_manager.list_tools()
         tool_names = {t.name for t in tools}
         assert "embed_paper" in tool_names
         assert "find_similar" in tool_names
         assert "batch_embed" in tool_names
-        assert len(tool_names) == 3
+        assert "get_citation_intents" in tool_names
+        assert len(tool_names) == 4
 
 
 class TestEmbedPaperTool:
@@ -316,3 +317,88 @@ def _call_batch_embed(provider, papers):
         "embedded": len(results),
         "failed": len(errors),
     }
+
+
+# ---------------------------------------------------------------------------
+# Citation Intent Comparison Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareIntents:
+    """Tests for LLM vs S2 citation intent comparison."""
+
+    def test_perfect_match(self):
+        llm = {"p1": "background", "p2": "method", "p3": "result_comparison"}
+        s2 = {
+            "p1": ["Background"],
+            "p2": ["Methodology"],
+            "p3": ["Result"],
+        }
+        result = compare_intents(llm, s2)
+        assert result["total"] == 3
+        assert result["matches"] == 3
+        assert result["accuracy"] == 1.0
+
+    def test_no_match(self):
+        llm = {"p1": "background", "p2": "method"}
+        s2 = {
+            "p1": ["Methodology"],
+            "p2": ["Result"],
+        }
+        result = compare_intents(llm, s2)
+        assert result["total"] == 2
+        assert result["matches"] == 0
+        assert result["accuracy"] == 0.0
+
+    def test_partial_match(self):
+        llm = {"p1": "background", "p2": "method", "p3": "background"}
+        s2 = {
+            "p1": ["Background"],
+            "p2": ["Result"],
+            "p3": ["Background", "Methodology"],
+        }
+        result = compare_intents(llm, s2)
+        assert result["total"] == 3
+        assert result["matches"] == 2  # p1 and p3 match
+        assert result["accuracy"] == pytest.approx(2 / 3, abs=0.01)
+
+    def test_multi_intent_s2(self):
+        """S2 can return multiple intents per citation — match if any."""
+        llm = {"p1": "method"}
+        s2 = {"p1": ["Background", "Methodology"]}
+        result = compare_intents(llm, s2)
+        assert result["matches"] == 1
+
+    def test_missing_s2_data(self):
+        """Papers not in S2 data are skipped."""
+        llm = {"p1": "background", "p2": "method"}
+        s2 = {"p1": ["Background"]}
+        result = compare_intents(llm, s2)
+        assert result["total"] == 1  # p2 skipped
+        assert result["matches"] == 1
+
+    def test_empty_inputs(self):
+        result = compare_intents({}, {})
+        assert result["total"] == 0
+        assert result["accuracy"] == 0.0
+
+    def test_confusion_matrix(self):
+        llm = {"p1": "background", "p2": "background"}
+        s2 = {
+            "p1": ["Background"],
+            "p2": ["Methodology"],
+        }
+        result = compare_intents(llm, s2)
+        assert "background" in result["confusion"]
+        assert result["confusion"]["background"]["background"] == 1
+        assert result["confusion"]["background"]["method"] == 1
+
+    def test_details_per_paper(self):
+        llm = {"p1": "method"}
+        s2 = {"p1": ["Methodology"]}
+        result = compare_intents(llm, s2)
+        assert len(result["details"]) == 1
+        detail = result["details"][0]
+        assert detail["citekey"] == "p1"
+        assert detail["llm_intent"] == "method"
+        assert detail["match"] is True


### PR DESCRIPTION
## Summary

Complete modernization of Klemma across 4 sprints + comprehensive documentation update:

- **Sprint 1**: Citation intent classification (background/method/result_comparison) for fragments and reference gaps
- **Sprint 2**: SPECTER embeddings — 3 backends (S2/local/OpenAI), semantic search (`klemma embed`, `klemma similar`)
- **Sprint 3**: Citation graph (`citation_links` table), co-citation analysis, library audit with prune recommendations
- **Sprint 4**: MCP tool infrastructure — SPECTER MCP server (4 tools), S2 citation intents API, intent comparison
- **Docs**: Full README rewrite, comprehensive Russian user guide (`docs/USER_GUIDE.md`), all 6 CLAUDE.md files updated

### Key changes
- 14 commands (was 9): added `embed`, `similar`, `outline`, `library prune`, `info`, `tree`, `migrate`
- SQLite schema v3 with 3 migration blocks
- 207 tests (was ~50)
- Removed stale MCP/search/discover references from docs

## Test plan
- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest tests/ -q` — 207 passed
- [ ] Manual: `klemma embed --dry-run` with S2 backend
- [ ] Manual: `klemma similar <citekey>` returns ranked results
- [ ] Manual: `klemma outline` generates project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)