### PR TITLE
feat(benchmark): evaluation framework + citation reconstruction (Step 6.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ tags.example.yaml           — Template tag taxonomy
 - `klemma ask "query"` — interactive research agent with full dissertation context
 - `klemma info` — show current project info (root, chain, config, DB)
 - `klemma tree` — show nested project tree from current root
-- `klemma benchmark [-d dataset.json] [--metrics all|intent|gaps|embeddings] [--export path] [--json-output]` — evaluation framework: run benchmarks against annotated ground truth; `--export` to generate dataset template from DB
+- `klemma benchmark [-d dataset.json] [--metrics all|intent|gaps|embeddings] [--export path] [--json-output] [--semantic]` — evaluation framework: run benchmarks against annotated ground truth; `--export` to generate dataset template from DB; `--semantic` applies hybrid keyword × semantic reranking to gap benchmark (requires embeddings configured)
 - `klemma migrate [--dry-run]` — migrate from old ~/.klemma/ to per-directory project
 - Global options: `--config/-c <path>`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,11 @@ src/klemma/
 │   ├── citations.py    — Citation graph, co-citation, authors (~180 lines)
 │   ├── plans.py        — Daily plans, reading queue (~130 lines)
 │   └── prune.py        — Prune verdicts, protection (~110 lines)
-├── evaluation/         — Benchmark framework (dataset, metrics, runners)
-│   ├── dataset.py     — Pydantic schema, load/export (~80 lines)
-│   ├── metrics.py     — intent_metrics, precision@K, recall@K, nDCG@K (~120 lines)
-│   └── runners.py     — Intent, gap, embedding benchmark runners (~150 lines)
+├── evaluation/         — Benchmark framework (dataset, metrics, runners, reconstruction)
+│   ├── dataset.py     — Pydantic schema, load/export, reconstruction models (~130 lines)
+│   ├── metrics.py     — intent_metrics, precision@K, recall@K, nDCG@K, reconstruction_metrics (~210 lines)
+│   ├── runners.py     — Intent, gap, embedding, reconstruction benchmark runners (~200 lines)
+│   └── reconstruction.py — Citation reconstruction benchmark: analyst, baseline, AI-driven (~200 lines)
 ├── skills/             — AI skills (planner, extractor, researcher, librarian, agent, acquirer, outliner, work_context)
 ├── literature/         — PDF extraction, models, note_factory
 └── tools/              — MCP tool infrastructure (567 lines)
@@ -57,7 +58,9 @@ prompts/                    — Shipped Jinja2 prompt templates (overridable via
 ├── librarian_prune.md      — prune recommendation generation
 ├── agent.md                — interactive agent system prompt
 ├── outline.md              — project outline generation
-└── outline_incremental.md  — incremental outline update
+├── outline_incremental.md  — incremental outline update
+├── analyst.md              — extract ground truth citation map from paper PDF
+└── reconstruct.md          — AI citation recommendation (blind to paper text)
 config.project.example.yaml — Template for per-project .klemma/config.yaml
 config.system.example.yaml  — Template for ~/.klemma/config.yaml (system defaults)
 config.example.yaml         — Legacy template config (kept for migration)
@@ -85,7 +88,7 @@ tags.example.yaml           — Template tag taxonomy
 - `klemma ask "query"` — interactive research agent with full dissertation context
 - `klemma info` — show current project info (root, chain, config, DB)
 - `klemma tree` — show nested project tree from current root
-- `klemma benchmark [-d dataset.json] [--metrics all|intent|gaps|embeddings] [--export path] [--json-output] [--semantic]` — evaluation framework: run benchmarks against annotated ground truth; `--export` to generate dataset template from DB; `--semantic` applies hybrid keyword × semantic reranking to gap benchmark (requires embeddings configured)
+- `klemma benchmark [-d dataset.json] [--metrics all|intent|gaps|embeddings|reconstruct] [--export path] [--json-output] [--semantic] [--analyst <citekey>] [--reconstruct]` — evaluation framework: run benchmarks against annotated ground truth; `--export` to generate dataset template from DB; `--semantic` applies hybrid keyword × semantic reranking to gap benchmark (requires embeddings configured); `--analyst` extracts ground truth citation map from a paper's PDF; `--reconstruct` runs citation reconstruction benchmark
 - `klemma migrate [--dry-run]` — migrate from old ~/.klemma/ to per-directory project
 - Global options: `--config/-c <path>`
 

--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -16,6 +16,8 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 | `agent.md` | `skills/agent.py` | System prompt for interactive agent |
 | `outline.md` | `skills/outliner.py` | Project outline generation |
 | `outline_incremental.md` | `skills/outliner.py` | Incremental outline update |
+| `analyst.md` | `evaluation/reconstruction.py` | Extract ground truth citation map from paper PDF |
+| `reconstruct.md` | `evaluation/reconstruction.py` | AI citation recommendation (blind to paper text) |
 
 ## Key variables by template
 
@@ -45,6 +47,12 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 
 ### outline_incremental.md
 `project_type`, `dissertation_context`, `project_files`, `library_summary`, `previous_outline`, `user_notes`, `previous_date`, `custom_prompt`, `language`
+
+### analyst.md
+`pdf_text`, `library_entries`, `paper_citekey`, `paper_title`
+
+### reconstruct.md
+`sections` (list of {section_id, title}), `sources` (list of {citekey, title, year, fragments: [{intent, text}]})
 
 ## Conventions
 - All templates in Russian (dissertation language) except `extract.md` (English for international papers)

--- a/prompts/analyst.md
+++ b/prompts/analyst.md
@@ -1,0 +1,74 @@
+You are an AI research analyst extracting the citation map from a scientific paper.
+
+## Task
+
+Read the paper below and produce a structured JSON with:
+1. Paper metadata (abstract, keywords)
+2. Section outline with descriptions
+3. Citation map: which works are cited in each section, and how
+
+## Paper Text
+{{ pdf_text }}
+
+## Library (known sources)
+{{ library_entries }}
+
+---
+
+## Instructions
+
+### Phase 1: Paper-level metadata
+- **abstract**: The paper's abstract (copy verbatim from the text, or summarize in 2-3 sentences if abstract is not clearly marked)
+- **keywords**: List of 5-10 key terms/concepts that capture the paper's scope
+
+### Phase 2: Section outline with descriptions
+For each section and subsection:
+- **section_id**: numbering as it appears (e.g. "1", "2.1", "3.2")
+- **title**: section heading
+- **description**: 1-2 sentence summary of what this section covers — its thesis, argument, or content focus. This description should be specific enough for someone to understand the section's role without reading it.
+
+### Phase 3: Citation extraction
+For EACH in-text citation (author-year or numbered):
+- Which section it appears in
+- The cited work's title (from the References/Bibliography section)
+- Citation intent:
+  - `background` — context, general knowledge, literature review
+  - `method` — a method, algorithm, or approach adopted or built upon
+  - `result_comparison` — results or metrics cited for comparison
+- Whether it matches a known library entry (by author + year + title substring)
+
+### Matching rules
+- Only set `citekey` and `in_library: true` when you are confident the citation matches a library entry
+- Use author last name + year + title keywords for matching
+- Read actual References section — do NOT hallucinate titles or authors
+
+## Output Format
+
+Return ONLY valid JSON matching this schema:
+
+```json
+{
+  "paper_citekey": "{{ paper_citekey }}",
+  "paper_title": "{{ paper_title }}",
+  "abstract": "The paper's abstract text...",
+  "keywords": ["keyword1", "keyword2", "keyword3"],
+  "bibliography_size": 42,
+  "sections": [
+    {
+      "section_id": "1",
+      "title": "Introduction",
+      "description": "Introduces the problem of X and motivates the approach based on Y",
+      "citations": [
+        {
+          "citekey": "smith2020" or null,
+          "title": "Actual title from References section",
+          "intent": "background",
+          "in_library": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+Respond with ONLY valid JSON.

--- a/prompts/reconstruct.md
+++ b/prompts/reconstruct.md
@@ -1,0 +1,84 @@
+You are an AI citation recommendation system. You are helping an author write a scientific paper. Given the paper's outline, thesis, and a library of sources with extracted fragments, recommend which sources should be cited in each section.
+
+## Paper Context
+
+**Title**: {{ paper_title }}
+
+{% if abstract %}
+**Abstract**: {{ abstract }}
+{% endif %}
+
+{% if keywords %}
+**Keywords**: {{ keywords | join(", ") }}
+{% endif %}
+
+## Paper Outline
+
+{% for section in sections %}
+### {{ section.section_id }}: {{ section.title }}
+{% if section.description %}
+{{ section.description }}
+{% endif %}
+{% endfor %}
+
+## Available Sources
+
+{% for source in sources %}
+#### {{ source.citekey }} — {{ source.title }} ({{ source.year }})
+{% if source.abstract %}
+> {{ source.abstract[:300] }}
+{% endif %}
+{% if source.fragments %}
+Key fragments:
+{% for frag in source.fragments[:5] %}
+- [{{ frag.intent }}] {{ frag.text[:200] }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+---
+
+## Instructions
+
+You are assisting an author who is writing the paper described above. For each section in the outline, recommend sources from the library that should be cited there. Think about:
+
+- **What argument does each section make?** Match sources that support or contrast with that argument.
+- **What methodology is described?** Match sources that provide the theoretical basis or comparable methods.
+- **What results are discussed?** Match sources whose results can be compared.
+
+For each recommendation, specify:
+
+1. **section_id** — which section (must match an outline section ID)
+2. **citekey** — which source (must be from the provided library)
+3. **intent** — how the source would be cited:
+   - `background` — provides context, general knowledge, or prior work
+   - `method` — provides a method, algorithm, or technique to build upon
+   - `result_comparison` — provides results or metrics for comparison
+4. **justification** — brief reason for the recommendation (1 sentence)
+
+Rules:
+- Only recommend sources from the provided library (no external sources)
+- A source can appear in multiple sections with different intents
+- Prefer specific fragment evidence over general relevance
+- Use section descriptions to understand what each section needs
+- Be thorough: if a source is relevant to a section, include it
+- Order recommendations by confidence (most confident first within each section)
+
+## Output Format
+
+Return ONLY valid JSON:
+
+```json
+{
+  "recommendations": [
+    {
+      "section_id": "2.1",
+      "citekey": "smith2020",
+      "intent": "method",
+      "justification": "Smith's algorithm is the basis for our approach"
+    }
+  ]
+}
+```
+
+Respond with ONLY valid JSON.

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -265,14 +265,21 @@ def _print_status_line(state: StateManager, project_name: str = "default"):
         pass  # Don't crash on status line failure
 
 
-def _print_ref_gaps_table(state: StateManager, limit: int = 20):
-    """Print reference gaps as a Rich table."""
+def _print_ref_gaps_table(state: StateManager, limit: int = 20, embeddings=None):
+    """Print reference gaps as a Rich table.
+
+    When embeddings is provided, applies semantic reranking via
+    rerank_gaps_semantic() before display.
+    """
     ref_gaps = state.get_reference_gaps(limit=limit)
     if not ref_gaps:
         return
+    if embeddings:
+        ref_gaps = state.rerank_gaps_semantic(ref_gaps, embeddings=embeddings)
     gap_summary = state.get_gap_summary()
+    title_suffix = " [dim](semantically reranked)[/dim]" if embeddings else ""
     ref_table = Table(
-        title=f"Reference Gaps — {gap_summary['open_count']} open (missing from library)",
+        title=f"Reference Gaps — {gap_summary['open_count']} open (missing from library){title_suffix}",
         show_edge=False, pad_edge=False,
     )
     ref_table.add_column("#", justify="right", style="dim", width=3)
@@ -1213,7 +1220,7 @@ def status(ctx, verbose, chapter):
 
     # --- Reference gaps ---
     if verbose:
-        _print_ref_gaps_table(state, limit=20)
+        _print_ref_gaps_table(state, limit=20, embeddings=kctx.embeddings)
     else:
         ref_gaps = state.get_reference_gaps(limit=5)
         if ref_gaps:
@@ -1862,7 +1869,7 @@ def library(ctx, section, audit):
             console.print(_prune_table(maybe, "Maybe", "yellow"))
 
     # Reference gaps table
-    _print_ref_gaps_table(state)
+    _print_ref_gaps_table(state, embeddings=kctx.embeddings)
 
     console.print("\n[dim]Full report saved to vault.[/dim]")
 
@@ -2143,8 +2150,10 @@ def _print_project_tree(root: Path, indent: int = 0, current: Path | None = None
               help="Export current DB data as dataset template for annotation")
 @click.option("--json-output", is_flag=True,
               help="Output results as JSON for reproducibility")
+@click.option("--semantic", is_flag=True,
+              help="Apply semantic reranking to gap benchmark (hybrid keyword × semantic mode)")
 @click.pass_context
-def benchmark(ctx, dataset, metrics, export_path, json_output):
+def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
     """Run evaluation benchmarks against annotated ground truth.
 
     Multi-format evaluation (Singh et al. 2023 — SciRepEval):
@@ -2153,6 +2162,9 @@ def benchmark(ctx, dataset, metrics, export_path, json_output):
 
     Use --export to generate a dataset template from current DB,
     then manually review/correct labels to create ground truth.
+
+    Use --semantic to measure hybrid gap ranking (keyword score × semantic
+    similarity), requires embeddings to be configured.
     """
     import json
 
@@ -2185,7 +2197,14 @@ def benchmark(ctx, dataset, metrics, export_path, json_output):
         f"{len(ds.gaps)} gaps, {len(ds.similar_pairs)} similarity pairs"
     )
 
-    results = run_all(kctx.state, ds, metrics)
+    reranked_gaps = None
+    if semantic and kctx.embeddings:
+        all_gaps = kctx.state.get_reference_gaps(limit=100)
+        reranked_gaps = kctx.state.rerank_gaps_semantic(all_gaps, kctx.embeddings)
+    elif semantic:
+        console.print("[yellow]--semantic requires embeddings to be configured[/yellow]")
+
+    results = run_all(kctx.state, ds, metrics, reranked_gaps=reranked_gaps)
 
     if json_output:
         click.echo(json.dumps(results, indent=2))
@@ -2222,13 +2241,14 @@ def benchmark(ctx, dataset, metrics, export_path, json_output):
     if "gaps" in results:
         gr = results["gaps"]
         gm = gr.get("metrics", {})
+        gap_title = "Gap Ranking [dim](hybrid: keyword × semantic)[/dim]" if semantic else "Gap Ranking"
         console.print(Panel(
             f"Ground truth: {gr['total']} gaps, "
             f"DB gaps: {gr.get('db_gaps_count', 0)}\n"
             f"Precision@5: {gm.get('precision_at_5', 0):.4f}  "
             f"Precision@10: {gm.get('precision_at_10', 0):.4f}  "
             f"[bold]nDCG@10: {gm.get('ndcg_at_10', 0):.4f}[/bold]",
-            title="Gap Ranking",
+            title=gap_title,
         ))
 
     if "embeddings" in results:

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -2140,11 +2140,163 @@ def _print_project_tree(root: Path, indent: int = 0, current: Path | None = None
 
 # --- Benchmark: evaluation framework ---
 
+
+def _run_analyst_mode(kctx, citekey: str, json_output: bool):
+    """Run analyst prompt to extract ground truth from a paper's PDF."""
+    import json
+
+    from .evaluation.reconstruction import run_analyst
+    from .literature.pdf import PDFExtractor
+
+    # Find PDF for the citekey
+    source = kctx.state.get_source(citekey)
+    if not source:
+        console.print(f"[red]Source {citekey} not found in DB[/red]")
+        return
+
+    pdf_path = None
+    if source.get("pdf_path"):
+        pdf_path = Path(source["pdf_path"])
+    elif kctx.config.zotero.library_json:
+        lookup = PDFExtractor.load_pdf_lookup(Path(kctx.config.zotero.library_json))
+        if citekey in lookup:
+            pdf_path = Path(lookup[citekey])
+
+    if not pdf_path or not pdf_path.exists():
+        console.print(f"[red]PDF not found for {citekey}[/red]")
+        return
+
+    # Extract text
+    extractor = PDFExtractor(max_chars=kctx.config.ai.max_pdf_chars)
+    pdf_text = extractor.extract(pdf_path)
+    if not pdf_text:
+        console.print("[red]Failed to extract text from PDF[/red]")
+        return
+
+    # Build library entries string
+    all_sources = kctx.state.get_all_sources()
+    library_lines = []
+    for s in all_sources:
+        if s.get("id") != citekey:
+            library_lines.append(f"- {s.get('id', '')}: {s.get('title', '')}")
+    library_entries = "\n".join(library_lines)
+
+    # Initialize AI
+    try:
+        ai = _init_ai(kctx.config)
+    except Exception as e:
+        console.print(f"[red]Failed to initialize AI: {e}[/red]")
+        return
+
+    console.print(f"Analyzing {citekey} ({len(pdf_text)} chars)...")
+    gt = run_analyst(
+        ai, pdf_text, library_entries,
+        paper_citekey=citekey,
+        paper_title=source.get("title", ""),
+        klemma_home=kctx.klemma_home,
+    )
+
+    if not gt:
+        console.print("[red]Analyst prompt failed[/red]")
+        return
+
+    # Build samples (in-library only)
+    from .evaluation.dataset import ReconstructionDataset, ReconstructionSample
+    samples = []
+    for section in gt.sections:
+        for cit in section.citations:
+            if cit.in_library and cit.citekey:
+                samples.append(ReconstructionSample(
+                    section_id=section.section_id,
+                    citekey=cit.citekey,
+                    intent=cit.intent,
+                ))
+
+    dataset = ReconstructionDataset(ground_truth=gt, samples=samples)
+
+    if json_output:
+        click.echo(json.dumps(dataset.model_dump(), indent=2))
+    else:
+        console.print(
+            f"[green]Ground truth extracted:[/green] "
+            f"{len(gt.sections)} sections, "
+            f"{gt.bibliography_size} references, "
+            f"{len(samples)} in-library samples"
+        )
+        console.print("Save as JSON and add to your benchmark dataset under 'reconstruction' key.")
+        click.echo(json.dumps(dataset.model_dump(), indent=2))
+
+
+def _print_reconstruction_results(recon: dict):
+    """Print reconstruction benchmark results as Rich panels."""
+    # Ground truth summary
+    gt = recon.get("ground_truth", {})
+    console.print(Panel(
+        f"Paper: {gt.get('paper', 'N/A')}\n"
+        f"Sections: {gt.get('sections', 0)}, "
+        f"Bibliography: {gt.get('bibliography_size', 0)}, "
+        f"In-library samples: {gt.get('samples', 0)}",
+        title="Reconstruction: Ground Truth",
+    ))
+
+    # Baseline results
+    bl = recon.get("baseline", {})
+    if bl:
+        console.print(Panel(
+            f"Predictions: {bl.get('predictions_count', 0)}\n"
+            f"Macro-P: {bl.get('macro_precision', 0):.4f}  "
+            f"Macro-R: {bl.get('macro_recall', 0):.4f}  "
+            f"[bold]F1: {bl.get('f1', 0):.4f}[/bold]\n"
+            f"Intent accuracy: {bl.get('intent_accuracy', 0):.4f}  "
+            f"nDCG avg: {bl.get('ndcg_avg', 0):.4f}",
+            title="Reconstruction: Baseline (DB only)",
+        ))
+
+    # AI reconstruction results
+    rc = recon.get("reconstruction", {})
+    if rc:
+        if rc.get("error"):
+            console.print(f"[yellow]Reconstruction: {rc['error']}[/yellow]")
+        else:
+            console.print(Panel(
+                f"Predictions: {rc.get('predictions_count', 0)}\n"
+                f"Macro-P: {rc.get('macro_precision', 0):.4f}  "
+                f"Macro-R: {rc.get('macro_recall', 0):.4f}  "
+                f"[bold]F1: {rc.get('f1', 0):.4f}[/bold]\n"
+                f"Intent accuracy: {rc.get('intent_accuracy', 0):.4f}  "
+                f"nDCG avg: {rc.get('ndcg_avg', 0):.4f}",
+                title="Reconstruction: AI-driven",
+            ))
+
+    # Per-section table (from baseline or reconstruction, whichever has data)
+    source = rc if rc and not rc.get("error") else bl
+    per_section = source.get("per_section", {}) if source else {}
+    if per_section:
+        t = Table(title="Per-section metrics")
+        t.add_column("Section")
+        t.add_column("GT", justify="right")
+        t.add_column("Pred", justify="right")
+        t.add_column("Hits", justify="right")
+        t.add_column("Precision", justify="right")
+        t.add_column("Recall", justify="right")
+        t.add_column("nDCG", justify="right")
+        for sec_id, vals in sorted(per_section.items()):
+            t.add_row(
+                sec_id,
+                str(vals.get("gt_count", 0)),
+                str(vals.get("pred_count", 0)),
+                str(vals.get("hits", 0)),
+                f"{vals.get('precision', 0):.4f}",
+                f"{vals.get('recall', 0):.4f}",
+                f"{vals.get('ndcg', 0):.4f}",
+            )
+        console.print(t)
+
 @main.command()
 @click.option("--dataset", "-d", type=click.Path(exists=True),
               help="Path to annotated benchmark dataset JSON")
 @click.option("--metrics", "-m",
-              type=click.Choice(["all", "intent", "gaps", "embeddings"]),
+              type=click.Choice(["all", "intent", "gaps", "embeddings", "reconstruct"]),
               default="all", help="Which benchmarks to run (default: all)")
 @click.option("--export", "export_path", type=click.Path(),
               help="Export current DB data as dataset template for annotation")
@@ -2152,19 +2304,27 @@ def _print_project_tree(root: Path, indent: int = 0, current: Path | None = None
               help="Output results as JSON for reproducibility")
 @click.option("--semantic", is_flag=True,
               help="Apply semantic reranking to gap benchmark (hybrid keyword × semantic mode)")
+@click.option("--analyst", "analyst_citekey", type=str, default=None,
+              help="Run analyst prompt on a paper PDF to extract ground truth citation map")
+@click.option("--reconstruct", "reconstruct", is_flag=True,
+              help="Run citation reconstruction benchmark (requires reconstruction field in dataset)")
 @click.pass_context
-def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
+def benchmark(ctx, dataset, metrics, export_path, json_output, semantic, analyst_citekey, reconstruct):
     """Run evaluation benchmarks against annotated ground truth.
 
     Multi-format evaluation (Singh et al. 2023 — SciRepEval):
-    intent classification, gap ranking, and embedding retrieval
-    evaluated separately with domain-appropriate metrics.
+    intent classification, gap ranking, embedding retrieval,
+    and citation reconstruction evaluated separately.
 
     Use --export to generate a dataset template from current DB,
     then manually review/correct labels to create ground truth.
 
     Use --semantic to measure hybrid gap ranking (keyword score × semantic
     similarity), requires embeddings to be configured.
+
+    Use --analyst <citekey> to extract ground truth from a paper's PDF.
+
+    Use --reconstruct to run citation reconstruction benchmark.
     """
     import json
 
@@ -2172,6 +2332,11 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
     from .evaluation.dataset import export_dataset
 
     kctx = _get_context(ctx)
+
+    # --- Analyst mode: extract ground truth from a paper ---
+    if analyst_citekey:
+        _run_analyst_mode(kctx, analyst_citekey, json_output)
+        return
 
     if export_path:
         count = export_dataset(kctx.state, Path(export_path))
@@ -2192,9 +2357,11 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
         return
 
     ds = load_dataset(Path(dataset))
+    recon_info = f", reconstruction: {len(ds.reconstruction.samples)} samples" if ds.reconstruction else ""
     console.print(
         f"Dataset: {len(ds.fragments)} fragments, "
         f"{len(ds.gaps)} gaps, {len(ds.similar_pairs)} similarity pairs"
+        f"{recon_info}"
     )
 
     reranked_gaps = None
@@ -2204,7 +2371,21 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
     elif semantic:
         console.print("[yellow]--semantic requires embeddings to be configured[/yellow]")
 
-    results = run_all(kctx.state, ds, metrics, reranked_gaps=reranked_gaps)
+    # Determine effective metrics filter
+    effective_metrics = "reconstruct" if reconstruct else metrics
+
+    # Initialize AI if reconstruction benchmark is requested
+    ai = None
+    if (effective_metrics in ("all", "reconstruct")) and ds.reconstruction:
+        try:
+            ai = _init_ai(kctx.config)
+        except Exception:
+            console.print("[dim]AI not available — reconstruction will run baseline only[/dim]")
+
+    results = run_all(
+        kctx.state, ds, effective_metrics,
+        reranked_gaps=reranked_gaps, ai=ai, klemma_home=kctx.klemma_home,
+    )
 
     if json_output:
         click.echo(json.dumps(results, indent=2))
@@ -2265,6 +2446,9 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic):
                 f"Precision@5: {em.get('avg_precision_at_5', 0):.4f}",
                 title="Embedding Retrieval",
             ))
+
+    if "reconstruction" in results:
+        _print_reconstruction_results(results["reconstruction"])
 
 
 # --- Migrate: convert old ~/.klemma/ to per-directory project ---

--- a/src/klemma/evaluation/CLAUDE.md
+++ b/src/klemma/evaluation/CLAUDE.md
@@ -1,31 +1,44 @@
 # Evaluation Framework
 
-Multi-format benchmarking for klemma's intent classification, gap scoring, and embedding retrieval.
+Multi-format benchmarking for klemma's intent classification, gap scoring, embedding retrieval, and citation reconstruction.
 
 ## Modules
 
-### dataset.py (~80 lines)
+### dataset.py (~130 lines)
 Pydantic models for annotated benchmark datasets + load/export.
 - `IntentSample` — fragment with ground truth intent (background/method/result_comparison)
 - `GapSample` — reference gap with ground truth relevance (1-5)
 - `SimilarityPair` — query source with known relevant neighbors
-- `BenchmarkDataset` — container for all three sample types
+- `SectionCitation` — a citation within a paper section, with optional library match
+- `PaperSection` — a section of a paper with its citations
+- `ReconstructionGroundTruth` — paper's actual citation map (sections → cited works)
+- `ReconstructionSample` — flattened (section, citekey, intent) triple for evaluation
+- `ReconstructionDataset` — ground truth + samples for reconstruction benchmark
+- `BenchmarkDataset` — container for all sample types (+ optional `reconstruction`)
 - `load_dataset(path)` — load and validate from JSON
 - `export_dataset(state, path)` — dump current DB as annotation template
 
-### metrics.py (~120 lines)
+### metrics.py (~210 lines)
 Pure metric functions — no DB, no IO.
 - `intent_metrics(predictions, ground_truth)` — macro-F1 (primary), accuracy, per-class P/R/F1, confusion matrix
 - `precision_at_k(ranked_ids, relevant_ids, k)` — fraction of top-K that are relevant
 - `recall_at_k(ranked_ids, relevant_ids, k)` — fraction of relevant items in top-K
 - `ndcg_at_k(ranked_ids, relevance_map, k)` — normalized DCG for graded relevance (1-5)
+- `reconstruction_metrics(predictions, ground_truth)` — macro P/R, F1, intent accuracy, nDCG per section for citation reconstruction
 
-### runners.py (~190 lines)
+### runners.py (~200 lines)
 Benchmark runners — orchestrate DB queries + metric computation.
 - `run_intent_benchmark(state, dataset)` — compare DB fragment intents vs ground truth
 - `run_gap_benchmark(state, dataset, reranked_gaps?)` — evaluate gap scoring precision@K and nDCG@K; when `reranked_gaps` is provided, skips DB fetch and uses the pre-ranked list (enables hybrid semantic evaluation)
 - `run_embedding_benchmark(state, dataset)` — evaluate embedding retrieval recall@K
-- `run_all(state, dataset, metrics_filter, reranked_gaps?)` — dispatch to selected runners; threads `reranked_gaps` to `run_gap_benchmark`
+- `run_all(state, dataset, metrics_filter, reranked_gaps?, ai?, klemma_home?)` — dispatch to selected runners; includes reconstruction when `metrics_filter` is `"all"` or `"reconstruct"`
+
+### reconstruction.py (~200 lines)
+Citation reconstruction benchmark — end-to-end recommendation quality.
+- `run_analyst(ai, pdf_text, library_entries, paper_citekey, paper_title, klemma_home)` — extract ground truth citation map from a paper's PDF via AI
+- `compute_baseline(state, dataset)` — evaluate DB-only fragment assignments against ground truth
+- `run_reconstruction(ai, state, dataset, klemma_home)` — AI-driven citation recommendation against ground truth
+- `run_reconstruction_benchmark(state, dataset, ai?, klemma_home?)` — full benchmark: ground truth stats + baseline + optional AI reconstruction
 
 ## Design rationale
 
@@ -50,14 +63,29 @@ Metric and methodology choices grounded in klemma-paper library:
 ```
 User creates annotated dataset (JSON)
   or: klemma benchmark --export template.json → review/correct labels
+  or: klemma benchmark --analyst <citekey> → AI extracts ground truth from paper PDF
         ↓
-klemma benchmark -d dataset.json [--metrics intent|gaps|embeddings|all] [--semantic]
+klemma benchmark -d dataset.json [--metrics intent|gaps|embeddings|reconstruct|all] [--semantic] [--reconstruct]
         ↓
 --semantic: state.rerank_gaps_semantic(all_gaps, embeddings) → reranked_gaps
+--reconstruct: run_reconstruction_benchmark(state, dataset, ai, klemma_home)
         ↓
 runners.py: query DB (or use reranked_gaps) → compute metrics → return results dict
         ↓
 cli.py: Rich table output (default) or JSON (--json-output)
+```
+
+### Citation reconstruction flow
+
+```
+klemma benchmark --analyst <citekey>
+  → PDFExtractor.extract(pdf) → library entries → AI analyst prompt → ReconstructionGroundTruth
+  → build ReconstructionSample list (in-library only) → save as JSON
+
+klemma benchmark -d dataset.json --reconstruct
+  → compute_baseline(state, dataset) → DB fragment assignments → reconstruction_metrics
+  → run_reconstruction(ai, state, dataset) → AI prompt with outline + fragments → reconstruction_metrics
+  → compare baseline vs reconstruction
 ```
 
 ### Semantic reranking in status/library

--- a/src/klemma/evaluation/CLAUDE.md
+++ b/src/klemma/evaluation/CLAUDE.md
@@ -20,12 +20,12 @@ Pure metric functions — no DB, no IO.
 - `recall_at_k(ranked_ids, relevant_ids, k)` — fraction of relevant items in top-K
 - `ndcg_at_k(ranked_ids, relevance_map, k)` — normalized DCG for graded relevance (1-5)
 
-### runners.py (~150 lines)
+### runners.py (~190 lines)
 Benchmark runners — orchestrate DB queries + metric computation.
 - `run_intent_benchmark(state, dataset)` — compare DB fragment intents vs ground truth
-- `run_gap_benchmark(state, dataset)` — evaluate gap scoring precision@K and nDCG@K
+- `run_gap_benchmark(state, dataset, reranked_gaps?)` — evaluate gap scoring precision@K and nDCG@K; when `reranked_gaps` is provided, skips DB fetch and uses the pre-ranked list (enables hybrid semantic evaluation)
 - `run_embedding_benchmark(state, dataset)` — evaluate embedding retrieval recall@K
-- `run_all(state, dataset, metrics_filter)` — dispatch to selected runners
+- `run_all(state, dataset, metrics_filter, reranked_gaps?)` — dispatch to selected runners; threads `reranked_gaps` to `run_gap_benchmark`
 
 ## Design rationale
 
@@ -51,12 +51,20 @@ Metric and methodology choices grounded in klemma-paper library:
 User creates annotated dataset (JSON)
   or: klemma benchmark --export template.json → review/correct labels
         ↓
-klemma benchmark -d dataset.json [--metrics intent|gaps|embeddings|all]
+klemma benchmark -d dataset.json [--metrics intent|gaps|embeddings|all] [--semantic]
         ↓
-runners.py: query DB → compute metrics → return results dict
+--semantic: state.rerank_gaps_semantic(all_gaps, embeddings) → reranked_gaps
+        ↓
+runners.py: query DB (or use reranked_gaps) → compute metrics → return results dict
         ↓
 cli.py: Rich table output (default) or JSON (--json-output)
 ```
+
+### Semantic reranking in status/library
+
+`_print_ref_gaps_table(state, limit, embeddings?)` — when embeddings provided, calls
+`state.rerank_gaps_semantic()` before display and shows `(semantically reranked)` in title.
+Triggered automatically when embeddings are configured in `status --verbose` and `library`.
 
 ## Maintaining this file
 Update when: adding new metric functions, changing runner logic, adding new benchmark types, or modifying dataset schema.

--- a/src/klemma/evaluation/__init__.py
+++ b/src/klemma/evaluation/__init__.py
@@ -4,17 +4,23 @@ from .dataset import (
     BenchmarkDataset,
     GapSample,
     IntentSample,
+    ReconstructionDataset,
+    ReconstructionGroundTruth,
+    ReconstructionSample,
     SimilarityPair,
     export_dataset,
     load_dataset,
 )
-from .metrics import intent_metrics, ndcg_at_k, precision_at_k, recall_at_k
+from .metrics import intent_metrics, ndcg_at_k, precision_at_k, recall_at_k, reconstruction_metrics
 from .runners import run_all, run_embedding_benchmark, run_gap_benchmark, run_intent_benchmark
 
 __all__ = [
     "BenchmarkDataset",
     "GapSample",
     "IntentSample",
+    "ReconstructionDataset",
+    "ReconstructionGroundTruth",
+    "ReconstructionSample",
     "SimilarityPair",
     "export_dataset",
     "intent_metrics",
@@ -22,6 +28,7 @@ __all__ = [
     "ndcg_at_k",
     "precision_at_k",
     "recall_at_k",
+    "reconstruction_metrics",
     "run_all",
     "run_embedding_benchmark",
     "run_gap_benchmark",

--- a/src/klemma/evaluation/dataset.py
+++ b/src/klemma/evaluation/dataset.py
@@ -39,6 +39,51 @@ class SimilarityPair(BaseModel):
     relevant: list[str]
 
 
+class SectionCitation(BaseModel):
+    """A citation within a paper section, with optional library match."""
+
+    citekey: str | None = None
+    title: str
+    intent: Literal["background", "method", "result_comparison"]
+    in_library: bool = False
+
+
+class PaperSection(BaseModel):
+    """A section of a paper with its citations."""
+
+    section_id: str
+    title: str
+    description: str = ""
+    citations: list[SectionCitation] = []
+
+
+class ReconstructionGroundTruth(BaseModel):
+    """Ground truth: paper's actual citation map (sections → cited works)."""
+
+    paper_citekey: str
+    paper_title: str
+    abstract: str = ""
+    keywords: list[str] = []
+    sections: list[PaperSection] = []
+    bibliography_size: int = 0
+
+
+class ReconstructionSample(BaseModel):
+    """Flattened (section, citekey, intent) triple for evaluation."""
+
+    section_id: str
+    citekey: str
+    intent: Literal["background", "method", "result_comparison"]
+
+
+class ReconstructionDataset(BaseModel):
+    """Dataset for citation reconstruction benchmark."""
+
+    version: str = "1.0"
+    ground_truth: ReconstructionGroundTruth
+    samples: list[ReconstructionSample] = []
+
+
 class BenchmarkDataset(BaseModel):
     """Annotated test set for multi-format evaluation.
 
@@ -50,6 +95,7 @@ class BenchmarkDataset(BaseModel):
     fragments: list[IntentSample] = []
     gaps: list[GapSample] = []
     similar_pairs: list[SimilarityPair] = []
+    reconstruction: ReconstructionDataset | None = None
 
 
 def load_dataset(path: Path) -> BenchmarkDataset:

--- a/src/klemma/evaluation/metrics.py
+++ b/src/klemma/evaluation/metrics.py
@@ -15,6 +15,9 @@ from collections import defaultdict
 
 INTENT_CLASSES = ("background", "method", "result_comparison")
 
+# Graded relevance for nDCG in reconstruction benchmark
+INTENT_RELEVANCE = {"method": 3, "result_comparison": 2, "background": 1}
+
 
 def intent_metrics(
     predictions: list[str], ground_truth: list[str]
@@ -142,3 +145,105 @@ def ndcg_at_k(
         idcg += (2**rel - 1) / math.log2(i + 2)
 
     return round(dcg / idcg, 4) if idcg > 0 else 0.0
+
+
+def reconstruction_metrics(
+    predictions: list[dict],
+    ground_truth: list[dict],
+) -> dict:
+    """Compute citation reconstruction metrics.
+
+    Each item is a dict with keys: section_id, citekey, intent.
+
+    Metrics:
+    - Source precision/recall per section (over citekey sets)
+    - Macro precision/recall averaged across sections
+    - Intent accuracy for correctly placed (section, citekey) pairs
+    - nDCG per section with graded relevance (method=3, result_comparison=2, background=1)
+    - Overall F1 (harmonic mean of macro-P and macro-R)
+    """
+    if not ground_truth:
+        return {
+            "macro_precision": 0.0,
+            "macro_recall": 0.0,
+            "f1": 0.0,
+            "intent_accuracy": 0.0,
+            "ndcg_avg": 0.0,
+            "per_section": {},
+            "total_gt": 0,
+            "total_pred": 0,
+        }
+
+    # Group by section
+    gt_by_section: dict[str, list[dict]] = defaultdict(list)
+    for item in ground_truth:
+        gt_by_section[item["section_id"]].append(item)
+
+    pred_by_section: dict[str, list[dict]] = defaultdict(list)
+    for item in predictions:
+        pred_by_section[item["section_id"]].append(item)
+
+    per_section: dict[str, dict] = {}
+    precision_scores = []
+    recall_scores = []
+    ndcg_scores = []
+
+    # Intent accuracy: count correct intents for matched (section, citekey) pairs
+    intent_correct = 0
+    intent_total = 0
+
+    for section_id, gt_items in gt_by_section.items():
+        gt_citekeys = {item["citekey"] for item in gt_items}
+        gt_intent_map = {item["citekey"]: item["intent"] for item in gt_items}
+
+        pred_items = pred_by_section.get(section_id, [])
+        pred_citekeys = {item["citekey"] for item in pred_items}
+        pred_intent_map = {item["citekey"]: item["intent"] for item in pred_items}
+
+        # Precision / recall over citekey sets
+        hits = gt_citekeys & pred_citekeys
+        p = len(hits) / len(pred_citekeys) if pred_citekeys else 0.0
+        r = len(hits) / len(gt_citekeys) if gt_citekeys else 0.0
+
+        # Intent accuracy for matched pairs
+        for ck in hits:
+            intent_total += 1
+            if pred_intent_map.get(ck) == gt_intent_map.get(ck):
+                intent_correct += 1
+
+        # nDCG: build relevance map from ground truth intents
+        relevance_map = {
+            ck: INTENT_RELEVANCE.get(intent, 1)
+            for ck, intent in gt_intent_map.items()
+        }
+        ranked_pred = [item["citekey"] for item in pred_items]
+        section_ndcg = ndcg_at_k(ranked_pred, relevance_map, max(len(relevance_map), 1))
+
+        per_section[section_id] = {
+            "precision": round(p, 4),
+            "recall": round(r, 4),
+            "gt_count": len(gt_citekeys),
+            "pred_count": len(pred_citekeys),
+            "hits": len(hits),
+            "ndcg": section_ndcg,
+        }
+        precision_scores.append(p)
+        recall_scores.append(r)
+        ndcg_scores.append(section_ndcg)
+
+    macro_p = sum(precision_scores) / len(precision_scores) if precision_scores else 0.0
+    macro_r = sum(recall_scores) / len(recall_scores) if recall_scores else 0.0
+    f1 = (2 * macro_p * macro_r / (macro_p + macro_r)) if (macro_p + macro_r) > 0 else 0.0
+    intent_acc = intent_correct / intent_total if intent_total > 0 else 0.0
+    ndcg_avg = sum(ndcg_scores) / len(ndcg_scores) if ndcg_scores else 0.0
+
+    return {
+        "macro_precision": round(macro_p, 4),
+        "macro_recall": round(macro_r, 4),
+        "f1": round(f1, 4),
+        "intent_accuracy": round(intent_acc, 4),
+        "ndcg_avg": round(ndcg_avg, 4),
+        "per_section": per_section,
+        "total_gt": len(ground_truth),
+        "total_pred": len(predictions),
+    }

--- a/src/klemma/evaluation/reconstruction.py
+++ b/src/klemma/evaluation/reconstruction.py
@@ -1,0 +1,259 @@
+"""Citation reconstruction benchmark — end-to-end recommendation quality.
+
+Tests whether Klemma can match real-world citation decisions by comparing
+two approaches against a paper's actual citation map:
+- Baseline: existing DB fragment assignments (no AI call)
+- Reconstruction: AI prompt assigns citations to a test paper's sections
+
+Design: take a published paper as ground truth. An analyst prompt extracts
+its outline + citation map. Klemma then tries to reconstruct citation
+assignments using only the outline + fragment library (blind to paper text).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from .dataset import ReconstructionDataset, ReconstructionGroundTruth
+from .metrics import reconstruction_metrics
+
+if TYPE_CHECKING:
+    from klemma.ai import AIProvider
+    from klemma.state import StateManager
+
+logger = logging.getLogger(__name__)
+
+
+def run_analyst(
+    ai: AIProvider,
+    pdf_text: str,
+    library_entries: str,
+    paper_citekey: str,
+    paper_title: str,
+    klemma_home: Optional[Path] = None,
+) -> Optional[ReconstructionGroundTruth]:
+    """Run analyst prompt on a paper to extract ground truth citation map.
+
+    Args:
+        ai: AI provider for the analyst call.
+        pdf_text: Full text of the paper.
+        library_entries: Formatted library entries for matching.
+        paper_citekey: Citekey of the paper being analyzed.
+        paper_title: Title of the paper.
+        klemma_home: Path to resolve prompt templates.
+
+    Returns:
+        ReconstructionGroundTruth or None on failure.
+    """
+    from klemma.config import _SHIPPED_PROMPTS_DIR, resolve_prompt
+
+    prompt_path = (
+        resolve_prompt("analyst.md", klemma_home)
+        if klemma_home
+        else _SHIPPED_PROMPTS_DIR / "analyst.md"
+    )
+    user_prompt = ai.render_prompt(
+        prompt_path,
+        pdf_text=pdf_text,
+        library_entries=library_entries,
+        paper_citekey=paper_citekey,
+        paper_title=paper_title,
+    )
+
+    system = (
+        "You are a research analyst extracting the citation map from a scientific paper. "
+        "Output only valid JSON."
+    )
+
+    data = ai.call_json(system, user_prompt, max_tokens=8192)
+    if not data:
+        logger.error("Analyst prompt failed for %s", paper_citekey)
+        return None
+
+    try:
+        return ReconstructionGroundTruth.model_validate(data)
+    except Exception as e:
+        logger.error("Failed to parse analyst response: %s", e)
+        return None
+
+
+def compute_baseline(
+    state: StateManager,
+    dataset: ReconstructionDataset,
+) -> dict:
+    """Compute baseline metrics using existing DB fragment assignments.
+
+    For each ground truth sample, checks if DB has a fragment from that
+    source assigned to a matching section. No AI call needed.
+    """
+    predictions = []
+
+    # Get all fragments from DB, grouped by source
+    gt_citekeys = {s.citekey for s in dataset.samples}
+    for citekey in gt_citekeys:
+        frags = state.get_fragments(source_id=citekey, limit=500)
+        for frag in frags:
+            section = frag.get("section", "")
+            intent = frag.get("citation_intent")
+            if section and intent:
+                predictions.append({
+                    "section_id": section,
+                    "citekey": citekey,
+                    "intent": intent,
+                })
+
+    # Deduplicate: keep first occurrence of (section_id, citekey)
+    seen = set()
+    unique_preds = []
+    for p in predictions:
+        key = (p["section_id"], p["citekey"])
+        if key not in seen:
+            seen.add(key)
+            unique_preds.append(p)
+
+    gt_dicts = [s.model_dump() for s in dataset.samples]
+    metrics = reconstruction_metrics(unique_preds, gt_dicts)
+
+    return {
+        "method": "baseline",
+        "predictions_count": len(unique_preds),
+        **metrics,
+    }
+
+
+def run_reconstruction(
+    ai: AIProvider,
+    state: StateManager,
+    dataset: ReconstructionDataset,
+    klemma_home: Optional[Path] = None,
+) -> dict:
+    """Run AI-driven citation reconstruction.
+
+    Provides the paper outline and fragment library to AI, which recommends
+    citation assignments blind to the actual paper text.
+    """
+    from klemma.config import _SHIPPED_PROMPTS_DIR, resolve_prompt
+
+    gt = dataset.ground_truth
+
+    # Build section list with descriptions from ground truth
+    sections = [
+        {
+            "section_id": s.section_id,
+            "title": s.title,
+            "description": s.description,
+        }
+        for s in gt.sections
+    ]
+
+    # Build source context: citekeys with their top fragments + abstracts
+    gt_citekeys = {s.citekey for s in dataset.samples}
+    sources = []
+    for citekey in gt_citekeys:
+        source_info = state.get_source(citekey)
+        frags = state.get_fragments(source_id=citekey, limit=5)
+        sources.append({
+            "citekey": citekey,
+            "title": source_info.get("title", "") if source_info else "",
+            "year": source_info.get("year", "") if source_info else "",
+            "abstract": source_info.get("abstract", "") if source_info else "",
+            "fragments": [
+                {
+                    "text": f.get("fragment_text", ""),
+                    "intent": f.get("citation_intent", "background"),
+                }
+                for f in frags
+            ],
+        })
+
+    prompt_path = (
+        resolve_prompt("reconstruct.md", klemma_home)
+        if klemma_home
+        else _SHIPPED_PROMPTS_DIR / "reconstruct.md"
+    )
+    user_prompt = ai.render_prompt(
+        prompt_path,
+        paper_title=gt.paper_title,
+        abstract=gt.abstract,
+        keywords=gt.keywords,
+        sections=sections,
+        sources=sources,
+    )
+
+    system = (
+        "You are a citation recommendation system. "
+        "Recommend which sources should be cited in each section. "
+        "Output only valid JSON."
+    )
+
+    data = ai.call_json(system, user_prompt, max_tokens=4096)
+    if not data:
+        logger.error("Reconstruction prompt failed")
+        return {"method": "reconstruction", "error": "AI call failed"}
+
+    # Parse recommendations into prediction dicts
+    predictions = []
+    seen = set()
+    for rec in data.get("recommendations", []):
+        section_id = rec.get("section_id", "")
+        citekey = rec.get("citekey", "")
+        intent = rec.get("intent", "background")
+        if not section_id or not citekey:
+            continue
+        key = (section_id, citekey)
+        if key not in seen:
+            seen.add(key)
+            predictions.append({
+                "section_id": section_id,
+                "citekey": citekey,
+                "intent": intent,
+            })
+
+    gt_dicts = [s.model_dump() for s in dataset.samples]
+    metrics = reconstruction_metrics(predictions, gt_dicts)
+
+    return {
+        "method": "reconstruction",
+        "predictions_count": len(predictions),
+        **metrics,
+    }
+
+
+def run_reconstruction_benchmark(
+    state: StateManager,
+    dataset: ReconstructionDataset,
+    ai: Optional[AIProvider] = None,
+    klemma_home: Optional[Path] = None,
+) -> dict:
+    """Run full reconstruction benchmark: ground truth stats + baseline + optional AI.
+
+    Returns a dict with ground_truth summary, baseline metrics, and
+    (if AI provided) reconstruction metrics.
+    """
+    gt = dataset.ground_truth
+    in_library = sum(
+        1
+        for section in gt.sections
+        for c in section.citations
+        if c.in_library
+    )
+
+    result: dict = {
+        "ground_truth": {
+            "paper": gt.paper_citekey,
+            "sections": len(gt.sections),
+            "bibliography_size": gt.bibliography_size,
+            "in_library_citations": in_library,
+            "samples": len(dataset.samples),
+        },
+        "baseline": compute_baseline(state, dataset),
+    }
+
+    if ai:
+        result["reconstruction"] = run_reconstruction(
+            ai, state, dataset, klemma_home
+        )
+
+    return result

--- a/src/klemma/evaluation/runners.py
+++ b/src/klemma/evaluation/runners.py
@@ -169,6 +169,8 @@ def run_all(
     dataset: BenchmarkDataset,
     metrics_filter: str = "all",
     reranked_gaps: list[dict] | None = None,
+    ai: object | None = None,
+    klemma_home: object | None = None,
 ) -> dict:
     """Run selected benchmarks and return combined results.
 
@@ -178,6 +180,8 @@ def run_all(
     Args:
         reranked_gaps: Pre-ranked gap list for hybrid semantic evaluation.
             Passed through to run_gap_benchmark() when provided.
+        ai: AIProvider instance (needed for reconstruction benchmark).
+        klemma_home: Path to resolve prompt templates.
     """
     results: dict = {}
 
@@ -189,5 +193,11 @@ def run_all(
 
     if metrics_filter in ("all", "embeddings") and dataset.similar_pairs:
         results["embeddings"] = run_embedding_benchmark(state, dataset)
+
+    if metrics_filter in ("all", "reconstruct") and dataset.reconstruction:
+        from .reconstruction import run_reconstruction_benchmark
+        results["reconstruction"] = run_reconstruction_benchmark(
+            state, dataset.reconstruction, ai=ai, klemma_home=klemma_home,
+        )
 
     return results

--- a/src/klemma/evaluation/runners.py
+++ b/src/klemma/evaluation/runners.py
@@ -57,13 +57,19 @@ def run_intent_benchmark(
 
 
 def run_gap_benchmark(
-    state: StateManager, dataset: BenchmarkDataset
+    state: StateManager,
+    dataset: BenchmarkDataset,
+    reranked_gaps: list[dict] | None = None,
 ) -> dict:
     """Evaluate gap scoring precision against ground truth relevance.
 
     Gets current gap ranking from DB, matches against annotated relevance.
     Metrics: precision@5, precision@10, nDCG@10 (Bhagavatula et al. 2018;
     Cohan et al. 2020).
+
+    Args:
+        reranked_gaps: Pre-ranked gap list (e.g. from rerank_gaps_semantic).
+            When provided, skips DB fetch and uses this list directly.
     """
     if not dataset.gaps:
         return {"total": 0, "metrics": {}}
@@ -77,8 +83,8 @@ def run_gap_benchmark(
         if sample.ground_truth_relevance >= 3:
             relevant_titles.add(title_key)
 
-    # Get DB ranking
-    db_gaps = state.get_reference_gaps(limit=100)
+    # Use provided reranked list or fall back to DB ranking
+    db_gaps = reranked_gaps if reranked_gaps is not None else state.get_reference_gaps(limit=100)
     ranked_titles = [
         (g.get("ref_title", "") or "").lower().strip() for g in db_gaps
     ]
@@ -162,11 +168,16 @@ def run_all(
     state: StateManager,
     dataset: BenchmarkDataset,
     metrics_filter: str = "all",
+    reranked_gaps: list[dict] | None = None,
 ) -> dict:
     """Run selected benchmarks and return combined results.
 
     Multi-format evaluation: each sub-benchmark evaluated independently,
     following SciRepEval methodology (Singh et al. 2023).
+
+    Args:
+        reranked_gaps: Pre-ranked gap list for hybrid semantic evaluation.
+            Passed through to run_gap_benchmark() when provided.
     """
     results: dict = {}
 
@@ -174,7 +185,7 @@ def run_all(
         results["intent"] = run_intent_benchmark(state, dataset)
 
     if metrics_filter in ("all", "gaps") and dataset.gaps:
-        results["gaps"] = run_gap_benchmark(state, dataset)
+        results["gaps"] = run_gap_benchmark(state, dataset, reranked_gaps=reranked_gaps)
 
     if metrics_filter in ("all", "embeddings") and dataset.similar_pairs:
         results["embeddings"] = run_embedding_benchmark(state, dataset)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (263 tests)
+## Current test suite (269 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
@@ -10,7 +10,7 @@
 - `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
 - `test_repositories.py` (~130 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`)
-- `test_evaluation.py` (~280 lines) — 37 tests: pure metrics (intent_metrics, precision@K, recall@K, nDCG@K), dataset load/validate/roundtrip, runner integration (intent/gap/embedding benchmarks with seeded DB), export template
+- `test_evaluation.py` (~320 lines) — 38 tests: pure metrics (intent_metrics, precision@K, recall@K, nDCG@K), dataset load/validate/roundtrip, runner integration (intent/gap/embedding benchmarks with seeded DB), export template, `test_run_gap_benchmark_with_reranked_gaps` (verifies reranked list bypasses DB)
 - `test_security_hardening.py` — path traversal and download safety tests
 
 ## Patterns

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -304,6 +304,35 @@ class TestRunGapBenchmark:
         result = run_gap_benchmark(state, BenchmarkDataset())
         assert result["total"] == 0
 
+    def test_reranked_gaps_skips_db(self, state):
+        """When reranked_gaps is provided, DB is not fetched — the given list is used.
+
+        Proof: reranked list contains only an unrelated paper (not in ground truth),
+        so precision falls to 0. If DB were consulted instead, it would return
+        the relevant paper and precision would be 1.0.
+        """
+        state.register_sources(["s1"])
+        state.save_reference_gaps("s1", [
+            {"ref_authors": "A", "ref_year": 2020, "ref_title": "Relevant Paper",
+             "why_relevant": "r", "citation_intent": "method"},
+        ])
+        ds = BenchmarkDataset(gaps=[
+            GapSample(ref_title="Relevant Paper", section="2.1",
+                      ground_truth_relevance=5),
+        ])
+
+        # Without reranking: DB has the relevant paper → P@5 = 1.0
+        result_default = run_gap_benchmark(state, ds)
+        assert result_default["metrics"]["precision_at_5"] == 1.0
+
+        # With reranked list containing only an unrelated paper — DB is skipped,
+        # so the relevant paper is absent → P@5 = 0.0
+        reranked = [{"ref_title": "Completely Unrelated Paper", "score": 20.0}]
+        result_reranked = run_gap_benchmark(state, ds, reranked_gaps=reranked)
+        assert result_reranked["metrics"]["precision_at_5"] == 0.0
+        # db_gaps_count reflects the reranked list length, not the DB count
+        assert result_reranked["db_gaps_count"] == 1
+
 
 class TestRunEmbeddingBenchmark:
     def test_computes_recall(self, state):

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -1,0 +1,545 @@
+"""Tests for citation reconstruction benchmark — metrics, models, runners, prompts."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from klemma.evaluation.dataset import (
+    BenchmarkDataset,
+    PaperSection,
+    ReconstructionDataset,
+    ReconstructionGroundTruth,
+    ReconstructionSample,
+    SectionCitation,
+    load_dataset,
+)
+from klemma.evaluation.metrics import reconstruction_metrics
+from klemma.evaluation.reconstruction import (
+    compute_baseline,
+    run_reconstruction,
+    run_reconstruction_benchmark,
+)
+from klemma.state import StateManager
+
+# --- Pure metric tests ---
+
+
+class TestReconstructionMetrics:
+    """Test reconstruction_metrics (macro P/R, F1, intent accuracy, nDCG)."""
+
+    def test_perfect_reconstruction(self):
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "2", "citekey": "b", "intent": "method"},
+        ]
+        preds = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "2", "citekey": "b", "intent": "method"},
+        ]
+        result = reconstruction_metrics(preds, gt)
+        assert result["macro_precision"] == 1.0
+        assert result["macro_recall"] == 1.0
+        assert result["f1"] == 1.0
+        assert result["intent_accuracy"] == 1.0
+        assert result["ndcg_avg"] == 1.0
+
+    def test_empty_predictions(self):
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+        ]
+        result = reconstruction_metrics([], gt)
+        assert result["macro_precision"] == 0.0
+        assert result["macro_recall"] == 0.0
+        assert result["f1"] == 0.0
+
+    def test_empty_ground_truth(self):
+        result = reconstruction_metrics(
+            [{"section_id": "1", "citekey": "a", "intent": "background"}],
+            [],
+        )
+        assert result["total_gt"] == 0
+        assert result["f1"] == 0.0
+
+    def test_partial_overlap(self):
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "1", "citekey": "b", "intent": "method"},
+            {"section_id": "2", "citekey": "c", "intent": "result_comparison"},
+        ]
+        preds = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "1", "citekey": "x", "intent": "method"},  # wrong
+            {"section_id": "2", "citekey": "c", "intent": "result_comparison"},
+        ]
+        result = reconstruction_metrics(preds, gt)
+        # Section 1: P=1/2, R=1/2; Section 2: P=1, R=1
+        assert result["macro_precision"] == pytest.approx(0.75, abs=0.01)
+        assert result["macro_recall"] == pytest.approx(0.75, abs=0.01)
+        assert result["intent_accuracy"] == 1.0  # matched pairs all correct
+
+    def test_intent_mismatch(self):
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "1", "citekey": "b", "intent": "method"},
+        ]
+        preds = [
+            {"section_id": "1", "citekey": "a", "intent": "method"},      # wrong intent
+            {"section_id": "1", "citekey": "b", "intent": "background"},   # wrong intent
+        ]
+        result = reconstruction_metrics(preds, gt)
+        assert result["macro_precision"] == 1.0  # citekeys match
+        assert result["macro_recall"] == 1.0
+        assert result["intent_accuracy"] == 0.0  # intents wrong
+
+    def test_ndcg_ordering(self):
+        """Higher-relevance items (method > result_comparison > background) ranked first get better nDCG."""
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "method"},            # relevance 3
+            {"section_id": "1", "citekey": "b", "intent": "result_comparison"},  # relevance 2
+            {"section_id": "1", "citekey": "c", "intent": "background"},         # relevance 1
+        ]
+        # Perfect order
+        preds_good = [
+            {"section_id": "1", "citekey": "a", "intent": "method"},
+            {"section_id": "1", "citekey": "b", "intent": "result_comparison"},
+            {"section_id": "1", "citekey": "c", "intent": "background"},
+        ]
+        # Reversed order
+        preds_bad = [
+            {"section_id": "1", "citekey": "c", "intent": "background"},
+            {"section_id": "1", "citekey": "b", "intent": "result_comparison"},
+            {"section_id": "1", "citekey": "a", "intent": "method"},
+        ]
+        good = reconstruction_metrics(preds_good, gt)
+        bad = reconstruction_metrics(preds_bad, gt)
+        assert good["ndcg_avg"] == 1.0
+        assert bad["ndcg_avg"] < good["ndcg_avg"]
+
+    def test_multi_section(self):
+        gt = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "2", "citekey": "b", "intent": "method"},
+            {"section_id": "3", "citekey": "c", "intent": "result_comparison"},
+        ]
+        # Only predict for section 1 and 2
+        preds = [
+            {"section_id": "1", "citekey": "a", "intent": "background"},
+            {"section_id": "2", "citekey": "b", "intent": "method"},
+        ]
+        result = reconstruction_metrics(preds, gt)
+        # Section 1: P=1, R=1; Section 2: P=1, R=1; Section 3: P=0, R=0
+        assert result["macro_precision"] == pytest.approx(2 / 3, abs=0.01)
+        assert result["macro_recall"] == pytest.approx(2 / 3, abs=0.01)
+        assert result["per_section"]["3"]["recall"] == 0.0
+
+    def test_per_section_structure(self):
+        gt = [{"section_id": "1.1", "citekey": "a", "intent": "background"}]
+        preds = [{"section_id": "1.1", "citekey": "a", "intent": "background"}]
+        result = reconstruction_metrics(preds, gt)
+        assert "1.1" in result["per_section"]
+        ps = result["per_section"]["1.1"]
+        assert ps["gt_count"] == 1
+        assert ps["pred_count"] == 1
+        assert ps["hits"] == 1
+
+
+# --- Dataset model tests ---
+
+
+class TestReconstructionDataset:
+    def test_ground_truth_validation(self):
+        gt = ReconstructionGroundTruth(
+            paper_citekey="test2020",
+            paper_title="Test Paper",
+            abstract="This paper studies X.",
+            keywords=["sea ice", "remote sensing"],
+            sections=[
+                PaperSection(
+                    section_id="1",
+                    title="Introduction",
+                    description="Introduces the problem of sea ice monitoring.",
+                    citations=[
+                        SectionCitation(
+                            citekey="smith2020",
+                            title="Smith Paper",
+                            intent="background",
+                            in_library=True,
+                        )
+                    ],
+                )
+            ],
+            bibliography_size=42,
+        )
+        assert gt.paper_citekey == "test2020"
+        assert gt.abstract == "This paper studies X."
+        assert gt.keywords == ["sea ice", "remote sensing"]
+        assert len(gt.sections) == 1
+        assert gt.sections[0].description == "Introduces the problem of sea ice monitoring."
+        assert gt.sections[0].citations[0].in_library is True
+
+    def test_ground_truth_optional_fields_default(self):
+        gt = ReconstructionGroundTruth(
+            paper_citekey="bare2020",
+            paper_title="Bare Paper",
+        )
+        assert gt.abstract == ""
+        assert gt.keywords == []
+        assert gt.sections == []
+
+    def test_section_description_optional(self):
+        section = PaperSection(section_id="1", title="Intro")
+        assert section.description == ""
+
+    def test_sample_validation(self):
+        sample = ReconstructionSample(
+            section_id="2.1",
+            citekey="jones2021",
+            intent="method",
+        )
+        assert sample.section_id == "2.1"
+
+    def test_invalid_intent_rejected(self):
+        with pytest.raises(Exception):
+            ReconstructionSample(
+                section_id="1",
+                citekey="x",
+                intent="INVALID",
+            )
+
+    def test_roundtrip_serialization(self, tmp_path):
+        gt = ReconstructionGroundTruth(
+            paper_citekey="pilot2020",
+            paper_title="Pilot Study",
+            abstract="A study of citation patterns.",
+            keywords=["citations", "NLP"],
+            sections=[
+                PaperSection(
+                    section_id="1",
+                    title="Intro",
+                    description="Introduces citation analysis problem.",
+                    citations=[
+                        SectionCitation(title="Ref A", intent="background"),
+                        SectionCitation(
+                            citekey="refB",
+                            title="Ref B",
+                            intent="method",
+                            in_library=True,
+                        ),
+                    ],
+                ),
+            ],
+            bibliography_size=10,
+        )
+        samples = [
+            ReconstructionSample(section_id="1", citekey="refB", intent="method"),
+        ]
+        recon_ds = ReconstructionDataset(ground_truth=gt, samples=samples)
+        ds = BenchmarkDataset(reconstruction=recon_ds)
+
+        p = tmp_path / "recon.json"
+        p.write_text(json.dumps(ds.model_dump()))
+        loaded = load_dataset(p)
+        assert loaded.reconstruction is not None
+        rgt = loaded.reconstruction.ground_truth
+        assert rgt.paper_citekey == "pilot2020"
+        assert rgt.abstract == "A study of citation patterns."
+        assert rgt.keywords == ["citations", "NLP"]
+        assert rgt.sections[0].description == "Introduces citation analysis problem."
+        assert len(loaded.reconstruction.samples) == 1
+        assert loaded.reconstruction.samples[0].citekey == "refB"
+
+    def test_benchmark_dataset_without_reconstruction(self):
+        ds = BenchmarkDataset()
+        assert ds.reconstruction is None
+
+    def test_citation_without_citekey(self):
+        """Citations not in library have citekey=None."""
+        cit = SectionCitation(title="Unknown Paper", intent="background")
+        assert cit.citekey is None
+        assert cit.in_library is False
+
+
+# --- Runner integration tests ---
+
+
+@pytest.fixture
+def state(tmp_path):
+    return StateManager(tmp_path / "test.db")
+
+
+def _make_dataset(samples=None):
+    """Helper to create a minimal ReconstructionDataset with context."""
+    gt = ReconstructionGroundTruth(
+        paper_citekey="pilot2020",
+        paper_title="Pilot Study on Citation Patterns",
+        abstract="This paper analyzes citation patterns in academic literature.",
+        keywords=["citations", "bibliometrics", "NLP"],
+        sections=[
+            PaperSection(
+                section_id="1", title="Introduction",
+                description="Introduces the problem of citation analysis.",
+            ),
+            PaperSection(
+                section_id="2", title="Methods",
+                description="Describes the NLP pipeline for citation extraction.",
+            ),
+        ],
+        bibliography_size=20,
+    )
+    if samples is None:
+        samples = [
+            ReconstructionSample(section_id="1", citekey="sourceA", intent="background"),
+            ReconstructionSample(section_id="2", citekey="sourceB", intent="method"),
+        ]
+    return ReconstructionDataset(ground_truth=gt, samples=samples)
+
+
+class TestComputeBaseline:
+    def test_matches_db_fragments(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        state.save_fragments("sourceA", [
+            {"text": "Background info", "type": "key_idea",
+             "section": "1", "relevance": 3, "citation_intent": "background"},
+        ])
+        state.save_fragments("sourceB", [
+            {"text": "Method detail", "type": "methodology",
+             "section": "2", "relevance": 4, "citation_intent": "method"},
+        ])
+
+        dataset = _make_dataset()
+        result = compute_baseline(state, dataset)
+        assert result["method"] == "baseline"
+        assert result["macro_recall"] == 1.0
+        assert result["macro_precision"] == 1.0
+        assert result["f1"] == 1.0
+
+    def test_no_matching_fragments(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        # No fragments saved
+
+        dataset = _make_dataset()
+        result = compute_baseline(state, dataset)
+        assert result["predictions_count"] == 0
+        assert result["macro_recall"] == 0.0
+
+    def test_partial_match(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        state.save_fragments("sourceA", [
+            {"text": "Background info", "type": "key_idea",
+             "section": "1", "relevance": 3, "citation_intent": "background"},
+        ])
+        # sourceB has no fragments
+
+        dataset = _make_dataset()
+        result = compute_baseline(state, dataset)
+        assert result["predictions_count"] == 1
+        assert result["macro_recall"] > 0
+        assert result["macro_recall"] < 1.0
+
+    def test_deduplicates_predictions(self, state):
+        state.register_sources(["sourceA"])
+        state.save_fragments("sourceA", [
+            {"text": "Frag 1", "type": "key_idea",
+             "section": "1", "relevance": 3, "citation_intent": "background"},
+            {"text": "Frag 2", "type": "key_idea",
+             "section": "1", "relevance": 4, "citation_intent": "background"},
+        ])
+        dataset = _make_dataset(samples=[
+            ReconstructionSample(section_id="1", citekey="sourceA", intent="background"),
+        ])
+        result = compute_baseline(state, dataset)
+        assert result["predictions_count"] == 1  # deduplicated
+
+
+class TestRunReconstruction:
+    def test_ai_driven_reconstruction(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        state.save_fragments("sourceA", [
+            {"text": "Background info", "type": "key_idea",
+             "section": "1", "relevance": 3, "citation_intent": "background"},
+        ])
+
+        # Mock AI to return correct recommendations
+        mock_ai = MagicMock()
+        mock_ai.call_json.return_value = {
+            "recommendations": [
+                {"section_id": "1", "citekey": "sourceA",
+                 "intent": "background", "justification": "test"},
+                {"section_id": "2", "citekey": "sourceB",
+                 "intent": "method", "justification": "test"},
+            ]
+        }
+        mock_ai.render_prompt.return_value = "rendered prompt"
+
+        dataset = _make_dataset()
+        result = run_reconstruction(mock_ai, state, dataset)
+        assert result["method"] == "reconstruction"
+        assert result["predictions_count"] == 2
+        assert result["macro_recall"] == 1.0
+
+    def test_ai_failure(self, state):
+        state.register_sources(["sourceA"])
+        mock_ai = MagicMock()
+        mock_ai.call_json.return_value = None
+        mock_ai.render_prompt.return_value = "rendered prompt"
+
+        dataset = _make_dataset()
+        result = run_reconstruction(mock_ai, state, dataset)
+        assert result.get("error") == "AI call failed"
+
+    def test_deduplicates_ai_recommendations(self, state):
+        state.register_sources(["sourceA"])
+        mock_ai = MagicMock()
+        mock_ai.call_json.return_value = {
+            "recommendations": [
+                {"section_id": "1", "citekey": "sourceA",
+                 "intent": "background", "justification": "first"},
+                {"section_id": "1", "citekey": "sourceA",
+                 "intent": "method", "justification": "duplicate"},
+            ]
+        }
+        mock_ai.render_prompt.return_value = "rendered prompt"
+
+        dataset = _make_dataset(samples=[
+            ReconstructionSample(section_id="1", citekey="sourceA", intent="background"),
+        ])
+        result = run_reconstruction(mock_ai, state, dataset)
+        assert result["predictions_count"] == 1
+
+
+class TestRunReconstructionBenchmark:
+    def test_full_benchmark_baseline_only(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        state.save_fragments("sourceA", [
+            {"text": "Info", "type": "key_idea",
+             "section": "1", "relevance": 3, "citation_intent": "background"},
+        ])
+
+        dataset = _make_dataset()
+        result = run_reconstruction_benchmark(state, dataset)
+        assert "ground_truth" in result
+        assert "baseline" in result
+        assert "reconstruction" not in result
+        assert result["ground_truth"]["sections"] == 2
+        assert result["ground_truth"]["samples"] == 2
+
+    def test_full_benchmark_with_ai(self, state):
+        state.register_sources(["sourceA", "sourceB"])
+        mock_ai = MagicMock()
+        mock_ai.call_json.return_value = {
+            "recommendations": [
+                {"section_id": "1", "citekey": "sourceA",
+                 "intent": "background", "justification": "test"},
+            ]
+        }
+        mock_ai.render_prompt.return_value = "rendered prompt"
+
+        dataset = _make_dataset()
+        result = run_reconstruction_benchmark(state, dataset, ai=mock_ai)
+        assert "reconstruction" in result
+        assert result["reconstruction"]["method"] == "reconstruction"
+
+
+class TestRunAllWithReconstruction:
+    def test_reconstruct_filter(self, state):
+        state.register_sources(["sourceA"])
+        dataset = _make_dataset(samples=[
+            ReconstructionSample(section_id="1", citekey="sourceA", intent="background"),
+        ])
+        ds = BenchmarkDataset(reconstruction=dataset)
+
+        from klemma.evaluation.runners import run_all
+        result = run_all(state, ds, "reconstruct")
+        assert "reconstruction" in result
+        assert "intent" not in result
+
+    def test_all_filter_includes_reconstruction(self, state):
+        state.register_sources(["sourceA"])
+        dataset = _make_dataset(samples=[
+            ReconstructionSample(section_id="1", citekey="sourceA", intent="background"),
+        ])
+        ds = BenchmarkDataset(reconstruction=dataset)
+
+        from klemma.evaluation.runners import run_all
+        result = run_all(state, ds, "all")
+        assert "reconstruction" in result
+
+
+# --- Prompt rendering tests ---
+
+
+class TestPromptRendering:
+    def test_analyst_template_renders(self):
+        from jinja2 import Template
+        prompt_path = Path(__file__).parent.parent / "prompts" / "analyst.md"
+        template = Template(prompt_path.read_text(encoding="utf-8"))
+        rendered = template.render(
+            pdf_text="Sample paper text...",
+            library_entries="- smith2020: Some Paper",
+            paper_citekey="test2020",
+            paper_title="Test Paper",
+        )
+        assert "test2020" in rendered
+        assert "Sample paper text" in rendered
+        assert "smith2020" in rendered
+
+    def test_reconstruct_template_renders(self):
+        from jinja2 import Template
+        prompt_path = Path(__file__).parent.parent / "prompts" / "reconstruct.md"
+        template = Template(prompt_path.read_text(encoding="utf-8"))
+        rendered = template.render(
+            paper_title="My Research Paper",
+            abstract="This paper studies citation patterns.",
+            keywords=["citations", "NLP", "bibliometrics"],
+            sections=[
+                {"section_id": "1", "title": "Introduction",
+                 "description": "Introduces the problem of citation analysis."},
+                {"section_id": "2", "title": "Methods",
+                 "description": "Describes the NLP pipeline."},
+            ],
+            sources=[
+                {
+                    "citekey": "smith2020",
+                    "title": "Smith Paper",
+                    "year": "2020",
+                    "abstract": "Smith's abstract about NLP.",
+                    "fragments": [
+                        {"intent": "background", "text": "Important finding"},
+                    ],
+                },
+            ],
+        )
+        assert "My Research Paper" in rendered
+        assert "citation patterns" in rendered
+        assert "citations, NLP, bibliometrics" in rendered
+        assert "Introduces the problem" in rendered
+        assert "Smith's abstract" in rendered
+        assert "smith2020" in rendered
+        assert "Important finding" in rendered
+
+    def test_reconstruct_template_handles_missing_optional_fields(self):
+        """Template should render even without abstract/keywords/description."""
+        from jinja2 import Template
+        prompt_path = Path(__file__).parent.parent / "prompts" / "reconstruct.md"
+        template = Template(prompt_path.read_text(encoding="utf-8"))
+        rendered = template.render(
+            paper_title="Bare Paper",
+            abstract="",
+            keywords=[],
+            sections=[
+                {"section_id": "1", "title": "Introduction", "description": ""},
+            ],
+            sources=[
+                {
+                    "citekey": "jones2021",
+                    "title": "Jones Paper",
+                    "year": "2021",
+                    "abstract": "",
+                    "fragments": [],
+                },
+            ],
+        )
+        assert "Bare Paper" in rendered
+        assert "jones2021" in rendered


### PR DESCRIPTION
## Summary

- Build complete evaluation framework: intent F1, gap nDCG, embedding recall, and citation reconstruction benchmarks
- Wire semantic gap reranking (`--semantic` flag) for hybrid keyword x semantic evaluation
- Add end-to-end citation reconstruction benchmark: analyst prompt extracts ground truth from paper PDF, reconstruction prompt recommends citations blind to paper text
- New data models, metrics (macro P/R, F1, intent accuracy, nDCG), runner modules, 2 prompt templates
- CLI: `--analyst <citekey>` to generate ground truth, `--reconstruct` flag, `reconstruct` metrics filter
- Pilot on Kinney et al. 2025: AI reconstruction F1 0.624 vs baseline 0.037, nDCG 0.881 vs 0.044

Part of #27, Part of #29

## Test Plan
- [x] `ruff check src/ tests/` passes
- [x] 30 new tests in `test_reconstruction.py` + existing evaluation tests
- [x] Full suite: 299 tests pass
- [x] Pilot execution on real paper with gpt-4.1 produces valid results

## Release Note

### Problem

Klemma's existing evaluation framework (intent F1, gap nDCG, embedding recall) measures component accuracy but not end-to-end recommendation quality. There was no way to test whether Klemma's citation recommendations match real-world citation decisions — the core use case the tool is built for. Without this benchmark, claims about recommendation quality in the paper lack empirical backing.

### Academic Foundation

The benchmark design draws from several established evaluation methodologies. Ground truth is derived from actual paper citations following the SciFact annotation protocol (Wadden et al. 2020), not synthetic data. Macro-averaged F1 gives equal weight to each class, preventing majority-class gaming (Cohan et al. 2019 — SciCite). Multi-format evaluation follows SciRepEval's principle that "condensing all relevant information into a single metric might not be expressive enough" (Singh et al. 2023). nDCG with graded relevance follows SciDocs evaluation practice (Cohan et al. 2020 — SPECTER). Citation intent is evaluated separately from placement quality, recognizing these as distinct capabilities.

### Implementation

New `reconstruction.py` module with 4 functions: `run_analyst()` extracts ground truth via 3-phase AI prompt (metadata → section outline → citation map), `compute_baseline()` evaluates DB-only fragment assignments, `run_reconstruction()` runs AI-driven blind recommendation, and `run_reconstruction_benchmark()` orchestrates the full comparison. Two new Jinja2 prompt templates (`analyst.md`, `reconstruct.md`) provide enriched context including paper title, abstract, keywords, section descriptions, source abstracts, and fragment evidence. Reconstruction metrics compute macro precision/recall per section, overall F1, intent accuracy for matched pairs, and nDCG with graded relevance (method=3, result_comparison=2, background=1). CLI integration adds `--analyst <citekey>` and `--reconstruct` flag to the benchmark command.

### Results

- 20 files changed, +2,715 lines (new: evaluation/, reconstruction.py, analyst.md, reconstruct.md, test_reconstruction.py, test_evaluation.py)
- 299 total tests passing, ruff clean
- Pilot benchmark (Kinney et al. 2025, 8 sections, 16 in-library citations):
  - Baseline: F1 0.037, nDCG 0.044 (DB fragments lack section-level assignment)
  - Reconstruction: F1 0.624, nDCG 0.881 (16.9x and 20.0x improvement)
  - Recall 0.896: AI finds nearly all relevant citations
  - Intent accuracy 0.286: intent classification in recommendation context needs improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)