### PR TITLE
refactor: phase 3 — repository decomposition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ src/klemma/
 ├── config.py           — Pydantic config models + discover_project_root(), resolve_effective_config(), resolve_prompt() (635 lines)
 ├── context.py          — KlemmaContext dataclass (single object per CLI command) (41 lines)
 ├── setup.py            — `klemma init` logic — init_project() + init_system() (263 lines)
-├── state.py            — SQLite state manager (1599 lines)
+├── state.py            — SQLite state manager facade (420 lines, delegates to repositories/)
 ├── ai.py               — AIProvider protocol + ClaudeClient + create_ai() factory (249 lines)
 ├── ai_openai.py        — OpenAI-compatible backend (105 lines)
 ├── ai_litellm.py       — LiteLLM universal backend (70 lines)
@@ -29,6 +29,14 @@ src/klemma/
 ├── discovery.py        — Auto-discovery for klemma init (Obsidian vault, Zotero, BBT JSON) (260 lines)
 ├── vault.py            — Obsidian adapter (CLI/file I/O, update_section) (249 lines)
 ├── library_provider.py — LibraryProvider protocol + LocalLibrary (BBT JSON) (86 lines)
+├── repositories/       — Domain repositories (decomposed from state.py)
+│   ├── sources.py      — Source CRUD, status, sections, Zotero keys, vault sync (~400 lines)
+│   ├── fragments.py    — Fragment CRUD, intent coverage (~120 lines)
+│   ├── embeddings_store.py — Vector BLOB storage (~100 lines)
+│   ├── gaps.py         — Reference gaps, coverage, scoring (~280 lines)
+│   ├── citations.py    — Citation graph, co-citation, authors (~200 lines)
+│   ├── plans.py        — Daily plans, reading queue (~120 lines)
+│   └── prune.py        — Prune verdicts, protection (~120 lines)
 ├── skills/             — AI skills (planner, extractor, researcher, librarian, agent, acquirer, outliner, work_context)
 ├── literature/         — PDF extraction, models, note_factory
 └── tools/              — MCP tool infrastructure (567 lines)
@@ -165,6 +173,7 @@ Schema versioned via `PRAGMA user_version` (currently v3). Migrations in `state.
 Detailed documentation for each subsystem lives in its directory, loaded incrementally as the agent navigates:
 
 - [Core infrastructure](src/klemma/CLAUDE.md) — config, state, AI providers, vault, library, CLI, context
+- [Repositories](src/klemma/repositories/CLAUDE.md) — domain repositories decomposed from StateManager
 - [AI Skills](src/klemma/skills/CLAUDE.md) — planner, extractor, researcher, librarian, agent, acquirer, outliner
 - [Literature](src/klemma/literature/CLAUDE.md) — PDF extraction, models, vault note factory
 - [TUI](src/klemma/tui/CLAUDE.md) — Textual dashboard and screens

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1024,10 +1024,12 @@ Sprint 6 (Phase 6): ~11 days (after Phase 4, can overlap Phase 5)
 
 # Refactoring Program Backlog (Phases 3-10)
 
-## Phase 3: Architecture Seams
-- Ввести `services/` (оркестрация) и `repositories/` (данные).
-- Оставить `cli.py` как тонкий слой маршрутизации команд.
-- Закрыть доступ к приватным методам state из внешних модулей.
+## Phase 3: Architecture Seams ✅ DONE
+- ✅ `repositories/` введён: 7 доменных модулей (sources, fragments, embeddings_store, gaps, citations, plans, prune).
+- ✅ `StateManager` — facade с делегацией, backward-compatible API.
+- ✅ Доступ к приватным методам (`_conn()`, `_set_sections_inline`) закрыт: 0 нарушений в `src/`.
+- ⏳ `services/` (оркестрация) — отложен на Phase 4.
+- ⏳ `cli.py` как тонкий слой — отложен на Phase 4.
 
 ## Phase 4: CLI Decomposition
 - Разбить `src/klemma/cli.py` по доменам команд: `init`, `process`, `research`, `library`, `ask`, `status`.

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -38,8 +38,8 @@ Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `Embed
 - `init_klemma_home()` — legacy alias for `init_system()`
 - Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`
 
-### state.py (1599 lines)
-SQLite state manager. Schema versioned via `PRAGMA user_version` (currently v3), auto-migrates via `_migrate_schema()`.
+### state.py (420 lines)
+SQLite state manager — **facade** over 7 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v3), auto-migrates via `_migrate_schema()`. All 58 public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, etc. See [Repositories](repositories/CLAUDE.md).
 
 Tables:
 - `sources` — Zotero entries (citekey, title, status, chapter, quality, pdf_path, `embedding` BLOB float32, `embedding_model` TEXT)

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -152,9 +152,7 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
     auto_register = not project or project.type != "paper"
 
     # Load existing DB source IDs (needed for paper filtering + new entry detection)
-    with state._conn() as conn:
-        cur = conn.execute("SELECT id FROM sources")
-        existing = {row["id"] for row in cur.fetchall()}
+    existing = state.get_existing_source_ids()
 
     new_entries = []
     renames = []
@@ -919,11 +917,7 @@ def embed(ctx, citekey, dry_run, backend):
         candidates = [citekey]
     else:
         # Find completed sources without embeddings
-        with state._conn() as conn:
-            cur = conn.execute(
-                "SELECT id FROM sources WHERE status='completed' AND embedding IS NULL"
-            )
-            candidates = [row["id"] for row in cur.fetchall()]
+        candidates = state.get_sources_without_embeddings()
 
     if not candidates:
         console.print("[green]All sources already have embeddings.[/green]")

--- a/src/klemma/repositories/CLAUDE.md
+++ b/src/klemma/repositories/CLAUDE.md
@@ -1,0 +1,79 @@
+# Repositories
+
+Domain repositories decomposed from `StateManager` (1599 lines -> 7 focused modules). StateManager remains as backward-compatible facade.
+
+## Architecture
+
+```
+StateManager (facade)
+├── _conn()          — shared SQLite connection factory (WAL + FK)
+├── _init_db()       — schema creation + migrations
+├── _migrate_schema()— idempotent PRAGMA user_version
+└── delegates to:
+    ├── SourceRepository      — source CRUD, status, sections, Zotero keys, vault sync
+    ├── FragmentRepository    — fragment CRUD, intent coverage
+    ├── EmbeddingsStoreRepository — vector BLOB storage, coverage stats
+    ├── GapsRepository        — reference gaps, coverage, scoring, semantic rerank
+    ├── CitationsRepository   — citation links, graph stats, co-citation, author groups
+    ├── PlansRepository       — daily plans, reading queue, writing streak
+    └── PruneRepository       — prune verdicts, protection logic
+```
+
+All repos receive `StateManager._conn` as their connection factory via `BaseRepository.__init__`.
+
+## Modules
+
+### base.py (8 lines)
+Base class providing shared `_conn` factory.
+- `BaseRepository` — all repos inherit from this
+
+### sources.py (~400 lines)
+Source lifecycle, sections, Zotero key management, vault sync.
+- `register_sources()`, `mark_completed()`, `get_source()`, `get_stats()`
+- `set_source_sections()` — replaces old `_set_sections_inline`
+- `get_existing_source_ids()` — replaces old direct `_conn()` usage in cli.py
+- `get_sources_without_embeddings()` — replaces old direct `_conn()` usage in cli.py
+- `sync_source_sections()` — vault frontmatter bidirectional sync
+- `rename_source()`, `delete_source()` — cascade operations
+
+### fragments.py (~120 lines)
+Fragment CRUD and citation intent coverage.
+- `save_fragments()`, `get_fragments()`, `get_fragment_stats()`
+- `get_intent_coverage()` — section x intent matrix
+
+### embeddings_store.py (~100 lines)
+Vector BLOB storage with model versioning.
+- `save_embedding()`, `get_embedding()`, `get_all_embeddings()`
+- `get_embedding_stats()` — coverage by model
+
+### gaps.py (~280 lines)
+Reference gaps, coverage analysis, intent-weighted scoring.
+- `get_reference_gaps()` — aggregated with intent-weighted scoring formula
+- `rerank_gaps_semantic()` — centroid-based semantic reranking (cross-repo via callables)
+- `resolve_gaps()` — auto-resolve against library entries
+- `get_coverage_stats()`, `get_gaps()`, `reset_non_completed()`
+
+### citations.py (~200 lines)
+Citation graph: links, stats, co-citation, author network.
+- `save_citation_links()` — MD5 title hash for dedup
+- `get_citation_graph_stats()`, `get_co_cited()`, `get_key_author_groups()`
+
+### plans.py (~120 lines)
+Daily plans and reading queue.
+- `save_plan()`, `get_plan()`, `get_writing_streak()`
+- `add_to_reading_queue()`, `get_next_reading()`, `complete_reading()`
+
+### prune.py (~120 lines)
+Library audit recommendations.
+- `save_prune_verdicts()` — hard-protects valuable sources
+- `get_prune_drop_ids()`, `get_prune_summary()`, `get_prune_verdicts()`
+
+## Cross-repo dependencies
+
+- `gaps.rerank_gaps_semantic()` needs embedding data — resolved via callable injection from StateManager
+- `sources.get_by_chapter/section` and `plans.get_next_reading` filter by prune drops — use SQL subquery (no repo import)
+
+## Maintaining this file
+Update when repos are added/renamed, or when methods move between repos.
+
+See: [Core infrastructure](../CLAUDE.md), [Tests](../../../tests/CLAUDE.md)

--- a/src/klemma/repositories/__init__.py
+++ b/src/klemma/repositories/__init__.py
@@ -1,0 +1,21 @@
+"""Domain repositories — decomposed from StateManager."""
+
+from .base import BaseRepository
+from .citations import CitationsRepository
+from .embeddings_store import EmbeddingsStoreRepository
+from .fragments import FragmentRepository
+from .gaps import GapsRepository
+from .plans import PlansRepository
+from .prune import PruneRepository
+from .sources import SourceRepository
+
+__all__ = [
+    "BaseRepository",
+    "CitationsRepository",
+    "EmbeddingsStoreRepository",
+    "FragmentRepository",
+    "GapsRepository",
+    "PlansRepository",
+    "PruneRepository",
+    "SourceRepository",
+]

--- a/src/klemma/repositories/base.py
+++ b/src/klemma/repositories/base.py
@@ -1,0 +1,8 @@
+"""Base class for domain repositories."""
+
+
+class BaseRepository:
+    """Base class sharing a DB connection factory across repositories."""
+
+    def __init__(self, conn_factory):
+        self._conn = conn_factory

--- a/src/klemma/repositories/citations.py
+++ b/src/klemma/repositories/citations.py
@@ -1,0 +1,183 @@
+"""Citation links and graph analysis repository."""
+
+import hashlib
+from typing import Optional
+
+from .base import BaseRepository
+
+
+class CitationsRepository(BaseRepository):
+
+    def save_citation_links(self, source_id: str, references: list[dict]):
+        """Save citation links from annotation key_references.
+
+        Each reference dict should have: authors, year, title, citation_intent,
+        in_library, citekey (optional).
+        Uses MD5 of normalized title for UNIQUE constraint.
+        """
+        with self._conn() as conn:
+            for ref in references:
+                title = ref.get("title", "")
+                if not title:
+                    continue
+                title_hash = hashlib.md5(
+                    title.lower().strip().encode()
+                ).hexdigest()
+                conn.execute(
+                    """INSERT OR REPLACE INTO citation_links
+                       (source_id, target_citekey, target_title_hash,
+                        target_title, target_authors, target_year,
+                        citation_intent, in_library)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        source_id,
+                        ref.get("citekey"),
+                        title_hash,
+                        title,
+                        ref.get("authors", ""),
+                        ref.get("year"),
+                        ref.get("citation_intent"),
+                        1 if ref.get("in_library") else 0,
+                    ),
+                )
+
+    def get_citation_links(
+        self, source_id: Optional[str] = None
+    ) -> list[dict]:
+        """Get citation links, optionally filtered by source."""
+        with self._conn() as conn:
+            if source_id:
+                cur = conn.execute(
+                    "SELECT * FROM citation_links WHERE source_id=?",
+                    (source_id,),
+                )
+            else:
+                cur = conn.execute("SELECT * FROM citation_links")
+            return [dict(row) for row in cur.fetchall()]
+
+    def get_citation_graph_stats(self) -> dict:
+        """Compute citation graph statistics."""
+        with self._conn() as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) as cnt FROM citation_links"
+            ).fetchone()["cnt"]
+            unique_targets = conn.execute(
+                "SELECT COUNT(DISTINCT target_title_hash) as cnt FROM citation_links"
+            ).fetchone()["cnt"]
+            in_library = conn.execute(
+                "SELECT COUNT(*) as cnt FROM citation_links WHERE in_library=1"
+            ).fetchone()["cnt"]
+            external = total - in_library
+
+            source_count = conn.execute(
+                "SELECT COUNT(DISTINCT source_id) as cnt FROM citation_links"
+            ).fetchone()["cnt"]
+            avg_refs = round(total / source_count, 1) if source_count else 0
+
+            # Most cited external works
+            cur = conn.execute(
+                """SELECT target_title, target_authors, target_year,
+                          COUNT(DISTINCT source_id) as cite_count
+                   FROM citation_links
+                   WHERE in_library=0
+                   GROUP BY target_title_hash
+                   ORDER BY cite_count DESC
+                   LIMIT 10"""
+            )
+            most_cited_external = [dict(row) for row in cur.fetchall()]
+
+            # Most connected internal works
+            cur = conn.execute(
+                """SELECT target_citekey, COUNT(DISTINCT source_id) as cite_count
+                   FROM citation_links
+                   WHERE in_library=1 AND target_citekey IS NOT NULL
+                   GROUP BY target_citekey
+                   ORDER BY cite_count DESC
+                   LIMIT 10"""
+            )
+            most_connected = [dict(row) for row in cur.fetchall()]
+
+            return {
+                "total_links": total,
+                "unique_targets": unique_targets,
+                "in_library": in_library,
+                "external": external,
+                "source_count": source_count,
+                "avg_refs_per_source": avg_refs,
+                "most_cited_external": most_cited_external,
+                "most_connected_internal": most_connected,
+            }
+
+    def get_co_cited(self, citekey: str) -> list[dict]:
+        """Find works frequently co-cited with the given citekey."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT DISTINCT source_id FROM citation_links
+                   WHERE target_citekey=? OR target_title_hash IN (
+                       SELECT target_title_hash FROM citation_links
+                       WHERE target_citekey=?
+                   )""",
+                (citekey, citekey),
+            )
+            citing_sources = [row["source_id"] for row in cur.fetchall()]
+
+            if not citing_sources:
+                return []
+
+            placeholders = ",".join("?" * len(citing_sources))
+            cur = conn.execute(
+                f"""SELECT target_title, target_authors, target_year,
+                           target_citekey, in_library,
+                           COUNT(DISTINCT source_id) as co_cite_count
+                    FROM citation_links
+                    WHERE source_id IN ({placeholders})
+                      AND (target_citekey IS NULL OR target_citekey != ?)
+                    GROUP BY target_title_hash
+                    ORDER BY co_cite_count DESC
+                    LIMIT 20""",
+                (*citing_sources, citekey),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def get_key_author_groups(self, min_papers: int = 2) -> list[dict]:
+        """Find author groups with multiple papers in the library."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT target_authors, target_title, target_year, target_citekey, in_library
+                   FROM citation_links
+                   WHERE target_authors IS NOT NULL AND target_authors != ''"""
+            )
+
+            groups: dict[str, list[dict]] = {}
+            for row in cur.fetchall():
+                authors = row["target_authors"]
+                surname = ""
+                for word in authors.replace("et al.", "").replace(",", " ").split():
+                    clean = word.strip(".").strip()
+                    if len(clean) > 2 and clean[0].isupper():
+                        surname = clean
+                        break
+                if not surname:
+                    continue
+                if surname not in groups:
+                    groups[surname] = []
+                groups[surname].append({
+                    "title": row["target_title"],
+                    "year": row["target_year"],
+                    "citekey": row["target_citekey"],
+                    "in_library": bool(row["in_library"]),
+                    "full_authors": authors,
+                })
+
+            result = []
+            for surname, papers in groups.items():
+                unique_titles = {p["title"] for p in papers}
+                if len(unique_titles) >= min_papers:
+                    result.append({
+                        "surname": surname,
+                        "paper_count": len(unique_titles),
+                        "in_library_count": sum(1 for p in papers if p["in_library"]),
+                        "papers": papers[:10],
+                    })
+            result.sort(key=lambda x: x["paper_count"], reverse=True)
+            return result

--- a/src/klemma/repositories/embeddings_store.py
+++ b/src/klemma/repositories/embeddings_store.py
@@ -1,0 +1,80 @@
+"""Embedding storage repository — vector CRUD and coverage stats."""
+
+import struct
+from typing import Optional
+
+from .base import BaseRepository
+
+
+class EmbeddingsStoreRepository(BaseRepository):
+
+    def save_embedding(
+        self, source_id: str, embedding: list[float], model: str
+    ):
+        """Store embedding vector as BLOB with model name."""
+        blob = struct.pack(f"{len(embedding)}f", *embedding)
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE sources SET embedding=?, embedding_model=? WHERE id=?",
+                (blob, model, source_id),
+            )
+
+    def get_embedding(self, source_id: str) -> Optional[tuple[list[float], str]]:
+        """Retrieve embedding vector and model name for a source.
+
+        Returns (vector, model_name) or None if no embedding stored.
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT embedding, embedding_model FROM sources WHERE id=?",
+                (source_id,),
+            ).fetchone()
+            if not row or not row["embedding"]:
+                return None
+            blob = row["embedding"]
+            n = len(blob) // 4  # float32 = 4 bytes
+            vec = list(struct.unpack(f"{n}f", blob))
+            return (vec, row["embedding_model"] or "")
+
+    def get_all_embeddings(
+        self, model: Optional[str] = None
+    ) -> dict[str, list[float]]:
+        """Get all source embeddings, optionally filtered by model.
+
+        Returns {source_id: vector}.
+        """
+        with self._conn() as conn:
+            if model:
+                cur = conn.execute(
+                    "SELECT id, embedding FROM sources "
+                    "WHERE embedding IS NOT NULL AND embedding_model=?",
+                    (model,),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT id, embedding FROM sources WHERE embedding IS NOT NULL"
+                )
+            result = {}
+            for row in cur.fetchall():
+                blob = row["embedding"]
+                n = len(blob) // 4
+                result[row["id"]] = list(struct.unpack(f"{n}f", blob))
+            return result
+
+    def get_embedding_stats(self) -> dict:
+        """Get embedding coverage stats."""
+        with self._conn() as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) as cnt FROM sources WHERE status='completed'"
+            ).fetchone()["cnt"]
+            embedded = conn.execute(
+                "SELECT COUNT(*) as cnt FROM sources WHERE embedding IS NOT NULL"
+            ).fetchone()["cnt"]
+            models = {}
+            cur = conn.execute(
+                "SELECT embedding_model, COUNT(*) as cnt FROM sources "
+                "WHERE embedding IS NOT NULL GROUP BY embedding_model"
+            )
+            for row in cur.fetchall():
+                models[row["embedding_model"] or "unknown"] = row["cnt"]
+            return {"total": total, "embedded": embedded, "models": models}

--- a/src/klemma/repositories/fragments.py
+++ b/src/klemma/repositories/fragments.py
@@ -1,0 +1,130 @@
+"""Fragment repository — CRUD and intent coverage stats."""
+
+from typing import Optional
+
+from .base import BaseRepository
+
+
+class FragmentRepository(BaseRepository):
+
+    def save_fragments(self, source_id: str, fragments: list[dict]) -> int:
+        """Save extracted fragments and update source fragment count."""
+        with self._conn() as conn:
+            for f in fragments:
+                conn.execute(
+                    """INSERT INTO fragments
+                       (source_id, fragment_text, fragment_type, chapter, section,
+                        relevance_score, usage_hint, page_number, citation_intent)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        source_id,
+                        f.get("text", ""),
+                        f.get("type", "key_idea"),
+                        f.get("chapter"),
+                        f.get("section"),
+                        f.get("relevance", 3),
+                        f.get("usage_hint", ""),
+                        f.get("page"),
+                        f.get("citation_intent"),
+                    ),
+                )
+            conn.execute(
+                "UPDATE sources SET fragment_count=? WHERE id=?",
+                (len(fragments), source_id),
+            )
+            return len(fragments)
+
+    def get_fragments(
+        self,
+        source_id: Optional[str] = None,
+        chapter: Optional[int] = None,
+        section: Optional[str] = None,
+        fragment_type: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Query fragments with optional filters."""
+        conditions = []
+        params: list = []
+        if source_id:
+            conditions.append("source_id=?")
+            params.append(source_id)
+        if chapter:
+            conditions.append("chapter=?")
+            params.append(chapter)
+        if section:
+            conditions.append("section LIKE ?")
+            params.append(f"{section}%")
+        if fragment_type:
+            conditions.append("fragment_type=?")
+            params.append(fragment_type)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        params.append(limit)
+
+        with self._conn() as conn:
+            cur = conn.execute(
+                f"""SELECT f.*, s.id as citekey
+                    FROM fragments f
+                    JOIN sources s ON f.source_id = s.id
+                    WHERE {where}
+                    ORDER BY f.relevance_score DESC, f.extracted_at DESC
+                    LIMIT ?""",
+                params,
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def get_fragment_stats(self) -> dict:
+        """Get fragment counts by type, chapter, section."""
+        with self._conn() as conn:
+            stats: dict = {"total": 0, "by_type": {}, "by_chapter": {}, "by_section": {}}
+            cur = conn.execute("SELECT COUNT(*) as cnt FROM fragments")
+            stats["total"] = cur.fetchone()["cnt"]
+
+            cur = conn.execute(
+                "SELECT fragment_type, COUNT(*) as cnt FROM fragments GROUP BY fragment_type"
+            )
+            for row in cur.fetchall():
+                stats["by_type"][row["fragment_type"] or "unknown"] = row["cnt"]
+
+            cur = conn.execute(
+                "SELECT chapter, COUNT(*) as cnt FROM fragments WHERE chapter IS NOT NULL GROUP BY chapter"
+            )
+            for row in cur.fetchall():
+                stats["by_chapter"][row["chapter"]] = row["cnt"]
+
+            cur = conn.execute(
+                "SELECT section, COUNT(*) as cnt FROM fragments WHERE section IS NOT NULL GROUP BY section"
+            )
+            for row in cur.fetchall():
+                stats["by_section"][row["section"]] = row["cnt"]
+            return stats
+
+    def get_intent_coverage(self) -> dict[str, dict[str, int]]:
+        """Get fragment counts by section x citation_intent.
+
+        Returns {section: {background: N, method: N, result_comparison: N, total: N}}.
+        Only includes sections with at least one fragment with non-NULL intent.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT section, citation_intent, COUNT(*) as cnt
+                   FROM fragments
+                   WHERE section IS NOT NULL AND citation_intent IS NOT NULL
+                   GROUP BY section, citation_intent
+                   ORDER BY section"""
+            )
+            result: dict[str, dict[str, int]] = {}
+            for row in cur.fetchall():
+                sec = row["section"]
+                if sec not in result:
+                    result[sec] = {
+                        "background": 0,
+                        "method": 0,
+                        "result_comparison": 0,
+                        "total": 0,
+                    }
+                intent = row["citation_intent"]
+                if intent in result[sec]:
+                    result[sec][intent] = row["cnt"]
+                    result[sec]["total"] += row["cnt"]
+            return result

--- a/src/klemma/repositories/gaps.py
+++ b/src/klemma/repositories/gaps.py
@@ -1,0 +1,328 @@
+"""Reference gaps, coverage, and scoring repository."""
+
+import json
+from typing import Optional
+
+from .base import BaseRepository
+
+
+class GapsRepository(BaseRepository):
+
+    def save_reference_gaps(self, source_id: str, gaps: list[dict]) -> int:
+        """Save reference gaps for a source (idempotent: replaces old gaps)."""
+        with self._conn() as conn:
+            conn.execute(
+                "DELETE FROM reference_gaps WHERE source_id=?", (source_id,)
+            )
+            for g in gaps:
+                sections = g.get("dissertation_sections", [])
+                conn.execute(
+                    """INSERT INTO reference_gaps
+                       (source_id, ref_authors, ref_year, ref_title,
+                        why_relevant, dissertation_sections, citation_intent)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        source_id,
+                        g.get("ref_authors", g.get("authors", "")),
+                        g.get("ref_year", g.get("year")),
+                        g.get("ref_title", g.get("title", "")),
+                        g.get("why_relevant", ""),
+                        json.dumps(sections) if sections else None,
+                        g.get("citation_intent"),
+                    ),
+                )
+            return len(gaps)
+
+    def get_reference_gaps(
+        self,
+        section: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Get open reference gaps aggregated by (authors, year, title).
+
+        Scoring formula: count * avg_quality * section_weight * intent_weight
+        where intent_weight = AVG(method=3.0, result_comparison=2.0, else=1.0)
+        NULL intents -> weight 1.0 (backward compatible).
+        """
+        with self._conn() as conn:
+            query = """
+                SELECT
+                    rg.ref_authors,
+                    rg.ref_year,
+                    rg.ref_title,
+                    GROUP_CONCAT(DISTINCT rg.why_relevant) as why_relevant,
+                    GROUP_CONCAT(DISTINCT rg.dissertation_sections) as dissertation_sections,
+                    COUNT(DISTINCT rg.source_id) as count,
+                    AVG(COALESCE(s.quality_score, 3)) as avg_quality,
+                    AVG(CASE
+                        WHEN rg.citation_intent = 'method' THEN 3.0
+                        WHEN rg.citation_intent = 'result_comparison' THEN 2.0
+                        ELSE 1.0
+                    END) as intent_weight,
+                    GROUP_CONCAT(DISTINCT rg.source_id) as source_ids
+                FROM reference_gaps rg
+                JOIN sources s ON rg.source_id = s.id
+                WHERE rg.status = 'open'
+            """
+            params: list = []
+            if section:
+                query += " AND rg.dissertation_sections LIKE ?"
+                params.append(f'%"{section}%')
+
+            query += """
+                GROUP BY rg.ref_authors, rg.ref_year, rg.ref_title
+                ORDER BY COUNT(DISTINCT rg.source_id)
+                       * AVG(COALESCE(s.quality_score, 3))
+                       * AVG(CASE
+                           WHEN rg.citation_intent = 'method' THEN 3.0
+                           WHEN rg.citation_intent = 'result_comparison' THEN 2.0
+                           ELSE 1.0
+                         END)
+                       DESC
+                LIMIT ?
+            """
+            params.append(limit)
+
+            cur = conn.execute(query, params)
+            results = []
+            for row in cur.fetchall():
+                r = dict(row)
+                count = r["count"]
+                avg_q = r["avg_quality"] or 3
+                intent_w = r.get("intent_weight") or 1.0
+                sections_str = r.get("dissertation_sections") or ""
+                section_weight = 2.0 if '"2.' in sections_str else 1.0
+                r["score"] = round(count * avg_q * section_weight * intent_w, 1)
+                results.append(r)
+            return results
+
+    def rerank_gaps_semantic(
+        self,
+        gaps: list[dict],
+        embeddings=None,
+        query_section: Optional[str] = None,
+        get_all_embeddings=None,
+        get_section_sources=None,
+    ) -> list[dict]:
+        """Rerank reference gaps using embedding similarity to section centroid.
+
+        Formula: final_score = heuristic_score * (0.5 + 0.5 * sim_to_centroid)
+        No embeddings -> returns gaps unchanged.
+
+        get_all_embeddings and get_section_sources are callables injected by
+        StateManager to avoid cross-repo coupling.
+        """
+        if not embeddings or not get_all_embeddings:
+            return gaps
+
+        from ..embeddings import cosine_similarity
+
+        all_emb = get_all_embeddings(model=embeddings.model_name)
+        if not all_emb:
+            return gaps
+
+        # Compute section centroid from sources assigned to that section
+        centroid = None
+        if query_section and get_section_sources:
+            section_sources = get_section_sources(query_section)
+            section_vecs = [
+                all_emb[sid] for sid in section_sources if sid in all_emb
+            ]
+            if section_vecs:
+                dim = len(section_vecs[0])
+                centroid = [
+                    sum(v[i] for v in section_vecs) / len(section_vecs)
+                    for i in range(dim)
+                ]
+
+        # If no section centroid, use global centroid of all embeddings
+        if not centroid and all_emb:
+            vecs = list(all_emb.values())
+            dim = len(vecs[0])
+            centroid = [
+                sum(v[i] for v in vecs) / len(vecs) for i in range(dim)
+            ]
+
+        if not centroid:
+            return gaps
+
+        # Rerank: boost by average similarity of citing sources to centroid
+        for gap in gaps:
+            source_ids = (gap.get("source_ids") or "").split(",")
+            sims = []
+            for sid in source_ids:
+                sid = sid.strip()
+                if sid in all_emb:
+                    sims.append(cosine_similarity(all_emb[sid], centroid))
+            if sims:
+                avg_sim = sum(sims) / len(sims)
+                gap["semantic_boost"] = round(avg_sim, 4)
+                gap["score"] = round(gap["score"] * (0.5 + 0.5 * avg_sim), 1)
+            else:
+                gap["semantic_boost"] = 0.0
+
+        gaps.sort(key=lambda g: g["score"], reverse=True)
+        return gaps
+
+    def get_section_sources(self, section: str) -> list[str]:
+        """Get source IDs assigned to a section (via source_sections or primary_section)."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT DISTINCT source_id FROM source_sections WHERE section LIKE ?",
+                (f"{section}%",),
+            )
+            ids = [row["source_id"] for row in cur.fetchall()]
+            if not ids:
+                cur = conn.execute(
+                    "SELECT id FROM sources WHERE primary_section LIKE ?",
+                    (f"{section}%",),
+                )
+                ids = [row["id"] for row in cur.fetchall()]
+            return ids
+
+    def get_gap_summary(self) -> dict:
+        """Lightweight summary for status line: open count + top gap."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(DISTINCT ref_authors || ref_year || ref_title) as cnt "
+                "FROM reference_gaps WHERE status='open'"
+            )
+            open_count = cur.fetchone()["cnt"]
+
+            top_ref = None
+            top_count = 0
+            if open_count > 0:
+                cur = conn.execute(
+                    """SELECT ref_authors, ref_year,
+                              COUNT(DISTINCT source_id) as cnt
+                       FROM reference_gaps WHERE status='open'
+                       GROUP BY ref_authors, ref_year, ref_title
+                       ORDER BY cnt DESC LIMIT 1"""
+                )
+                row = cur.fetchone()
+                if row:
+                    year_str = str(row["ref_year"]) if row["ref_year"] else ""
+                    top_ref = f"{row['ref_authors']} {year_str}".strip()
+                    top_count = row["cnt"]
+
+            return {
+                "open_count": open_count,
+                "top_ref": top_ref,
+                "top_count": top_count,
+            }
+
+    def resolve_gaps(self, entry_lookup: dict) -> int:
+        """Auto-resolve open gaps that match entries in library.
+
+        Matches by (author surname, year) or title prefix.
+        Returns count of resolved gaps.
+        """
+        lib_index: dict[str, str] = {}
+        for citekey, entry in entry_lookup.items():
+            if entry.author:
+                family = entry.author[0].family.lower().strip()
+                surname = family.split()[-1] if family else ""
+            else:
+                surname = ""
+            year = str(entry.year) if entry.year else ""
+            if surname and year:
+                lib_index[f"{surname} {year}"] = citekey
+            if entry.title:
+                lib_index[entry.title.lower()[:50]] = citekey
+
+        resolved = 0
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT id, ref_authors, ref_year, ref_title "
+                "FROM reference_gaps WHERE status='open'"
+            )
+            for row in cur.fetchall():
+                authors = (row["ref_authors"] or "").lower()
+                year = str(row["ref_year"]) if row["ref_year"] else ""
+                words = authors.replace("et al.", "").replace("\u0438 \u0434\u0440.", "").split()
+                surname = ""
+                for w in words:
+                    clean = w.strip(".,")
+                    if len(clean) > 2:
+                        surname = clean
+                        break
+                key = f"{surname} {year}"
+
+                matched_citekey = lib_index.get(key)
+                if not matched_citekey and row["ref_title"]:
+                    matched_citekey = lib_index.get(row["ref_title"].lower()[:50])
+
+                if matched_citekey:
+                    conn.execute(
+                        """UPDATE reference_gaps
+                           SET status='resolved', resolved_citekey=?,
+                               resolved_at=datetime('now')
+                           WHERE id=?""",
+                        (matched_citekey, row["id"]),
+                    )
+                    resolved += 1
+        return resolved
+
+    # ── Coverage ──────────────────────────────────────────────────────────
+
+    def get_coverage_stats(self) -> dict:
+        with self._conn() as conn:
+            stats: dict = {"chapters": {}, "sections": {}, "nr1": {}, "nr2": {}}
+            cur = conn.execute(
+                """SELECT primary_chapter, COUNT(*) as cnt FROM sources
+                   WHERE status=? AND primary_chapter IS NOT NULL
+                   GROUP BY primary_chapter""",
+                ("completed",),
+            )
+            for row in cur.fetchall():
+                stats["chapters"][row["primary_chapter"]] = row["cnt"]
+
+            cur = conn.execute(
+                """SELECT primary_section, COUNT(*) as cnt FROM sources
+                   WHERE status=? AND primary_section IS NOT NULL
+                   GROUP BY primary_section""",
+                ("completed",),
+            )
+            for row in cur.fetchall():
+                stats["sections"][row["primary_section"]] = row["cnt"]
+
+            for level in range(1, 6):
+                cur = conn.execute(
+                    "SELECT COUNT(*) as cnt FROM sources WHERE status=? AND relevance_nr1>=?",
+                    ("completed", level),
+                )
+                stats["nr1"][f">={level}"] = cur.fetchone()["cnt"]
+                cur = conn.execute(
+                    "SELECT COUNT(*) as cnt FROM sources WHERE status=? AND relevance_nr2>=?",
+                    ("completed", level),
+                )
+                stats["nr2"][f">={level}"] = cur.fetchone()["cnt"]
+            return stats
+
+    def get_gaps(self, min_sources: int = 3) -> list[dict]:
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT primary_section, COUNT(*) as cnt FROM sources
+                   WHERE status=? AND primary_section IS NOT NULL
+                   GROUP BY primary_section HAVING cnt < ?
+                   ORDER BY cnt ASC""",
+                ("completed", min_sources),
+            )
+            return [
+                {"section": row["primary_section"], "count": row["cnt"]}
+                for row in cur.fetchall()
+            ]
+
+    def reset_non_completed(self) -> dict[str, int]:
+        with self._conn() as conn:
+            counts = {}
+            for s in ["failed", "skipped", "processing"]:
+                cur = conn.execute(
+                    "SELECT COUNT(*) as cnt FROM sources WHERE status=?", (s,)
+                )
+                counts[s] = cur.fetchone()["cnt"]
+            conn.execute(
+                "UPDATE sources SET status=?, error_message=NULL WHERE status IN (?,?,?)",
+                ("pending", "failed", "skipped", "processing"),
+            )
+            return counts

--- a/src/klemma/repositories/plans.py
+++ b/src/klemma/repositories/plans.py
@@ -1,0 +1,126 @@
+"""Daily plans and reading queue repository."""
+
+from datetime import date, timedelta
+from typing import Optional
+
+from .base import BaseRepository
+
+# Subquery for filtering out sources marked for pruning
+PRUNE_DROP_SUBQUERY = (
+    "SELECT source_id FROM prune_verdicts "
+    "WHERE verdict='drop' AND updated_at > datetime('now', '-14 days')"
+)
+
+
+class PlansRepository(BaseRepository):
+
+    def save_plan(
+        self,
+        dissertation_task: str,
+        assistant_task: str,
+        reading_target: str = "",
+        reading_snippet: str = "",
+        plan_json: str = "",
+        progress_summary: str = "",
+    ):
+        today = date.today().isoformat()
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT INTO daily_plans
+                   (date, dissertation_task, assistant_task, reading_target,
+                    reading_snippet, plan_json, progress_summary)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(date) DO UPDATE SET
+                   dissertation_task=?, assistant_task=?, reading_target=?,
+                   reading_snippet=?, plan_json=?, progress_summary=?""",
+                (
+                    today, dissertation_task, assistant_task, reading_target,
+                    reading_snippet, plan_json, progress_summary,
+                    dissertation_task, assistant_task, reading_target,
+                    reading_snippet, plan_json, progress_summary,
+                ),
+            )
+
+    def get_writing_streak(self) -> dict:
+        """Calculate writing streak and days without progress from daily_plans."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT date FROM daily_plans ORDER BY date DESC LIMIT 30"
+            )
+            plan_dates = {row["date"] for row in cur.fetchall()}
+
+        if not plan_dates:
+            return {"days_without_progress": 0, "streak": 0, "last_progress_date": None}
+
+        today = date.today()
+        days_without = 0
+        streak = 0
+        last_progress = None
+
+        for i in range(1, 31):
+            check = (today - timedelta(days=i)).isoformat()
+            if check in plan_dates:
+                last_progress = last_progress or check
+                streak += 1
+            else:
+                if last_progress is None:
+                    days_without += 1
+                else:
+                    break
+
+        return {
+            "days_without_progress": days_without,
+            "streak": streak,
+            "last_progress_date": last_progress,
+        }
+
+    def get_plan(self, plan_date: Optional[str] = None) -> Optional[dict]:
+        d = plan_date or date.today().isoformat()
+        with self._conn() as conn:
+            cur = conn.execute("SELECT * FROM daily_plans WHERE date=?", (d,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def get_yesterday_plan(self) -> Optional[dict]:
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        return self.get_plan(yesterday)
+
+    # ── Reading Queue ────────────────────────────────────────────────────
+
+    def add_to_reading_queue(self, source_id: str, priority: int = 50, total_length: int = 0):
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT OR IGNORE INTO reading_queue (source_id, priority, total_length)
+                   VALUES (?, ?, ?)""",
+                (source_id, priority, total_length),
+            )
+
+    def get_next_reading(self) -> Optional[dict]:
+        with self._conn() as conn:
+            cur = conn.execute(
+                f"""SELECT rq.*, s.id as citekey
+                   FROM reading_queue rq
+                   JOIN sources s ON rq.source_id = s.id
+                   WHERE rq.status = 'queued'
+                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
+                   ORDER BY rq.priority DESC
+                   LIMIT 1"""
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def update_reading_position(self, source_id: str, position: int):
+        with self._conn() as conn:
+            conn.execute(
+                """UPDATE reading_queue SET current_position=?, status='reading',
+                   started_at=COALESCE(started_at, datetime('now'))
+                   WHERE source_id=?""",
+                (position, source_id),
+            )
+
+    def complete_reading(self, source_id: str):
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE reading_queue SET status='completed', completed_at=datetime('now') WHERE source_id=?",
+                (source_id,),
+            )

--- a/src/klemma/repositories/prune.py
+++ b/src/klemma/repositories/prune.py
@@ -1,0 +1,109 @@
+"""Prune verdicts repository — library audit recommendations."""
+
+from typing import Optional
+
+from .base import BaseRepository
+
+PRUNE_EXPIRY_DAYS = 14
+
+
+class PruneRepository(BaseRepository):
+
+    def save_prune_verdicts(self, drop: list[dict], maybe: list[dict]):
+        """Replace all prune verdicts with fresh results. Hard-protect valuable sources."""
+        with self._conn() as conn:
+            conn.execute("DELETE FROM prune_verdicts")
+            for item in drop:
+                ck = item.get("citekey", "").lstrip("@")
+                if not ck or self._is_protected(conn, ck):
+                    continue
+                conn.execute(
+                    "INSERT OR REPLACE INTO prune_verdicts (source_id, verdict, reason) VALUES (?, 'drop', ?)",
+                    (ck, item.get("reason", "")),
+                )
+            for item in maybe:
+                ck = item.get("citekey", "").lstrip("@")
+                if not ck or self._is_protected(conn, ck):
+                    continue
+                conn.execute(
+                    "INSERT OR REPLACE INTO prune_verdicts (source_id, verdict, reason) VALUES (?, 'maybe', ?)",
+                    (ck, item.get("reason", "")),
+                )
+
+    @staticmethod
+    def _is_protected(conn, source_id: str) -> bool:
+        """Check if source is too valuable to prune."""
+        cur = conn.execute(
+            "SELECT quality_score, relevance_nr1, relevance_nr2, citation_priority FROM sources WHERE id=?",
+            (source_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return True  # unknown source = don't prune
+        return (
+            (row["quality_score"] or 0) >= 4
+            or (row["relevance_nr1"] or 0) >= 4
+            or (row["relevance_nr2"] or 0) >= 4
+            or row["citation_priority"] == "high"
+        )
+
+    def get_prune_drop_ids(self, max_age_days: int = PRUNE_EXPIRY_DAYS) -> set[str]:
+        """Return citekeys with verdict='drop' within expiry window."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT source_id FROM prune_verdicts WHERE verdict='drop' AND updated_at > datetime('now', ?)",
+                (f"-{max_age_days} days",),
+            )
+            return {row["source_id"] for row in cur.fetchall()}
+
+    def get_prune_summary(self) -> dict:
+        """Return prune verdict counts for status display."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT verdict, COUNT(*) as cnt FROM prune_verdicts "
+                "WHERE updated_at > datetime('now', ?) GROUP BY verdict",
+                (f"-{PRUNE_EXPIRY_DAYS} days",),
+            )
+            result = {"drop": 0, "maybe": 0}
+            for row in cur.fetchall():
+                result[row["verdict"]] = row["cnt"]
+            result["total"] = result["drop"] + result["maybe"]
+            return result
+
+    def get_prune_verdicts(self, chapter: Optional[int] = None, verdict: Optional[str] = None) -> list[dict]:
+        """Get prune verdicts with source metadata, optionally filtered by chapter/verdict."""
+        with self._conn() as conn:
+            conditions = [f"pv.updated_at > datetime('now', '-{PRUNE_EXPIRY_DAYS} days')"]
+            params: list = []
+
+            if verdict:
+                conditions.append("pv.verdict = ?")
+                params.append(verdict)
+
+            if chapter is not None:
+                ch = str(chapter)
+                conditions.append(
+                    "EXISTS (SELECT 1 FROM source_sections ss2 "
+                    "WHERE ss2.source_id = pv.source_id AND (ss2.section = ? OR ss2.section LIKE ?))"
+                )
+                params.extend([ch, f"{ch}.%"])
+
+            where = " AND ".join(conditions)
+            cur = conn.execute(
+                f"""SELECT pv.source_id, pv.verdict, pv.reason,
+                           s.quality_score, s.fragment_count,
+                           GROUP_CONCAT(DISTINCT ss.section) as sections
+                    FROM prune_verdicts pv
+                    LEFT JOIN sources s ON s.id = pv.source_id
+                    LEFT JOIN source_sections ss ON ss.source_id = pv.source_id
+                    WHERE {where}
+                    GROUP BY pv.source_id
+                    ORDER BY pv.verdict, s.quality_score ASC NULLS LAST""",
+                params,
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def clear_prune_verdict(self, source_id: str):
+        """Remove prune verdict for a source (e.g. when user edits its vault note)."""
+        with self._conn() as conn:
+            conn.execute("DELETE FROM prune_verdicts WHERE source_id=?", (source_id,))

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -1,0 +1,398 @@
+"""Source management repository — CRUD, status, sections, Zotero keys, vault sync."""
+
+from datetime import date, datetime
+from typing import Optional
+
+from .base import BaseRepository
+
+# Subquery for filtering out sources marked for pruning
+PRUNE_DROP_SUBQUERY = (
+    "SELECT source_id FROM prune_verdicts "
+    "WHERE verdict='drop' AND updated_at > datetime('now', '-14 days')"
+)
+
+
+class ProcessingStatus:
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    ALL = [PENDING, PROCESSING, COMPLETED, FAILED, SKIPPED]
+
+
+class SourceRepository(BaseRepository):
+
+    def register_sources(self, source_ids: list[str]):
+        with self._conn() as conn:
+            conn.executemany(
+                "INSERT OR IGNORE INTO sources (id) VALUES (?)",
+                [(sid,) for sid in source_ids],
+            )
+
+    def set_pdf_path(self, source_id: str, path: str):
+        """Set the direct PDF path for a source."""
+        with self._conn() as conn:
+            conn.execute("UPDATE sources SET pdf_path = ? WHERE id = ?", (path, source_id))
+
+    def get_pending_sources(self, limit: int = 0) -> list[str]:
+        with self._conn() as conn:
+            if limit > 0:
+                today = date.today().isoformat()
+                cur = conn.execute(
+                    "SELECT count FROM daily_batches WHERE date = ?", (today,)
+                )
+                row = cur.fetchone()
+                already = row["count"] if row else 0
+                remaining = max(0, limit - already)
+                if remaining == 0:
+                    return []
+                cur = conn.execute(
+                    "SELECT id FROM sources WHERE status = ? ORDER BY id LIMIT ?",
+                    (ProcessingStatus.PENDING, remaining),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT id FROM sources WHERE status = ? ORDER BY id",
+                    (ProcessingStatus.PENDING,),
+                )
+            return [row["id"] for row in cur.fetchall()]
+
+    def mark_processing(self, source_id: str):
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE sources SET status = ? WHERE id = ?",
+                (ProcessingStatus.PROCESSING, source_id),
+            )
+
+    def mark_completed(
+        self,
+        source_id: str,
+        note_path: str,
+        quality_score: int = 0,
+        primary_chapter: Optional[int] = None,
+        primary_section: Optional[str] = None,
+        relevance_nr1: int = 0,
+        relevance_nr2: int = 0,
+        citation_priority: str = "medium",
+    ):
+        now = datetime.now().isoformat()
+        today = date.today().isoformat()
+        with self._conn() as conn:
+            conn.execute(
+                """UPDATE sources
+                   SET status=?, processed_at=?, note_path=?, quality_score=?,
+                       primary_chapter=?, primary_section=?,
+                       relevance_nr1=?, relevance_nr2=?, citation_priority=?
+                   WHERE id=?""",
+                (
+                    ProcessingStatus.COMPLETED, now, note_path, quality_score,
+                    primary_chapter, primary_section,
+                    relevance_nr1, relevance_nr2, citation_priority,
+                    source_id,
+                ),
+            )
+            conn.execute(
+                """INSERT INTO daily_batches (date, count) VALUES (?, 1)
+                   ON CONFLICT(date) DO UPDATE SET count = count + 1""",
+                (today,),
+            )
+
+    def update_source_metadata(
+        self,
+        source_id: str,
+        quality_score: int = 0,
+        primary_chapter: Optional[int] = None,
+        primary_section: Optional[str] = None,
+        relevance_nr1: int = 0,
+        relevance_nr2: int = 0,
+        citation_priority: str = "medium",
+        note_path: Optional[str] = None,
+        status: str = "completed",
+    ):
+        """Set metadata on an existing source (e.g. from vault import)."""
+        now = datetime.now().isoformat()
+        with self._conn() as conn:
+            conn.execute(
+                """UPDATE sources
+                   SET status=?, processed_at=?, quality_score=?,
+                       primary_chapter=?, primary_section=?,
+                       relevance_nr1=?, relevance_nr2=?, citation_priority=?,
+                       note_path=COALESCE(?, note_path)
+                   WHERE id=?""",
+                (
+                    status, now, quality_score,
+                    primary_chapter, primary_section,
+                    relevance_nr1, relevance_nr2, citation_priority,
+                    note_path,
+                    source_id,
+                ),
+            )
+
+    def mark_failed(self, source_id: str, error: str):
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE sources SET status=?, error_message=? WHERE id=?",
+                (ProcessingStatus.FAILED, error, source_id),
+            )
+
+    def mark_skipped(self, source_id: str, reason: str):
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE sources SET status=?, error_message=? WHERE id=?",
+                (ProcessingStatus.SKIPPED, reason, source_id),
+            )
+
+    def get_source(self, source_id: str) -> Optional[dict]:
+        with self._conn() as conn:
+            cur = conn.execute("SELECT * FROM sources WHERE id=?", (source_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def get_existing_source_ids(self) -> set[str]:
+        """Return set of all source IDs in DB."""
+        with self._conn() as conn:
+            return {row["id"] for row in conn.execute("SELECT id FROM sources")}
+
+    def get_sources_without_embeddings(self) -> list[str]:
+        """Return citekeys of completed sources missing embeddings."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT id FROM sources WHERE status='completed' AND embedding IS NULL"
+            )
+            return [row["id"] for row in cur]
+
+    def get_stats(self) -> dict[str, int]:
+        with self._conn() as conn:
+            stats = {}
+            for s in ProcessingStatus.ALL:
+                cur = conn.execute(
+                    "SELECT COUNT(*) as cnt FROM sources WHERE status=?", (s,)
+                )
+                stats[s] = cur.fetchone()["cnt"]
+            stats["total"] = sum(stats.values())
+            today = date.today().isoformat()
+            cur = conn.execute(
+                "SELECT count FROM daily_batches WHERE date=?", (today,)
+            )
+            row = cur.fetchone()
+            stats["today"] = row["count"] if row else 0
+            return stats
+
+    def set_source_sections(
+        self, source_id: str, sections: list[str], chapters: list[int]
+    ) -> None:
+        """Write all section/chapter assignments for a source."""
+        with self._conn() as conn:
+            self._set_sections_sql(conn, source_id, sections, chapters)
+
+    @staticmethod
+    def _set_sections_sql(conn, source_id: str, sections: list[str], chapters: list[int]):
+        """Write source_sections using an existing connection (avoids nested lock)."""
+        conn.execute("DELETE FROM source_sections WHERE source_id=?", (source_id,))
+        for sec in sections:
+            ch = int(sec.split(".")[0]) if "." in sec else None
+            if ch is None:
+                continue
+            conn.execute(
+                "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
+                (source_id, ch, sec),
+            )
+        existing_chapters = {int(s.split(".")[0]) for s in sections if "." in s}
+        for ch in chapters:
+            if ch not in existing_chapters:
+                conn.execute(
+                    "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
+                    (source_id, ch, str(ch)),
+                )
+
+    def get_all_sources(self) -> list[dict]:
+        """Get all completed sources with metadata."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT id, note_path, quality_score, primary_chapter,
+                          primary_section, relevance_nr1, relevance_nr2,
+                          citation_priority, fragment_count
+                   FROM sources WHERE status=?
+                   ORDER BY primary_chapter, citation_priority DESC, quality_score DESC""",
+                (ProcessingStatus.COMPLETED,),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def get_by_chapter(self, chapter: int) -> list[dict]:
+        with self._conn() as conn:
+            cur = conn.execute(
+                f"""SELECT DISTINCT s.id, s.note_path, s.quality_score, s.primary_section,
+                          s.relevance_nr1, s.relevance_nr2, s.citation_priority,
+                          s.fragment_count
+                   FROM sources s
+                   LEFT JOIN source_sections ss ON s.id = ss.source_id
+                   WHERE s.status=? AND (s.primary_chapter=? OR ss.chapter=?)
+                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
+                   ORDER BY s.citation_priority DESC, s.quality_score DESC""",
+                (ProcessingStatus.COMPLETED, chapter, chapter),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def get_by_section(self, section: str) -> list[dict]:
+        with self._conn() as conn:
+            cur = conn.execute(
+                f"""SELECT DISTINCT s.id, s.note_path, s.quality_score, s.primary_chapter,
+                          s.relevance_nr1, s.relevance_nr2, s.citation_priority,
+                          s.fragment_count
+                   FROM sources s
+                   LEFT JOIN source_sections ss ON s.id = ss.source_id
+                   WHERE s.status=? AND (s.primary_section LIKE ? OR ss.section LIKE ?)
+                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
+                   ORDER BY s.citation_priority DESC, s.quality_score DESC""",
+                (ProcessingStatus.COMPLETED, f"{section}%", f"{section}%"),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    # ── Zotero Key / Rename ────────────────────────────────────────────────
+
+    def get_zotero_key_map(self) -> dict[str, str]:
+        """Return {zotero_key: citekey} for all sources with a populated zotero_key."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT id, zotero_key FROM sources WHERE zotero_key IS NOT NULL AND zotero_key != ''"
+            )
+            return {row["zotero_key"]: row["id"] for row in cur.fetchall()}
+
+    def rename_source(self, old_id: str, new_id: str, zotero_key: str = ""):
+        """Cascade-rename source across all tables."""
+        with self._conn() as conn:
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute(
+                "UPDATE sources SET id=?, zotero_key=? WHERE id=?",
+                (new_id, zotero_key, old_id),
+            )
+            for table, col in [
+                ("fragments", "source_id"),
+                ("source_sections", "source_id"),
+                ("reference_gaps", "source_id"),
+                ("reading_queue", "source_id"),
+                ("prune_verdicts", "source_id"),
+            ]:
+                conn.execute(
+                    f"UPDATE {table} SET {col}=? WHERE {col}=?",
+                    (new_id, old_id),
+                )
+            conn.execute("PRAGMA foreign_keys=ON")
+
+    def delete_source(self, source_id: str):
+        """Delete an orphan source and all its FK-dependent rows."""
+        with self._conn() as conn:
+            for table, col in [
+                ("fragments", "source_id"),
+                ("source_sections", "source_id"),
+                ("reference_gaps", "source_id"),
+                ("reading_queue", "source_id"),
+                ("prune_verdicts", "source_id"),
+            ]:
+                conn.execute(f"DELETE FROM {table} WHERE {col}=?", (source_id,))
+            conn.execute("DELETE FROM sources WHERE id=?", (source_id,))
+
+    def populate_zotero_keys(self, mapping: dict[str, str]):
+        """Backfill zotero_key from {citekey: itemKey}. Only updates NULL rows."""
+        with self._conn() as conn:
+            for citekey, item_key in mapping.items():
+                conn.execute(
+                    "UPDATE sources SET zotero_key=? WHERE id=? AND (zotero_key IS NULL OR zotero_key='')",
+                    (item_key, citekey),
+                )
+
+    # ── Vault Sync ──────────────────────────────────────────────────────────
+
+    def sync_source_sections(
+        self,
+        vault_data: list[dict],
+        new_entries: list[tuple[str, dict]],
+    ) -> dict:
+        """Sync section assignments from vault frontmatter and register new Zotero entries.
+
+        vault_data: [{citekey, primary_section, primary_chapter, sections, chapters,
+                      quality, priority, nr1, nr2, note_path}]
+        new_entries: [(citekey, {chapter, section, chapters, sections})]
+
+        Returns {"vault_updated": int, "new_registered": int, "unchanged": int}.
+        """
+        vault_updated = 0
+        unchanged = 0
+        new_registered = 0
+
+        with self._conn() as conn:
+            for vd in vault_data:
+                citekey = vd["citekey"]
+
+                cur = conn.execute(
+                    """SELECT primary_section, primary_chapter, quality_score,
+                              relevance_nr1, relevance_nr2, citation_priority
+                       FROM sources WHERE id=?""",
+                    (citekey,),
+                )
+                row = cur.fetchone()
+                if not row:
+                    conn.execute("INSERT OR IGNORE INTO sources (id) VALUES (?)", (citekey,))
+
+                # Current DB sections
+                cur = conn.execute(
+                    "SELECT section FROM source_sections WHERE source_id=?",
+                    (citekey,),
+                )
+                db_sections = {r["section"] for r in cur.fetchall()}
+                vault_sections = set(vd.get("sections", []))
+
+                vault_primary = vd.get("primary_section")
+                needs_update = (
+                    row is None
+                    or vault_primary != (row["primary_section"] or None)
+                    or vault_sections != db_sections
+                    or (vd.get("quality", 0) or 0) != (row["quality_score"] or 0)
+                    or (vd.get("nr1", 0) or 0) != (row["relevance_nr1"] or 0)
+                    or (vd.get("nr2", 0) or 0) != (row["relevance_nr2"] or 0)
+                )
+
+                if needs_update:
+                    conn.execute(
+                        """UPDATE sources SET
+                            primary_section=?, primary_chapter=?,
+                            quality_score=?, relevance_nr1=?, relevance_nr2=?,
+                            citation_priority=?, note_path=COALESCE(?, note_path),
+                            status=CASE WHEN status='pending' THEN 'completed' ELSE status END
+                        WHERE id=?""",
+                        (
+                            vault_primary, vd.get("primary_chapter"),
+                            vd.get("quality", 0), vd.get("nr1", 0), vd.get("nr2", 0),
+                            vd.get("priority", "medium"), vd.get("note_path"),
+                            citekey,
+                        ),
+                    )
+                    self._set_sections_sql(conn, citekey, list(vault_sections), vd.get("chapters", []))
+                    # Auto-restore: if user edited vault note, clear prune verdict
+                    conn.execute("DELETE FROM prune_verdicts WHERE source_id=?", (citekey,))
+                    vault_updated += 1
+                else:
+                    unchanged += 1
+
+            # Register new Zotero entries not in DB
+            for citekey, classification in new_entries:
+                cur = conn.execute("SELECT id FROM sources WHERE id=?", (citekey,))
+                if cur.fetchone():
+                    continue
+                conn.execute(
+                    """INSERT INTO sources (id, status, primary_chapter, primary_section)
+                       VALUES (?, 'pending', ?, ?)""",
+                    (citekey, classification.get("chapter"), classification.get("section")),
+                )
+                sections = classification.get("sections", [])
+                chapters = classification.get("chapters", [])
+                if sections:
+                    self._set_sections_sql(conn, citekey, sections, chapters)
+                new_registered += 1
+
+        return {
+            "vault_updated": vault_updated,
+            "new_registered": new_registered,
+            "unchanged": unchanged,
+        }

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -189,8 +189,7 @@ def acquire_paper_local(
             state.set_pdf_path(citekey, permanent_path)
         if meta.sections:
             chapters = list({int(s.split(".")[0]) for s in meta.sections if "." in s})
-            with state._conn() as conn:
-                state._set_sections_inline(conn, citekey, meta.sections, chapters)
+            state.set_source_sections(citekey, meta.sections, chapters)
 
     pdf_path.unlink(missing_ok=True)
     return AcquireResult(

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -1,12 +1,20 @@
-"""Unified SQLite state manager."""
+"""Unified SQLite state manager — facade over domain repositories."""
 
-import json
 import sqlite3
 from contextlib import contextmanager
-from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Optional
+
+from .repositories import (
+    CitationsRepository,
+    EmbeddingsStoreRepository,
+    FragmentRepository,
+    GapsRepository,
+    PlansRepository,
+    PruneRepository,
+    SourceRepository,
+)
 
 
 class ProcessingStatus(Enum):
@@ -126,12 +134,28 @@ PRUNE_DROP_SUBQUERY = (
 
 
 class StateManager:
-    """Unified SQLite state for sources, fragments, plans, reading queue."""
+    """Facade over domain repositories — backward-compatible public API.
+
+    Repositories are exposed as attributes for direct access:
+        state.sources, state.fragments, state.embeddings_store,
+        state.gaps, state.citations, state.plans, state.prune
+
+    All original public methods still work via delegation.
+    """
 
     def __init__(self, db_path: str | Path):
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
+
+        # Compose domain repositories
+        self.sources = SourceRepository(self._conn)
+        self.fragments = FragmentRepository(self._conn)
+        self.embeddings_store = EmbeddingsStoreRepository(self._conn)
+        self.gaps = GapsRepository(self._conn)
+        self.citations = CitationsRepository(self._conn)
+        self.plans = PlansRepository(self._conn)
+        self.prune = PruneRepository(self._conn)
 
     @contextmanager
     def _conn(self):
@@ -160,7 +184,6 @@ class StateManager:
         target = 3  # bump this when adding new migrations
 
         if version < 1:
-            # Step 1.1: citation_intent for fragments and reference_gaps
             existing_frag = {
                 row[1] for row in conn.execute("PRAGMA table_info(fragments)")
             }
@@ -178,7 +201,6 @@ class StateManager:
                 )
 
         if version < 2:
-            # Step 2.2: embedding storage for sources
             existing_src = {
                 row[1] for row in conn.execute("PRAGMA table_info(sources)")
             }
@@ -192,7 +214,6 @@ class StateManager:
                 )
 
         if version < 3:
-            # Step 3.1: citation_links table for citation graph
             conn.execute("""CREATE TABLE IF NOT EXISTS citation_links (
                 source_id TEXT NOT NULL,
                 target_citekey TEXT,
@@ -207,1132 +228,218 @@ class StateManager:
 
         conn.execute(f"PRAGMA user_version = {target}")
 
-    # ── Sources ──────────────────────────────────────────────────────────
+    # ── Source delegation ─────────────────────────────────────────────────
 
     def register_sources(self, source_ids: list[str]):
-        with self._conn() as conn:
-            conn.executemany(
-                "INSERT OR IGNORE INTO sources (id) VALUES (?)",
-                [(sid,) for sid in source_ids],
-            )
+        return self.sources.register_sources(source_ids)
 
     def set_pdf_path(self, source_id: str, path: str):
-        """Set the direct PDF path for a source."""
-        with self._conn() as conn:
-            conn.execute("UPDATE sources SET pdf_path = ? WHERE id = ?", (path, source_id))
+        return self.sources.set_pdf_path(source_id, path)
 
     def get_pending_sources(self, limit: int = 0) -> list[str]:
-        with self._conn() as conn:
-            if limit > 0:
-                today = date.today().isoformat()
-                cur = conn.execute(
-                    "SELECT count FROM daily_batches WHERE date = ?", (today,)
-                )
-                row = cur.fetchone()
-                already = row["count"] if row else 0
-                remaining = max(0, limit - already)
-                if remaining == 0:
-                    return []
-                cur = conn.execute(
-                    "SELECT id FROM sources WHERE status = ? ORDER BY id LIMIT ?",
-                    (ProcessingStatus.PENDING.value, remaining),
-                )
-            else:
-                cur = conn.execute(
-                    "SELECT id FROM sources WHERE status = ? ORDER BY id",
-                    (ProcessingStatus.PENDING.value,),
-                )
-            return [row["id"] for row in cur.fetchall()]
+        return self.sources.get_pending_sources(limit)
 
     def mark_processing(self, source_id: str):
-        with self._conn() as conn:
-            conn.execute(
-                "UPDATE sources SET status = ? WHERE id = ?",
-                (ProcessingStatus.PROCESSING.value, source_id),
-            )
+        return self.sources.mark_processing(source_id)
 
-    def mark_completed(
-        self,
-        source_id: str,
-        note_path: str,
-        quality_score: int = 0,
-        primary_chapter: Optional[int] = None,
-        primary_section: Optional[str] = None,
-        relevance_nr1: int = 0,
-        relevance_nr2: int = 0,
-        citation_priority: str = "medium",
-    ):
-        now = datetime.now().isoformat()
-        today = date.today().isoformat()
-        with self._conn() as conn:
-            conn.execute(
-                """UPDATE sources
-                   SET status=?, processed_at=?, note_path=?, quality_score=?,
-                       primary_chapter=?, primary_section=?,
-                       relevance_nr1=?, relevance_nr2=?, citation_priority=?
-                   WHERE id=?""",
-                (
-                    ProcessingStatus.COMPLETED.value, now, note_path, quality_score,
-                    primary_chapter, primary_section,
-                    relevance_nr1, relevance_nr2, citation_priority,
-                    source_id,
-                ),
-            )
-            conn.execute(
-                """INSERT INTO daily_batches (date, count) VALUES (?, 1)
-                   ON CONFLICT(date) DO UPDATE SET count = count + 1""",
-                (today,),
-            )
+    def mark_completed(self, source_id: str, note_path: str, quality_score: int = 0,
+                       primary_chapter: Optional[int] = None, primary_section: Optional[str] = None,
+                       relevance_nr1: int = 0, relevance_nr2: int = 0, citation_priority: str = "medium"):
+        return self.sources.mark_completed(source_id, note_path, quality_score,
+                                           primary_chapter, primary_section,
+                                           relevance_nr1, relevance_nr2, citation_priority)
 
-    def update_source_metadata(
-        self,
-        source_id: str,
-        quality_score: int = 0,
-        primary_chapter: Optional[int] = None,
-        primary_section: Optional[str] = None,
-        relevance_nr1: int = 0,
-        relevance_nr2: int = 0,
-        citation_priority: str = "medium",
-        note_path: Optional[str] = None,
-        status: str = "completed",
-    ):
-        """Set metadata on an existing source (e.g. from vault import)."""
-        now = datetime.now().isoformat()
-        with self._conn() as conn:
-            conn.execute(
-                """UPDATE sources
-                   SET status=?, processed_at=?, quality_score=?,
-                       primary_chapter=?, primary_section=?,
-                       relevance_nr1=?, relevance_nr2=?, citation_priority=?,
-                       note_path=COALESCE(?, note_path)
-                   WHERE id=?""",
-                (
-                    status, now, quality_score,
-                    primary_chapter, primary_section,
-                    relevance_nr1, relevance_nr2, citation_priority,
-                    note_path,
-                    source_id,
-                ),
-            )
+    def update_source_metadata(self, source_id: str, quality_score: int = 0,
+                               primary_chapter: Optional[int] = None, primary_section: Optional[str] = None,
+                               relevance_nr1: int = 0, relevance_nr2: int = 0,
+                               citation_priority: str = "medium", note_path: Optional[str] = None,
+                               status: str = "completed"):
+        return self.sources.update_source_metadata(source_id, quality_score,
+                                                   primary_chapter, primary_section,
+                                                   relevance_nr1, relevance_nr2,
+                                                   citation_priority, note_path, status)
 
     def mark_failed(self, source_id: str, error: str):
-        with self._conn() as conn:
-            conn.execute(
-                "UPDATE sources SET status=?, error_message=? WHERE id=?",
-                (ProcessingStatus.FAILED.value, error, source_id),
-            )
+        return self.sources.mark_failed(source_id, error)
 
     def mark_skipped(self, source_id: str, reason: str):
-        with self._conn() as conn:
-            conn.execute(
-                "UPDATE sources SET status=?, error_message=? WHERE id=?",
-                (ProcessingStatus.SKIPPED.value, reason, source_id),
-            )
+        return self.sources.mark_skipped(source_id, reason)
 
     def get_source(self, source_id: str) -> Optional[dict]:
-        with self._conn() as conn:
-            cur = conn.execute("SELECT * FROM sources WHERE id=?", (source_id,))
-            row = cur.fetchone()
-            return dict(row) if row else None
+        return self.sources.get_source(source_id)
+
+    def get_existing_source_ids(self) -> set[str]:
+        return self.sources.get_existing_source_ids()
+
+    def get_sources_without_embeddings(self) -> list[str]:
+        return self.sources.get_sources_without_embeddings()
 
     def get_stats(self) -> dict[str, int]:
-        with self._conn() as conn:
-            stats = {}
-            for s in ProcessingStatus:
-                cur = conn.execute(
-                    "SELECT COUNT(*) as cnt FROM sources WHERE status=?", (s.value,)
-                )
-                stats[s.value] = cur.fetchone()["cnt"]
-            stats["total"] = sum(stats.values())
-            today = date.today().isoformat()
-            cur = conn.execute(
-                "SELECT count FROM daily_batches WHERE date=?", (today,)
-            )
-            row = cur.fetchone()
-            stats["today"] = row["count"] if row else 0
-            return stats
+        return self.sources.get_stats()
 
-    def set_source_sections(
-        self, source_id: str, sections: list[str], chapters: list[int]
-    ) -> None:
-        """Записать все секции/главы для источника (из frontmatter sections/chapters)."""
-        with self._conn() as conn:
-            conn.execute(
-                "DELETE FROM source_sections WHERE source_id=?", (source_id,)
-            )
-            for sec in sections:
-                # Определить главу из номера секции
-                ch = int(sec.split(".")[0]) if "." in sec else None
-                # Или взять из списка chapters если глава без точки
-                if ch is None:
-                    continue
-                conn.execute(
-                    "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
-                    (source_id, ch, sec),
-                )
-            # Добавить главы без конкретных секций (если chapters шире чем sections)
-            existing_chapters = {int(s.split(".")[0]) for s in sections if "." in s}
-            for ch in chapters:
-                if ch not in existing_chapters:
-                    conn.execute(
-                        "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
-                        (source_id, ch, str(ch)),
-                    )
+    def set_source_sections(self, source_id: str, sections: list[str], chapters: list[int]) -> None:
+        return self.sources.set_source_sections(source_id, sections, chapters)
 
     def get_all_sources(self) -> list[dict]:
-        """Get all completed sources with metadata."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                """SELECT id, note_path, quality_score, primary_chapter,
-                          primary_section, relevance_nr1, relevance_nr2,
-                          citation_priority, fragment_count
-                   FROM sources WHERE status=?
-                   ORDER BY primary_chapter, citation_priority DESC, quality_score DESC""",
-                (ProcessingStatus.COMPLETED.value,),
-            )
-            return [dict(row) for row in cur.fetchall()]
+        return self.sources.get_all_sources()
 
     def get_by_chapter(self, chapter: int) -> list[dict]:
-        with self._conn() as conn:
-            cur = conn.execute(
-                f"""SELECT DISTINCT s.id, s.note_path, s.quality_score, s.primary_section,
-                          s.relevance_nr1, s.relevance_nr2, s.citation_priority,
-                          s.fragment_count
-                   FROM sources s
-                   LEFT JOIN source_sections ss ON s.id = ss.source_id
-                   WHERE s.status=? AND (s.primary_chapter=? OR ss.chapter=?)
-                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
-                   ORDER BY s.citation_priority DESC, s.quality_score DESC""",
-                (ProcessingStatus.COMPLETED.value, chapter, chapter),
-            )
-            return [dict(row) for row in cur.fetchall()]
+        return self.sources.get_by_chapter(chapter)
 
     def get_by_section(self, section: str) -> list[dict]:
-        with self._conn() as conn:
-            cur = conn.execute(
-                f"""SELECT DISTINCT s.id, s.note_path, s.quality_score, s.primary_chapter,
-                          s.relevance_nr1, s.relevance_nr2, s.citation_priority,
-                          s.fragment_count
-                   FROM sources s
-                   LEFT JOIN source_sections ss ON s.id = ss.source_id
-                   WHERE s.status=? AND (s.primary_section LIKE ? OR ss.section LIKE ?)
-                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
-                   ORDER BY s.citation_priority DESC, s.quality_score DESC""",
-                (ProcessingStatus.COMPLETED.value, f"{section}%", f"{section}%"),
-            )
-            return [dict(row) for row in cur.fetchall()]
-
-    def get_coverage_stats(self) -> dict:
-        with self._conn() as conn:
-            stats: dict = {"chapters": {}, "sections": {}, "nr1": {}, "nr2": {}}
-            cur = conn.execute(
-                """SELECT primary_chapter, COUNT(*) as cnt FROM sources
-                   WHERE status=? AND primary_chapter IS NOT NULL
-                   GROUP BY primary_chapter""",
-                (ProcessingStatus.COMPLETED.value,),
-            )
-            for row in cur.fetchall():
-                stats["chapters"][row["primary_chapter"]] = row["cnt"]
-
-            cur = conn.execute(
-                """SELECT primary_section, COUNT(*) as cnt FROM sources
-                   WHERE status=? AND primary_section IS NOT NULL
-                   GROUP BY primary_section""",
-                (ProcessingStatus.COMPLETED.value,),
-            )
-            for row in cur.fetchall():
-                stats["sections"][row["primary_section"]] = row["cnt"]
-
-            for level in range(1, 6):
-                cur = conn.execute(
-                    "SELECT COUNT(*) as cnt FROM sources WHERE status=? AND relevance_nr1>=?",
-                    (ProcessingStatus.COMPLETED.value, level),
-                )
-                stats["nr1"][f">={level}"] = cur.fetchone()["cnt"]
-                cur = conn.execute(
-                    "SELECT COUNT(*) as cnt FROM sources WHERE status=? AND relevance_nr2>=?",
-                    (ProcessingStatus.COMPLETED.value, level),
-                )
-                stats["nr2"][f">={level}"] = cur.fetchone()["cnt"]
-            return stats
-
-    def get_gaps(self, min_sources: int = 3) -> list[dict]:
-        with self._conn() as conn:
-            cur = conn.execute(
-                """SELECT primary_section, COUNT(*) as cnt FROM sources
-                   WHERE status=? AND primary_section IS NOT NULL
-                   GROUP BY primary_section HAVING cnt < ?
-                   ORDER BY cnt ASC""",
-                (ProcessingStatus.COMPLETED.value, min_sources),
-            )
-            return [
-                {"section": row["primary_section"], "count": row["cnt"]}
-                for row in cur.fetchall()
-            ]
-
-    def reset_non_completed(self) -> dict[str, int]:
-        with self._conn() as conn:
-            counts = {}
-            for s in [ProcessingStatus.FAILED, ProcessingStatus.SKIPPED, ProcessingStatus.PROCESSING]:
-                cur = conn.execute(
-                    "SELECT COUNT(*) as cnt FROM sources WHERE status=?", (s.value,)
-                )
-                counts[s.value] = cur.fetchone()["cnt"]
-            conn.execute(
-                "UPDATE sources SET status=?, error_message=NULL WHERE status IN (?,?,?)",
-                (
-                    ProcessingStatus.PENDING.value,
-                    ProcessingStatus.FAILED.value,
-                    ProcessingStatus.SKIPPED.value,
-                    ProcessingStatus.PROCESSING.value,
-                ),
-            )
-            return counts
-
-    # ── Zotero Key / Rename ────────────────────────────────────────────────
+        return self.sources.get_by_section(section)
 
     def get_zotero_key_map(self) -> dict[str, str]:
-        """Return {zotero_key: citekey} for all sources with a populated zotero_key."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT id, zotero_key FROM sources WHERE zotero_key IS NOT NULL AND zotero_key != ''"
-            )
-            return {row["zotero_key"]: row["id"] for row in cur.fetchall()}
+        return self.sources.get_zotero_key_map()
 
     def rename_source(self, old_id: str, new_id: str, zotero_key: str = ""):
-        """Cascade-rename source across all tables."""
-        with self._conn() as conn:
-            # Temporarily disable FK checks for atomic rename
-            conn.execute("PRAGMA foreign_keys=OFF")
-            conn.execute(
-                "UPDATE sources SET id=?, zotero_key=? WHERE id=?",
-                (new_id, zotero_key, old_id),
-            )
-            for table, col in [
-                ("fragments", "source_id"),
-                ("source_sections", "source_id"),
-                ("reference_gaps", "source_id"),
-                ("reading_queue", "source_id"),
-                ("prune_verdicts", "source_id"),
-            ]:
-                conn.execute(
-                    f"UPDATE {table} SET {col}=? WHERE {col}=?",
-                    (new_id, old_id),
-                )
-            conn.execute("PRAGMA foreign_keys=ON")
+        return self.sources.rename_source(old_id, new_id, zotero_key)
 
     def delete_source(self, source_id: str):
-        """Delete an orphan source and all its FK-dependent rows."""
-        with self._conn() as conn:
-            for table, col in [
-                ("fragments", "source_id"),
-                ("source_sections", "source_id"),
-                ("reference_gaps", "source_id"),
-                ("reading_queue", "source_id"),
-                ("prune_verdicts", "source_id"),
-            ]:
-                conn.execute(f"DELETE FROM {table} WHERE {col}=?", (source_id,))
-            conn.execute("DELETE FROM sources WHERE id=?", (source_id,))
+        return self.sources.delete_source(source_id)
 
     def populate_zotero_keys(self, mapping: dict[str, str]):
-        """Backfill zotero_key from {citekey: itemKey}. Only updates NULL rows."""
-        with self._conn() as conn:
-            for citekey, item_key in mapping.items():
-                conn.execute(
-                    "UPDATE sources SET zotero_key=? WHERE id=? AND (zotero_key IS NULL OR zotero_key='')",
-                    (item_key, citekey),
-                )
+        return self.sources.populate_zotero_keys(mapping)
 
-    # ── Embeddings ─────────────────────────────────────────────────────
+    def sync_source_sections(self, vault_data: list[dict], new_entries: list[tuple[str, dict]]) -> dict:
+        return self.sources.sync_source_sections(vault_data, new_entries)
 
-    def save_embedding(
-        self, source_id: str, embedding: list[float], model: str
-    ):
-        """Store embedding vector as BLOB with model name."""
-        import struct
-
-        blob = struct.pack(f"{len(embedding)}f", *embedding)
-        with self._conn() as conn:
-            conn.execute(
-                "UPDATE sources SET embedding=?, embedding_model=? WHERE id=?",
-                (blob, model, source_id),
-            )
-
-    def get_embedding(self, source_id: str) -> Optional[tuple[list[float], str]]:
-        """Retrieve embedding vector and model name for a source.
-
-        Returns (vector, model_name) or None if no embedding stored.
-        """
-        import struct
-
-        with self._conn() as conn:
-            row = conn.execute(
-                "SELECT embedding, embedding_model FROM sources WHERE id=?",
-                (source_id,),
-            ).fetchone()
-            if not row or not row["embedding"]:
-                return None
-            blob = row["embedding"]
-            n = len(blob) // 4  # float32 = 4 bytes
-            vec = list(struct.unpack(f"{n}f", blob))
-            return (vec, row["embedding_model"] or "")
-
-    def get_all_embeddings(
-        self, model: Optional[str] = None
-    ) -> dict[str, list[float]]:
-        """Get all source embeddings, optionally filtered by model.
-
-        Returns {source_id: vector}.
-        """
-        import struct
-
-        with self._conn() as conn:
-            if model:
-                cur = conn.execute(
-                    "SELECT id, embedding FROM sources "
-                    "WHERE embedding IS NOT NULL AND embedding_model=?",
-                    (model,),
-                )
-            else:
-                cur = conn.execute(
-                    "SELECT id, embedding FROM sources WHERE embedding IS NOT NULL"
-                )
-            result = {}
-            for row in cur.fetchall():
-                blob = row["embedding"]
-                n = len(blob) // 4
-                result[row["id"]] = list(struct.unpack(f"{n}f", blob))
-            return result
-
-    def get_embedding_stats(self) -> dict:
-        """Get embedding coverage stats."""
-        with self._conn() as conn:
-            total = conn.execute(
-                "SELECT COUNT(*) as cnt FROM sources WHERE status='completed'"
-            ).fetchone()["cnt"]
-            embedded = conn.execute(
-                "SELECT COUNT(*) as cnt FROM sources WHERE embedding IS NOT NULL"
-            ).fetchone()["cnt"]
-            models = {}
-            cur = conn.execute(
-                "SELECT embedding_model, COUNT(*) as cnt FROM sources "
-                "WHERE embedding IS NOT NULL GROUP BY embedding_model"
-            )
-            for row in cur.fetchall():
-                models[row["embedding_model"] or "unknown"] = row["cnt"]
-            return {"total": total, "embedded": embedded, "models": models}
-
-    # ── Fragments ────────────────────────────────────────────────────────
+    # ── Fragment delegation ───────────────────────────────────────────────
 
     def save_fragments(self, source_id: str, fragments: list[dict]) -> int:
-        """Save extracted fragments and update source fragment count."""
-        with self._conn() as conn:
-            for f in fragments:
-                conn.execute(
-                    """INSERT INTO fragments
-                       (source_id, fragment_text, fragment_type, chapter, section,
-                        relevance_score, usage_hint, page_number, citation_intent)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        source_id,
-                        f.get("text", ""),
-                        f.get("type", "key_idea"),
-                        f.get("chapter"),
-                        f.get("section"),
-                        f.get("relevance", 3),
-                        f.get("usage_hint", ""),
-                        f.get("page"),
-                        f.get("citation_intent"),
-                    ),
-                )
-            conn.execute(
-                "UPDATE sources SET fragment_count=? WHERE id=?",
-                (len(fragments), source_id),
-            )
-            return len(fragments)
+        return self.fragments.save_fragments(source_id, fragments)
 
-    def get_fragments(
-        self,
-        source_id: Optional[str] = None,
-        chapter: Optional[int] = None,
-        section: Optional[str] = None,
-        fragment_type: Optional[str] = None,
-        limit: int = 50,
-    ) -> list[dict]:
-        """Query fragments with optional filters."""
-        conditions = []
-        params: list = []
-        if source_id:
-            conditions.append("source_id=?")
-            params.append(source_id)
-        if chapter:
-            conditions.append("chapter=?")
-            params.append(chapter)
-        if section:
-            conditions.append("section LIKE ?")
-            params.append(f"{section}%")
-        if fragment_type:
-            conditions.append("fragment_type=?")
-            params.append(fragment_type)
-
-        where = " AND ".join(conditions) if conditions else "1=1"
-        params.append(limit)
-
-        with self._conn() as conn:
-            cur = conn.execute(
-                f"""SELECT f.*, s.id as citekey
-                    FROM fragments f
-                    JOIN sources s ON f.source_id = s.id
-                    WHERE {where}
-                    ORDER BY f.relevance_score DESC, f.extracted_at DESC
-                    LIMIT ?""",
-                params,
-            )
-            return [dict(row) for row in cur.fetchall()]
+    def get_fragments(self, source_id: Optional[str] = None, chapter: Optional[int] = None,
+                      section: Optional[str] = None, fragment_type: Optional[str] = None,
+                      limit: int = 50) -> list[dict]:
+        return self.fragments.get_fragments(source_id, chapter, section, fragment_type, limit)
 
     def get_fragment_stats(self) -> dict:
-        """Get fragment counts by type, chapter, section."""
-        with self._conn() as conn:
-            stats: dict = {"total": 0, "by_type": {}, "by_chapter": {}, "by_section": {}}
-            cur = conn.execute("SELECT COUNT(*) as cnt FROM fragments")
-            stats["total"] = cur.fetchone()["cnt"]
-
-            cur = conn.execute(
-                "SELECT fragment_type, COUNT(*) as cnt FROM fragments GROUP BY fragment_type"
-            )
-            for row in cur.fetchall():
-                stats["by_type"][row["fragment_type"] or "unknown"] = row["cnt"]
-
-            cur = conn.execute(
-                "SELECT chapter, COUNT(*) as cnt FROM fragments WHERE chapter IS NOT NULL GROUP BY chapter"
-            )
-            for row in cur.fetchall():
-                stats["by_chapter"][row["chapter"]] = row["cnt"]
-
-            cur = conn.execute(
-                "SELECT section, COUNT(*) as cnt FROM fragments WHERE section IS NOT NULL GROUP BY section"
-            )
-            for row in cur.fetchall():
-                stats["by_section"][row["section"]] = row["cnt"]
-            return stats
+        return self.fragments.get_fragment_stats()
 
     def get_intent_coverage(self) -> dict[str, dict[str, int]]:
-        """Get fragment counts by section × citation_intent.
+        return self.fragments.get_intent_coverage()
 
-        Returns {section: {background: N, method: N, result_comparison: N, total: N}}.
-        Only includes sections that have at least one fragment with a non-NULL intent.
-        """
-        with self._conn() as conn:
-            cur = conn.execute(
-                """SELECT section, citation_intent, COUNT(*) as cnt
-                   FROM fragments
-                   WHERE section IS NOT NULL AND citation_intent IS NOT NULL
-                   GROUP BY section, citation_intent
-                   ORDER BY section"""
-            )
-            result: dict[str, dict[str, int]] = {}
-            for row in cur.fetchall():
-                sec = row["section"]
-                if sec not in result:
-                    result[sec] = {
-                        "background": 0,
-                        "method": 0,
-                        "result_comparison": 0,
-                        "total": 0,
-                    }
-                intent = row["citation_intent"]
-                if intent in result[sec]:
-                    result[sec][intent] = row["cnt"]
-                    result[sec]["total"] += row["cnt"]
-            return result
+    # ── Embedding delegation ──────────────────────────────────────────────
 
-    # ── Daily Plans ──────────────────────────────────────────────────────
+    def save_embedding(self, source_id: str, embedding: list[float], model: str):
+        return self.embeddings_store.save_embedding(source_id, embedding, model)
 
-    def save_plan(
-        self,
-        dissertation_task: str,
-        assistant_task: str,
-        reading_target: str = "",
-        reading_snippet: str = "",
-        plan_json: str = "",
-        progress_summary: str = "",
-    ):
-        today = date.today().isoformat()
-        with self._conn() as conn:
-            conn.execute(
-                """INSERT INTO daily_plans
-                   (date, dissertation_task, assistant_task, reading_target,
-                    reading_snippet, plan_json, progress_summary)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(date) DO UPDATE SET
-                   dissertation_task=?, assistant_task=?, reading_target=?,
-                   reading_snippet=?, plan_json=?, progress_summary=?""",
-                (
-                    today, dissertation_task, assistant_task, reading_target,
-                    reading_snippet, plan_json, progress_summary,
-                    dissertation_task, assistant_task, reading_target,
-                    reading_snippet, plan_json, progress_summary,
-                ),
-            )
+    def get_embedding(self, source_id: str) -> Optional[tuple[list[float], str]]:
+        return self.embeddings_store.get_embedding(source_id)
 
-    def get_writing_streak(self) -> dict:
-        """Calculate writing streak and days without progress from daily_plans.
+    def get_all_embeddings(self, model: Optional[str] = None) -> dict[str, list[float]]:
+        return self.embeddings_store.get_all_embeddings(model)
 
-        A day counts as 'progress' if a plan was generated for it.
-        Returns {"days_without_progress": int, "streak": int, "last_progress_date": str|None}.
-        """
-        from datetime import timedelta
+    def get_embedding_stats(self) -> dict:
+        return self.embeddings_store.get_embedding_stats()
 
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT date FROM daily_plans ORDER BY date DESC LIMIT 30"
-            )
-            plan_dates = {row["date"] for row in cur.fetchall()}
-
-        if not plan_dates:
-            return {"days_without_progress": 0, "streak": 0, "last_progress_date": None}
-
-        today = date.today()
-        days_without = 0
-        streak = 0
-        last_progress = None
-
-        # Count from yesterday backward (today's plan hasn't been generated yet)
-        for i in range(1, 31):
-            check = (today - timedelta(days=i)).isoformat()
-            if check in plan_dates:
-                last_progress = last_progress or check
-                streak += 1
-            else:
-                if last_progress is None:
-                    days_without += 1
-                else:
-                    break
-
-        return {
-            "days_without_progress": days_without,
-            "streak": streak,
-            "last_progress_date": last_progress,
-        }
-
-    def get_plan(self, plan_date: Optional[str] = None) -> Optional[dict]:
-        d = plan_date or date.today().isoformat()
-        with self._conn() as conn:
-            cur = conn.execute("SELECT * FROM daily_plans WHERE date=?", (d,))
-            row = cur.fetchone()
-            return dict(row) if row else None
-
-    def get_yesterday_plan(self) -> Optional[dict]:
-        from datetime import timedelta
-        yesterday = (date.today() - timedelta(days=1)).isoformat()
-        return self.get_plan(yesterday)
-
-    # ── Reading Queue ────────────────────────────────────────────────────
-
-    def add_to_reading_queue(self, source_id: str, priority: int = 50, total_length: int = 0):
-        with self._conn() as conn:
-            conn.execute(
-                """INSERT OR IGNORE INTO reading_queue (source_id, priority, total_length)
-                   VALUES (?, ?, ?)""",
-                (source_id, priority, total_length),
-            )
-
-    def get_next_reading(self) -> Optional[dict]:
-        with self._conn() as conn:
-            cur = conn.execute(
-                f"""SELECT rq.*, s.id as citekey
-                   FROM reading_queue rq
-                   JOIN sources s ON rq.source_id = s.id
-                   WHERE rq.status = 'queued'
-                     AND s.id NOT IN ({PRUNE_DROP_SUBQUERY})
-                   ORDER BY rq.priority DESC
-                   LIMIT 1"""
-            )
-            row = cur.fetchone()
-            return dict(row) if row else None
-
-    def update_reading_position(self, source_id: str, position: int):
-        with self._conn() as conn:
-            conn.execute(
-                """UPDATE reading_queue SET current_position=?, status='reading',
-                   started_at=COALESCE(started_at, datetime('now'))
-                   WHERE source_id=?""",
-                (position, source_id),
-            )
-
-    def complete_reading(self, source_id: str):
-        with self._conn() as conn:
-            conn.execute(
-                "UPDATE reading_queue SET status='completed', completed_at=datetime('now') WHERE source_id=?",
-                (source_id,),
-            )
-
-    # ── Reference Gaps ────────────────────────────────────────────────────
+    # ── Gaps delegation ───────────────────────────────────────────────────
 
     def save_reference_gaps(self, source_id: str, gaps: list[dict]) -> int:
-        """Save reference gaps for a source (idempotent: replaces old gaps)."""
-        with self._conn() as conn:
-            conn.execute(
-                "DELETE FROM reference_gaps WHERE source_id=?", (source_id,)
-            )
-            for g in gaps:
-                sections = g.get("dissertation_sections", [])
-                conn.execute(
-                    """INSERT INTO reference_gaps
-                       (source_id, ref_authors, ref_year, ref_title,
-                        why_relevant, dissertation_sections, citation_intent)
-                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        source_id,
-                        g.get("ref_authors", g.get("authors", "")),
-                        g.get("ref_year", g.get("year")),
-                        g.get("ref_title", g.get("title", "")),
-                        g.get("why_relevant", ""),
-                        json.dumps(sections) if sections else None,
-                        g.get("citation_intent"),
-                    ),
-                )
-            return len(gaps)
+        return self.gaps.save_reference_gaps(source_id, gaps)
 
-    def get_reference_gaps(
-        self,
-        section: Optional[str] = None,
-        limit: int = 50,
-    ) -> list[dict]:
-        """Get open reference gaps aggregated by (authors, year, title).
+    def get_reference_gaps(self, section: Optional[str] = None, limit: int = 50) -> list[dict]:
+        return self.gaps.get_reference_gaps(section, limit)
 
-        Returns list of dicts with: ref_authors, ref_year, ref_title,
-        why_relevant, dissertation_sections, count, avg_quality,
-        intent_weight, score, source_ids.
-
-        Scoring formula: count * avg_quality * section_weight * intent_weight
-        where intent_weight = AVG(method=3.0, result_comparison=2.0, else=1.0)
-        NULL intents → weight 1.0 (backward compatible).
-        """
-        with self._conn() as conn:
-            query = """
-                SELECT
-                    rg.ref_authors,
-                    rg.ref_year,
-                    rg.ref_title,
-                    GROUP_CONCAT(DISTINCT rg.why_relevant) as why_relevant,
-                    GROUP_CONCAT(DISTINCT rg.dissertation_sections) as dissertation_sections,
-                    COUNT(DISTINCT rg.source_id) as count,
-                    AVG(COALESCE(s.quality_score, 3)) as avg_quality,
-                    AVG(CASE
-                        WHEN rg.citation_intent = 'method' THEN 3.0
-                        WHEN rg.citation_intent = 'result_comparison' THEN 2.0
-                        ELSE 1.0
-                    END) as intent_weight,
-                    GROUP_CONCAT(DISTINCT rg.source_id) as source_ids
-                FROM reference_gaps rg
-                JOIN sources s ON rg.source_id = s.id
-                WHERE rg.status = 'open'
-            """
-            params: list = []
-            if section:
-                query += " AND rg.dissertation_sections LIKE ?"
-                params.append(f'%"{section}%')
-
-            query += """
-                GROUP BY rg.ref_authors, rg.ref_year, rg.ref_title
-                ORDER BY COUNT(DISTINCT rg.source_id)
-                       * AVG(COALESCE(s.quality_score, 3))
-                       * AVG(CASE
-                           WHEN rg.citation_intent = 'method' THEN 3.0
-                           WHEN rg.citation_intent = 'result_comparison' THEN 2.0
-                           ELSE 1.0
-                         END)
-                       DESC
-                LIMIT ?
-            """
-            params.append(limit)
-
-            cur = conn.execute(query, params)
-            results = []
-            for row in cur.fetchall():
-                r = dict(row)
-                count = r["count"]
-                avg_q = r["avg_quality"] or 3
-                intent_w = r.get("intent_weight") or 1.0
-                # section_weight: 2.0 if relevant to NR1/NR2 sections (2.x)
-                sections_str = r.get("dissertation_sections") or ""
-                section_weight = 2.0 if '"2.' in sections_str else 1.0
-                r["score"] = round(count * avg_q * section_weight * intent_w, 1)
-                results.append(r)
-            return results
-
-    def rerank_gaps_semantic(
-        self,
-        gaps: list[dict],
-        embeddings=None,
-        query_section: Optional[str] = None,
-    ) -> list[dict]:
-        """Rerank reference gaps using embedding similarity to section centroid.
-
-        When embeddings are stored, computes centroid of sources assigned to
-        the relevant section, then boosts gaps whose citing sources are
-        semantically close to that centroid.
-
-        Formula: final_score = heuristic_score * (0.5 + 0.5 * sim_to_centroid)
-        No embeddings → returns gaps unchanged.
-        """
-        if not embeddings:
-            return gaps
-
-        from .embeddings import cosine_similarity
-
-        all_emb = self.get_all_embeddings(model=embeddings.model_name)
-        if not all_emb:
-            return gaps
-
-        # Compute section centroid from sources assigned to that section
-        centroid = None
-        if query_section:
-            section_sources = self.get_section_sources(query_section)
-            section_vecs = [
-                all_emb[sid] for sid in section_sources if sid in all_emb
-            ]
-            if section_vecs:
-                dim = len(section_vecs[0])
-                centroid = [
-                    sum(v[i] for v in section_vecs) / len(section_vecs)
-                    for i in range(dim)
-                ]
-
-        # If no section centroid, use global centroid of all embeddings
-        if not centroid and all_emb:
-            vecs = list(all_emb.values())
-            dim = len(vecs[0])
-            centroid = [
-                sum(v[i] for v in vecs) / len(vecs) for i in range(dim)
-            ]
-
-        if not centroid:
-            return gaps
-
-        # Rerank: boost by average similarity of citing sources to centroid
-        for gap in gaps:
-            source_ids = (gap.get("source_ids") or "").split(",")
-            sims = []
-            for sid in source_ids:
-                sid = sid.strip()
-                if sid in all_emb:
-                    sims.append(cosine_similarity(all_emb[sid], centroid))
-            if sims:
-                avg_sim = sum(sims) / len(sims)
-                gap["semantic_boost"] = round(avg_sim, 4)
-                gap["score"] = round(gap["score"] * (0.5 + 0.5 * avg_sim), 1)
-            else:
-                gap["semantic_boost"] = 0.0
-
-        gaps.sort(key=lambda g: g["score"], reverse=True)
-        return gaps
+    def rerank_gaps_semantic(self, gaps: list[dict], embeddings=None,
+                             query_section: Optional[str] = None) -> list[dict]:
+        return self.gaps.rerank_gaps_semantic(
+            gaps, embeddings, query_section,
+            get_all_embeddings=self.embeddings_store.get_all_embeddings,
+            get_section_sources=self.gaps.get_section_sources,
+        )
 
     def get_section_sources(self, section: str) -> list[str]:
-        """Get source IDs assigned to a section (via source_sections or primary_section)."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT DISTINCT source_id FROM source_sections WHERE section LIKE ?",
-                (f"{section}%",),
-            )
-            ids = [row["source_id"] for row in cur.fetchall()]
-            if not ids:
-                cur = conn.execute(
-                    "SELECT id FROM sources WHERE primary_section LIKE ?",
-                    (f"{section}%",),
-                )
-                ids = [row["id"] for row in cur.fetchall()]
-            return ids
+        return self.gaps.get_section_sources(section)
 
     def get_gap_summary(self) -> dict:
-        """Lightweight summary for status line: open count + top gap."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT COUNT(DISTINCT ref_authors || ref_year || ref_title) as cnt "
-                "FROM reference_gaps WHERE status='open'"
-            )
-            open_count = cur.fetchone()["cnt"]
-
-            top_ref = None
-            top_count = 0
-            if open_count > 0:
-                cur = conn.execute(
-                    """SELECT ref_authors, ref_year,
-                              COUNT(DISTINCT source_id) as cnt
-                       FROM reference_gaps WHERE status='open'
-                       GROUP BY ref_authors, ref_year, ref_title
-                       ORDER BY cnt DESC LIMIT 1"""
-                )
-                row = cur.fetchone()
-                if row:
-                    year_str = str(row["ref_year"]) if row["ref_year"] else ""
-                    top_ref = f"{row['ref_authors']} {year_str}".strip()
-                    top_count = row["cnt"]
-
-            return {
-                "open_count": open_count,
-                "top_ref": top_ref,
-                "top_count": top_count,
-            }
+        return self.gaps.get_gap_summary()
 
     def resolve_gaps(self, entry_lookup: dict) -> int:
-        """Auto-resolve open gaps that match entries in library.
+        return self.gaps.resolve_gaps(entry_lookup)
 
-        Matches by (author surname, year) or title prefix.
-        Returns count of resolved gaps.
-        """
-        # Build lookup index: "surname year" -> citekey
-        lib_index: dict[str, str] = {}
-        for citekey, entry in entry_lookup.items():
-            if entry.author:
-                # Last word of family = actual surname (handles "А. В. Юлин")
-                family = entry.author[0].family.lower().strip()
-                surname = family.split()[-1] if family else ""
-            else:
-                surname = ""
-            year = str(entry.year) if entry.year else ""
-            if surname and year:
-                lib_index[f"{surname} {year}"] = citekey
-            if entry.title:
-                lib_index[entry.title.lower()[:50]] = citekey
+    def get_coverage_stats(self) -> dict:
+        return self.gaps.get_coverage_stats()
 
-        resolved = 0
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT id, ref_authors, ref_year, ref_title "
-                "FROM reference_gaps WHERE status='open'"
-            )
-            for row in cur.fetchall():
-                authors = (row["ref_authors"] or "").lower()
-                year = str(row["ref_year"]) if row["ref_year"] else ""
-                # Extract surname: first word >2 chars (skip initials "А.", "J.")
-                words = authors.replace("et al.", "").replace("и др.", "").split()
-                surname = ""
-                for w in words:
-                    clean = w.strip(".,")
-                    if len(clean) > 2:
-                        surname = clean
-                        break
-                key = f"{surname} {year}"
+    def get_gaps(self, min_sources: int = 3) -> list[dict]:
+        return self.gaps.get_gaps(min_sources)
 
-                matched_citekey = lib_index.get(key)
-                if not matched_citekey and row["ref_title"]:
-                    matched_citekey = lib_index.get(row["ref_title"].lower()[:50])
+    def reset_non_completed(self) -> dict[str, int]:
+        return self.gaps.reset_non_completed()
 
-                if matched_citekey:
-                    conn.execute(
-                        """UPDATE reference_gaps
-                           SET status='resolved', resolved_citekey=?,
-                               resolved_at=datetime('now')
-                           WHERE id=?""",
-                        (matched_citekey, row["id"]),
-                    )
-                    resolved += 1
-        return resolved
-
-    # ── Citation Links ─────────────────────────────────────────────────
+    # ── Citation delegation ───────────────────────────────────────────────
 
     def save_citation_links(self, source_id: str, references: list[dict]):
-        """Save citation links from annotation key_references.
+        return self.citations.save_citation_links(source_id, references)
 
-        Each reference dict should have: authors, year, title, citation_intent,
-        in_library, citekey (optional).
-        Uses MD5 of normalized title for UNIQUE constraint.
-        """
-        import hashlib
-
-        with self._conn() as conn:
-            for ref in references:
-                title = ref.get("title", "")
-                if not title:
-                    continue
-                title_hash = hashlib.md5(
-                    title.lower().strip().encode()
-                ).hexdigest()
-                conn.execute(
-                    """INSERT OR REPLACE INTO citation_links
-                       (source_id, target_citekey, target_title_hash,
-                        target_title, target_authors, target_year,
-                        citation_intent, in_library)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        source_id,
-                        ref.get("citekey"),
-                        title_hash,
-                        title,
-                        ref.get("authors", ""),
-                        ref.get("year"),
-                        ref.get("citation_intent"),
-                        1 if ref.get("in_library") else 0,
-                    ),
-                )
-
-    def get_citation_links(
-        self, source_id: Optional[str] = None
-    ) -> list[dict]:
-        """Get citation links, optionally filtered by source."""
-        with self._conn() as conn:
-            if source_id:
-                cur = conn.execute(
-                    "SELECT * FROM citation_links WHERE source_id=?",
-                    (source_id,),
-                )
-            else:
-                cur = conn.execute("SELECT * FROM citation_links")
-            return [dict(row) for row in cur.fetchall()]
+    def get_citation_links(self, source_id: Optional[str] = None) -> list[dict]:
+        return self.citations.get_citation_links(source_id)
 
     def get_citation_graph_stats(self) -> dict:
-        """Compute citation graph statistics."""
-        with self._conn() as conn:
-            total = conn.execute(
-                "SELECT COUNT(*) as cnt FROM citation_links"
-            ).fetchone()["cnt"]
-            unique_targets = conn.execute(
-                "SELECT COUNT(DISTINCT target_title_hash) as cnt FROM citation_links"
-            ).fetchone()["cnt"]
-            in_library = conn.execute(
-                "SELECT COUNT(*) as cnt FROM citation_links WHERE in_library=1"
-            ).fetchone()["cnt"]
-            external = total - in_library
-
-            # Average refs per source
-            source_count = conn.execute(
-                "SELECT COUNT(DISTINCT source_id) as cnt FROM citation_links"
-            ).fetchone()["cnt"]
-            avg_refs = round(total / source_count, 1) if source_count else 0
-
-            # Most cited external works
-            cur = conn.execute(
-                """SELECT target_title, target_authors, target_year,
-                          COUNT(DISTINCT source_id) as cite_count
-                   FROM citation_links
-                   WHERE in_library=0
-                   GROUP BY target_title_hash
-                   ORDER BY cite_count DESC
-                   LIMIT 10"""
-            )
-            most_cited_external = [dict(row) for row in cur.fetchall()]
-
-            # Most connected internal works
-            cur = conn.execute(
-                """SELECT target_citekey, COUNT(DISTINCT source_id) as cite_count
-                   FROM citation_links
-                   WHERE in_library=1 AND target_citekey IS NOT NULL
-                   GROUP BY target_citekey
-                   ORDER BY cite_count DESC
-                   LIMIT 10"""
-            )
-            most_connected = [dict(row) for row in cur.fetchall()]
-
-            return {
-                "total_links": total,
-                "unique_targets": unique_targets,
-                "in_library": in_library,
-                "external": external,
-                "source_count": source_count,
-                "avg_refs_per_source": avg_refs,
-                "most_cited_external": most_cited_external,
-                "most_connected_internal": most_connected,
-            }
+        return self.citations.get_citation_graph_stats()
 
     def get_co_cited(self, citekey: str) -> list[dict]:
-        """Find works frequently co-cited with the given citekey.
-
-        Returns works that appear in the same source's references as citekey.
-        """
-        with self._conn() as conn:
-            # Find which sources cite this citekey
-            cur = conn.execute(
-                """SELECT DISTINCT source_id FROM citation_links
-                   WHERE target_citekey=? OR target_title_hash IN (
-                       SELECT target_title_hash FROM citation_links
-                       WHERE target_citekey=?
-                   )""",
-                (citekey, citekey),
-            )
-            citing_sources = [row["source_id"] for row in cur.fetchall()]
-
-            if not citing_sources:
-                return []
-
-            placeholders = ",".join("?" * len(citing_sources))
-            cur = conn.execute(
-                f"""SELECT target_title, target_authors, target_year,
-                           target_citekey, in_library,
-                           COUNT(DISTINCT source_id) as co_cite_count
-                    FROM citation_links
-                    WHERE source_id IN ({placeholders})
-                      AND (target_citekey IS NULL OR target_citekey != ?)
-                    GROUP BY target_title_hash
-                    ORDER BY co_cite_count DESC
-                    LIMIT 20""",
-                (*citing_sources, citekey),
-            )
-            return [dict(row) for row in cur.fetchall()]
+        return self.citations.get_co_cited(citekey)
 
     def get_key_author_groups(self, min_papers: int = 2) -> list[dict]:
-        """Find author groups with multiple papers in the library.
+        return self.citations.get_key_author_groups(min_papers)
 
-        Extracts first author surname from citation_links target_authors,
-        groups by surname, returns those with min_papers or more.
-        """
-        with self._conn() as conn:
-            # Get all unique target authors from citation links
-            cur = conn.execute(
-                """SELECT target_authors, target_title, target_year, target_citekey, in_library
-                   FROM citation_links
-                   WHERE target_authors IS NOT NULL AND target_authors != ''"""
-            )
+    # ── Plans delegation ──────────────────────────────────────────────────
 
-            # Group by first-author surname
-            groups: dict[str, list[dict]] = {}
-            for row in cur.fetchall():
-                authors = row["target_authors"]
-                # Extract first surname (before "et al." or comma)
-                surname = ""
-                for word in authors.replace("et al.", "").replace(",", " ").split():
-                    clean = word.strip(".").strip()
-                    if len(clean) > 2 and clean[0].isupper():
-                        surname = clean
-                        break
-                if not surname:
-                    continue
-                if surname not in groups:
-                    groups[surname] = []
-                groups[surname].append({
-                    "title": row["target_title"],
-                    "year": row["target_year"],
-                    "citekey": row["target_citekey"],
-                    "in_library": bool(row["in_library"]),
-                    "full_authors": authors,
-                })
+    def save_plan(self, dissertation_task: str, assistant_task: str, reading_target: str = "",
+                  reading_snippet: str = "", plan_json: str = "", progress_summary: str = ""):
+        return self.plans.save_plan(dissertation_task, assistant_task, reading_target,
+                                    reading_snippet, plan_json, progress_summary)
 
-            # Filter by min_papers and sort by count
-            result = []
-            for surname, papers in groups.items():
-                unique_titles = {p["title"] for p in papers}
-                if len(unique_titles) >= min_papers:
-                    result.append({
-                        "surname": surname,
-                        "paper_count": len(unique_titles),
-                        "in_library_count": sum(1 for p in papers if p["in_library"]),
-                        "papers": papers[:10],  # cap at 10
-                    })
-            result.sort(key=lambda x: x["paper_count"], reverse=True)
-            return result
+    def get_writing_streak(self) -> dict:
+        return self.plans.get_writing_streak()
 
-    # --- Library analysis methods ---
+    def get_plan(self, plan_date: Optional[str] = None) -> Optional[dict]:
+        return self.plans.get_plan(plan_date)
+
+    def get_yesterday_plan(self) -> Optional[dict]:
+        return self.plans.get_yesterday_plan()
+
+    def add_to_reading_queue(self, source_id: str, priority: int = 50, total_length: int = 0):
+        return self.plans.add_to_reading_queue(source_id, priority, total_length)
+
+    def get_next_reading(self) -> Optional[dict]:
+        return self.plans.get_next_reading()
+
+    def update_reading_position(self, source_id: str, position: int):
+        return self.plans.update_reading_position(source_id, position)
+
+    def complete_reading(self, source_id: str):
+        return self.plans.complete_reading(source_id)
+
+    # ── Prune delegation ──────────────────────────────────────────────────
+
+    def save_prune_verdicts(self, drop: list[dict], maybe: list[dict]):
+        return self.prune.save_prune_verdicts(drop, maybe)
+
+    def get_prune_drop_ids(self, max_age_days: int = PRUNE_EXPIRY_DAYS) -> set[str]:
+        return self.prune.get_prune_drop_ids(max_age_days)
+
+    def get_prune_summary(self) -> dict:
+        return self.prune.get_prune_summary()
+
+    def get_prune_verdicts(self, chapter: Optional[int] = None, verdict: Optional[str] = None) -> list[dict]:
+        return self.prune.get_prune_verdicts(chapter, verdict)
+
+    def clear_prune_verdict(self, source_id: str):
+        return self.prune.clear_prune_verdict(source_id)
+
+    # ── Aggregation (cross-repo) ──────────────────────────────────────────
 
     def get_library_summary(self) -> dict:
         """Comprehensive library summary for AI analysis context."""
         with self._conn() as conn:
-            stats = self.get_stats()
-            frag_stats = self.get_fragment_stats()
-            cov = self.get_coverage_stats()
-            gap_summary = self.get_gap_summary()
+            stats = self.sources.get_stats()
+            frag_stats = self.fragments.get_fragment_stats()
+            cov = self.gaps.get_coverage_stats()
+            gap_summary = self.gaps.get_gap_summary()
 
-            # Quality distribution
             cur = conn.execute(
                 "SELECT quality_score, COUNT(*) as cnt FROM sources "
                 "WHERE status='completed' AND quality_score IS NOT NULL "
@@ -1340,7 +447,6 @@ class StateManager:
             )
             by_quality = {row["quality_score"]: row["cnt"] for row in cur.fetchall()}
 
-            # Average quality
             cur = conn.execute(
                 "SELECT AVG(quality_score) as avg_q, AVG(fragment_count) as avg_f "
                 "FROM sources WHERE status='completed' AND quality_score > 0"
@@ -1349,8 +455,6 @@ class StateManager:
             avg_quality = round(row["avg_q"], 1) if row["avg_q"] else 0
             avg_fragments = round(row["avg_f"], 1) if row["avg_f"] else 0
 
-            # Sections with zero sources
-            _all_sections = set(cov["sections"].keys()) if cov["sections"] else set()  # noqa: F841
             zero_sections = [s for s, c in cov["sections"].items() if c == 0] if cov["sections"] else []
 
             return {
@@ -1368,7 +472,7 @@ class StateManager:
             }
 
     def get_sources_by_quality(self) -> dict[int, list[dict]]:
-        """Completed sources grouped by quality tier (5 → 1)."""
+        """Completed sources grouped by quality tier (5 -> 1)."""
         with self._conn() as conn:
             cur = conn.execute(
                 """SELECT id, quality_score, primary_chapter, primary_section,
@@ -1382,218 +486,3 @@ class StateManager:
                 q = row["quality_score"] or 0
                 result.setdefault(q, []).append(dict(row))
             return result
-
-    @staticmethod
-    def _set_sections_inline(conn, source_id: str, sections: list[str], chapters: list[int]):
-        """Write source_sections using an existing connection (avoids nested lock)."""
-        conn.execute("DELETE FROM source_sections WHERE source_id=?", (source_id,))
-        for sec in sections:
-            ch = int(sec.split(".")[0]) if "." in sec else None
-            if ch is None:
-                continue
-            conn.execute(
-                "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
-                (source_id, ch, sec),
-            )
-        existing_chapters = {int(s.split(".")[0]) for s in sections if "." in s}
-        for ch in chapters:
-            if ch not in existing_chapters:
-                conn.execute(
-                    "INSERT OR IGNORE INTO source_sections (source_id, chapter, section) VALUES (?, ?, ?)",
-                    (source_id, ch, str(ch)),
-                )
-
-    def sync_source_sections(
-        self,
-        vault_data: list[dict],
-        new_entries: list[tuple[str, dict]],
-    ) -> dict:
-        """Sync section assignments from vault frontmatter and register new Zotero entries.
-
-        vault_data: [{citekey, primary_section, primary_chapter, sections, chapters,
-                      quality, priority, nr1, nr2, note_path}]
-        new_entries: [(citekey, {chapter, section, chapters, sections})]
-
-        Returns {"vault_updated": int, "new_registered": int, "unchanged": int}.
-        """
-        vault_updated = 0
-        unchanged = 0
-        new_registered = 0
-
-        with self._conn() as conn:
-            for vd in vault_data:
-                citekey = vd["citekey"]
-
-                cur = conn.execute(
-                    """SELECT primary_section, primary_chapter, quality_score,
-                              relevance_nr1, relevance_nr2, citation_priority
-                       FROM sources WHERE id=?""",
-                    (citekey,),
-                )
-                row = cur.fetchone()
-                if not row:
-                    # Source in vault but not DB — register it
-                    conn.execute("INSERT OR IGNORE INTO sources (id) VALUES (?)", (citekey,))
-
-                # Current DB sections
-                cur = conn.execute(
-                    "SELECT section FROM source_sections WHERE source_id=?",
-                    (citekey,),
-                )
-                db_sections = {r["section"] for r in cur.fetchall()}
-                vault_sections = set(vd.get("sections", []))
-
-                vault_primary = vd.get("primary_section")
-                needs_update = (
-                    row is None
-                    or vault_primary != (row["primary_section"] or None)
-                    or vault_sections != db_sections
-                    or (vd.get("quality", 0) or 0) != (row["quality_score"] or 0)
-                    or (vd.get("nr1", 0) or 0) != (row["relevance_nr1"] or 0)
-                    or (vd.get("nr2", 0) or 0) != (row["relevance_nr2"] or 0)
-                )
-
-                if needs_update:
-                    conn.execute(
-                        """UPDATE sources SET
-                            primary_section=?, primary_chapter=?,
-                            quality_score=?, relevance_nr1=?, relevance_nr2=?,
-                            citation_priority=?, note_path=COALESCE(?, note_path),
-                            status=CASE WHEN status='pending' THEN 'completed' ELSE status END
-                        WHERE id=?""",
-                        (
-                            vault_primary, vd.get("primary_chapter"),
-                            vd.get("quality", 0), vd.get("nr1", 0), vd.get("nr2", 0),
-                            vd.get("priority", "medium"), vd.get("note_path"),
-                            citekey,
-                        ),
-                    )
-                    self._set_sections_inline(conn, citekey, list(vault_sections), vd.get("chapters", []))
-                    # Auto-restore: if user edited vault note, clear prune verdict
-                    conn.execute("DELETE FROM prune_verdicts WHERE source_id=?", (citekey,))
-                    vault_updated += 1
-                else:
-                    unchanged += 1
-
-            # Register new Zotero entries not in DB
-            for citekey, classification in new_entries:
-                cur = conn.execute("SELECT id FROM sources WHERE id=?", (citekey,))
-                if cur.fetchone():
-                    continue
-                conn.execute(
-                    """INSERT INTO sources (id, status, primary_chapter, primary_section)
-                       VALUES (?, 'pending', ?, ?)""",
-                    (citekey, classification.get("chapter"), classification.get("section")),
-                )
-                sections = classification.get("sections", [])
-                chapters = classification.get("chapters", [])
-                if sections:
-                    self._set_sections_inline(conn, citekey, sections, chapters)
-                new_registered += 1
-
-        return {
-            "vault_updated": vault_updated,
-            "new_registered": new_registered,
-            "unchanged": unchanged,
-        }
-
-    # ── Prune Verdicts ──────────────────────────────────────────────────
-
-    def save_prune_verdicts(self, drop: list[dict], maybe: list[dict]):
-        """Replace all prune verdicts with fresh results. Hard-protect valuable sources."""
-        with self._conn() as conn:
-            conn.execute("DELETE FROM prune_verdicts")
-            for item in drop:
-                ck = item.get("citekey", "").lstrip("@")
-                if not ck or self._is_protected(conn, ck):
-                    continue
-                conn.execute(
-                    "INSERT OR REPLACE INTO prune_verdicts (source_id, verdict, reason) VALUES (?, 'drop', ?)",
-                    (ck, item.get("reason", "")),
-                )
-            for item in maybe:
-                ck = item.get("citekey", "").lstrip("@")
-                if not ck or self._is_protected(conn, ck):
-                    continue
-                conn.execute(
-                    "INSERT OR REPLACE INTO prune_verdicts (source_id, verdict, reason) VALUES (?, 'maybe', ?)",
-                    (ck, item.get("reason", "")),
-                )
-
-    @staticmethod
-    def _is_protected(conn, source_id: str) -> bool:
-        """Check if source is too valuable to prune."""
-        cur = conn.execute(
-            "SELECT quality_score, relevance_nr1, relevance_nr2, citation_priority FROM sources WHERE id=?",
-            (source_id,),
-        )
-        row = cur.fetchone()
-        if not row:
-            return True  # unknown source = don't prune
-        return (
-            (row["quality_score"] or 0) >= 4
-            or (row["relevance_nr1"] or 0) >= 4
-            or (row["relevance_nr2"] or 0) >= 4
-            or row["citation_priority"] == "high"
-        )
-
-    def get_prune_drop_ids(self, max_age_days: int = PRUNE_EXPIRY_DAYS) -> set[str]:
-        """Return citekeys with verdict='drop' within expiry window."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT source_id FROM prune_verdicts WHERE verdict='drop' AND updated_at > datetime('now', ?)",
-                (f"-{max_age_days} days",),
-            )
-            return {row["source_id"] for row in cur.fetchall()}
-
-    def get_prune_summary(self) -> dict:
-        """Return prune verdict counts for status display."""
-        with self._conn() as conn:
-            cur = conn.execute(
-                "SELECT verdict, COUNT(*) as cnt FROM prune_verdicts "
-                "WHERE updated_at > datetime('now', ?) GROUP BY verdict",
-                (f"-{PRUNE_EXPIRY_DAYS} days",),
-            )
-            result = {"drop": 0, "maybe": 0}
-            for row in cur.fetchall():
-                result[row["verdict"]] = row["cnt"]
-            result["total"] = result["drop"] + result["maybe"]
-            return result
-
-    def get_prune_verdicts(self, chapter: Optional[int] = None, verdict: Optional[str] = None) -> list[dict]:
-        """Get prune verdicts with source metadata, optionally filtered by chapter/verdict."""
-        with self._conn() as conn:
-            conditions = [f"pv.updated_at > datetime('now', '-{PRUNE_EXPIRY_DAYS} days')"]
-            params: list = []
-
-            if verdict:
-                conditions.append("pv.verdict = ?")
-                params.append(verdict)
-
-            if chapter is not None:
-                ch = str(chapter)
-                conditions.append(
-                    "EXISTS (SELECT 1 FROM source_sections ss2 "
-                    "WHERE ss2.source_id = pv.source_id AND (ss2.section = ? OR ss2.section LIKE ?))"
-                )
-                params.extend([ch, f"{ch}.%"])
-
-            where = " AND ".join(conditions)
-            cur = conn.execute(
-                f"""SELECT pv.source_id, pv.verdict, pv.reason,
-                           s.quality_score, s.fragment_count,
-                           GROUP_CONCAT(DISTINCT ss.section) as sections
-                    FROM prune_verdicts pv
-                    LEFT JOIN sources s ON s.id = pv.source_id
-                    LEFT JOIN source_sections ss ON ss.source_id = pv.source_id
-                    WHERE {where}
-                    GROUP BY pv.source_id
-                    ORDER BY pv.verdict, s.quality_score ASC NULLS LAST""",
-                params,
-            )
-            return [dict(row) for row in cur.fetchall()]
-
-    def clear_prune_verdict(self, source_id: str):
-        """Remove prune verdict for a source (e.g. when user edits its vault note)."""
-        with self._conn() as conn:
-            conn.execute("DELETE FROM prune_verdicts WHERE source_id=?", (source_id,))

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (207 tests)
+## Current test suite (226 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
@@ -9,6 +9,8 @@
 - `test_mcp.py` (404 lines) — `ToolRegistry` CRUD + routing, `ToolInfo`, SPECTER MCP server creation (4 tools), embed/similar/batch tool logic via helpers, `compare_intents()` (LLM vs S2 accuracy, confusion matrix)
 - `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
+- `test_repositories.py` (~130 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`)
+- `test_security_hardening.py` — path traversal and download safety tests
 
 ## Patterns
 - pytest + `unittest.mock` (`patch`, `MagicMock`)

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,135 @@
+"""Tests for domain repositories — verify repos work independently via StateManager."""
+
+import pytest
+
+from klemma.state import StateManager
+
+
+@pytest.fixture
+def state(tmp_path):
+    """Create a StateManager with a temporary database."""
+    db_path = tmp_path / "test.db"
+    return StateManager(db_path)
+
+
+class TestRepositoryComposition:
+    """Verify StateManager correctly composes and delegates to repositories."""
+
+    def test_repos_are_accessible(self, state):
+        assert state.sources is not None
+        assert state.fragments is not None
+        assert state.embeddings_store is not None
+        assert state.gaps is not None
+        assert state.citations is not None
+        assert state.plans is not None
+        assert state.prune is not None
+
+    def test_source_repo_register_and_get(self, state):
+        """Source repo: register + get roundtrip."""
+        state.sources.register_sources(["test-key"])
+        source = state.sources.get_source("test-key")
+        assert source is not None
+        assert source["id"] == "test-key"
+        assert source["status"] == "pending"
+
+    def test_facade_delegates_to_source_repo(self, state):
+        """Facade method calls same repo method."""
+        state.register_sources(["facade-key"])
+        source = state.get_source("facade-key")
+        assert source is not None
+        assert source["id"] == "facade-key"
+
+    def test_fragment_repo_save_and_stats(self, state):
+        """Fragment repo: save + stats roundtrip."""
+        state.sources.register_sources(["src-1"])
+        state.fragments.save_fragments("src-1", [
+            {"text": "Test fragment", "type": "key_idea", "section": "2.1",
+             "relevance": 4, "citation_intent": "method"},
+        ])
+        stats = state.fragments.get_fragment_stats()
+        assert stats["total"] == 1
+        assert stats["by_type"]["key_idea"] == 1
+
+    def test_embedding_repo_roundtrip(self, state):
+        """Embedding repo: save + get roundtrip."""
+        state.sources.register_sources(["emb-src"])
+        vec = [0.1, 0.2, 0.3]
+        state.embeddings_store.save_embedding("emb-src", vec, "test-model")
+        result = state.embeddings_store.get_embedding("emb-src")
+        assert result is not None
+        retrieved_vec, model = result
+        assert model == "test-model"
+        assert len(retrieved_vec) == 3
+        assert abs(retrieved_vec[0] - 0.1) < 1e-5
+
+    def test_gaps_repo_save_and_summary(self, state):
+        """Gaps repo: save + summary."""
+        state.sources.register_sources(["gap-src"])
+        state.gaps.save_reference_gaps("gap-src", [
+            {"ref_authors": "Smith", "ref_year": 2020, "ref_title": "Test Paper",
+             "why_relevant": "important", "citation_intent": "method"},
+        ])
+        summary = state.gaps.get_gap_summary()
+        assert summary["open_count"] == 1
+
+    def test_citations_repo_save_and_stats(self, state):
+        """Citations repo: save + graph stats."""
+        state.sources.register_sources(["cite-src"])
+        state.citations.save_citation_links("cite-src", [
+            {"title": "Cited Work", "authors": "Jones", "year": 2021,
+             "citation_intent": "background", "in_library": False},
+        ])
+        stats = state.citations.get_citation_graph_stats()
+        assert stats["total_links"] == 1
+        assert stats["external"] == 1
+
+    def test_plans_repo_save_and_get(self, state):
+        """Plans repo: save + get."""
+        state.plans.save_plan("Write intro", "Review papers")
+        plan = state.plans.get_plan()
+        assert plan is not None
+        assert plan["dissertation_task"] == "Write intro"
+
+    def test_prune_repo_save_and_summary(self, state):
+        """Prune repo: save + summary."""
+        state.sources.register_sources(["prune-src"])
+        state.prune.save_prune_verdicts(
+            drop=[{"citekey": "prune-src", "reason": "low quality"}],
+            maybe=[],
+        )
+        summary = state.prune.get_prune_summary()
+        assert summary["drop"] == 1
+
+    def test_existing_source_ids(self, state):
+        """New public method replaces old _conn() usage."""
+        state.register_sources(["a", "b", "c"])
+        ids = state.get_existing_source_ids()
+        assert ids == {"a", "b", "c"}
+
+    def test_sources_without_embeddings(self, state):
+        """New public method replaces old _conn() usage."""
+        state.register_sources(["s1", "s2"])
+        state.mark_completed("s1", "/notes/s1.md")
+        state.mark_completed("s2", "/notes/s2.md")
+        state.save_embedding("s1", [0.1, 0.2], "model")
+        without = state.get_sources_without_embeddings()
+        assert "s2" in without
+        assert "s1" not in without
+
+    def test_set_source_sections_public(self, state):
+        """Public set_source_sections replaces old _set_sections_inline."""
+        state.register_sources(["sec-src"])
+        state.set_source_sections("sec-src", ["2.1", "2.3"], [2])
+        with state._conn() as conn:
+            cur = conn.execute(
+                "SELECT section FROM source_sections WHERE source_id='sec-src' ORDER BY section"
+            )
+            sections = [row["section"] for row in cur.fetchall()]
+        assert "2.1" in sections
+        assert "2.3" in sections
+
+    def test_rerank_gaps_semantic_no_embeddings(self, state):
+        """rerank_gaps_semantic returns gaps unchanged without embeddings."""
+        gaps = [{"score": 10.0, "source_ids": "a,b"}]
+        result = state.rerank_gaps_semantic(gaps, embeddings=None)
+        assert result == gaps


### PR DESCRIPTION
## Summary

- Split monolithic `StateManager` (1599 lines) into 7 domain repositories with `StateManager` as backward-compatible facade (420 lines)
- Eliminated all private method access (`_conn()`, `_set_sections_inline()`) from production code in `cli.py` and `acquirer.py`
- Added 13 new tests in `test_repositories.py` (226 total, all passing)

## Repositories

| Module | Domain | ~Lines |
|--------|--------|--------|
| `sources.py` | Source CRUD, status, sections, Zotero keys, sync | 400 |
| `fragments.py` | Fragment CRUD, intent coverage | 130 |
| `embeddings_store.py` | Vector BLOB storage, model versioning | 80 |
| `gaps.py` | Reference gaps, coverage, intent-weighted scoring, semantic rerank | 328 |
| `citations.py` | Citation graph, co-citation, author groups | 183 |
| `plans.py` | Daily plans, reading queue, writing streak | 126 |
| `prune.py` | Prune verdicts, protection logic | 109 |

## Design decisions

- **Facade pattern**: All 58 public methods on `StateManager` still work — repos are an internal decomposition
- **Connection factory injection**: All repos share `StateManager._conn` via `BaseRepository.__init__`
- **Cross-repo deps**: `rerank_gaps_semantic()` uses callable injection (no repo-to-repo imports)
- **Schema stays centralized**: `SCHEMA`, `_init_db()`, `_migrate_schema()` remain in `StateManager`

## Release Note

Refactoring Phase 3 (Architecture Seams): decomposed `state.py` into 7 domain repositories. No API changes — `StateManager` remains the public interface. Internal coupling reduced, private method access eliminated.

## Test plan

- [x] `ruff check src/ tests/` — zero errors
- [x] `python -m pytest tests/ -q` — 226 passed
- [x] `grep -r 'state\._conn\|state\._set_sections' src/` — zero hits
- [ ] Codex CLI cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)