### PR TITLE
feat: add --outline to klemma init

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ pip install klemma[all-ai]             # все AI-бэкенды (openai + lite
 # 1. Инициализировать проект
 klemma init                                    # интерактивный мастер
 klemma init --type paper                       # проект-статья
+klemma init --outline                           # сгенерировать outline после init (нужен AI)
 
 # 2. Посмотреть статистику, покрытие, пробелы
 klemma status                                  # компактный обзор
@@ -95,6 +96,7 @@ klemma outline -p "Фокус на методологии"       # с дирек
 klemma init                    # интерактивный мастер
 klemma init --type paper       # проект-статья (вместо диссертации)
 klemma init --no-input         # без вопросов (defaults)
+klemma init --outline          # сгенерировать outline после init (нужен AI)
 ```
 
 ### `klemma plan`

--- a/README_EN.md
+++ b/README_EN.md
@@ -36,6 +36,7 @@ Requirements:
 ```bash
 # 1. Set up your config
 klemma init                          # creates ~/.klemma/ with templates
+klemma init --outline                 # generate outline after init (requires AI)
 # Edit ~/.klemma/config.yaml         — Zotero/Obsidian paths, AI backend
 # Edit ~/.klemma/context.md          — your dissertation topic and structure
 # Edit ~/.klemma/tags.yaml           — your domain tag taxonomy
@@ -63,7 +64,7 @@ klemma library --audit               # deep quality audit
 
 | Command | Description |
 |---------|-------------|
-| `klemma init` | Scaffold `~/.klemma/` with config templates |
+| `klemma init` | Scaffold `~/.klemma/` with config templates (use `--outline` to generate outline) |
 | `klemma plan` | Generate daily focus and briefing |
 | `klemma status` | Coverage stats, gaps, reference gaps |
 | `klemma process [citekeys...]` | Extract citation fragments from PDFs |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,6 +50,7 @@ pip install -e ".[local-embeddings]"     # + офлайн SPECTER2
 ```bash
 cd ~/research/my-thesis/
 klemma init
+klemma init --outline        # сгенерировать outline после init (нужен AI)
 ```
 
 Мастер задаст вопросы:
@@ -362,6 +363,7 @@ klemma init                         # диссертация
 
 cd paper_ice/
 klemma init --type paper            # статья (наследует vault/zotero)
+klemma init --outline               # сгенерировать outline после init (нужен AI)
 ```
 
 Статья использует свою БД, но vault и Zotero диссертации. AI видит контекст обоих проектов.

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -4,13 +4,14 @@ Foundation layer: config, state, AI providers, vault, library abstraction, CLI e
 
 ## Modules
 
-### cli.py (2861 lines)
+### cli.py (2947 lines)
 Click CLI entry point. Defines 16 commands + hidden aliases.
 - `_init_components(config_path)` — creates `KlemmaContext` via Git-style project discovery
 - `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
 - Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`
+- `init --outline` generates an outline after project setup (requires AI backend)
 
 ### context.py (41 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -406,8 +406,9 @@ def main(ctx, config):
 @click.option("--global-only", is_flag=True, help="Only create/update ~/.klemma/ system config")
 @click.option("--no-input", is_flag=True, help="Skip interactive prompts, use defaults")
 @click.option("--force", is_flag=True, help="Re-run wizard even if project exists (prefills from current config)")
+@click.option("--outline", is_flag=True, help="Generate outline after init (requires AI)")
 @click.pass_context
-def init(ctx, project_type, global_only, no_input, force):
+def init(ctx, project_type, global_only, no_input, force, outline):
     """Initialize a new klemma project in current directory.
 
     Creates .klemma/ and KLEMMA.md in the current directory.
@@ -481,6 +482,43 @@ def init(ctx, project_type, global_only, no_input, force):
         and values.zotero_library_json
     ):
         _discover_paper_sources(project_dir, values)
+
+    if outline:
+        try:
+            kctx = _init_components(ctx.obj["config_path"])
+        except Exception as e:
+            console.print(f"[yellow]Skipping outline: {e}[/yellow]")
+        else:
+            from .config import scan_project_files
+            from .skills.outliner import generate_outline as gen_outline
+            from .skills.outliner import save_outline
+
+            project_files = scan_project_files(kctx.project_root)
+            if not project_files:
+                console.print("[yellow]No files found in project directory; skipping outline.[/yellow]")
+            else:
+                try:
+                    ai = _init_ai(kctx.config)
+                except Exception as e:
+                    console.print("[yellow]Skipping outline: AI backend not configured.[/yellow]")
+                    console.print(f"[dim]{e}[/dim]")
+                else:
+                    with console.status("Generating outline...", spinner="dots"):
+                        result, _mode = gen_outline(
+                            kctx.config,
+                            kctx.state,
+                            ai,
+                            kctx.project_root,
+                            project_name=kctx.project_root.name,
+                            project=kctx.project,
+                            dissertation_context=kctx.dissertation_context,
+                            klemma_home=kctx.klemma_home,
+                        )
+                    if not result.title:
+                        console.print("[red]Failed to generate outline.[/red]")
+                    else:
+                        saved_path = save_outline(result, kctx.project_root.name, kctx.project_root)
+                        console.print(f"[dim]Outline saved: {saved_path}[/dim]")
 
     console.print()
     console.print("Run [bold]klemma status[/bold] to verify.")

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (353 tests)
+## Current test suite (371 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
@@ -9,6 +9,7 @@
 - `test_mcp.py` (404 lines) — `ToolRegistry` CRUD + routing, `ToolInfo`, SPECTER MCP server creation (4 tools), embed/similar/batch tool logic via helpers, `compare_intents()` (LLM vs S2 accuracy, confusion matrix)
 - `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
+- `test_cli_init_outline.py` (37 lines) — `klemma init --outline` CLI behavior, AI-missing skip, no-outline no AI call
 - `test_repositories.py` (~130 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`)
 - `test_evaluation.py` (~320 lines) — 38 tests: pure metrics (intent_metrics, precision@K, recall@K, nDCG@K), dataset load/validate/roundtrip, runner integration (intent/gap/embedding benchmarks with seeded DB), export template, `test_run_gap_benchmark_with_reranked_gaps` (verifies reranked list bypasses DB)
 - `test_security_hardening.py` — path traversal and download safety tests

--- a/tests/test_cli_init_outline.py
+++ b/tests/test_cli_init_outline.py
@@ -1,0 +1,37 @@
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+
+
+def test_init_outline_skips_when_ai_missing(monkeypatch, tmp_path):
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    def _boom(_cfg):
+        raise RuntimeError("AI not configured")
+
+    monkeypatch.setattr("klemma.cli._init_ai", _boom)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(klemma_cli, ["init", "--no-input", "--outline"])
+
+    assert result.exit_code == 0
+    assert "Skipping outline: AI backend not configured." in result.output
+
+
+def test_init_without_outline_does_not_call_ai(monkeypatch, tmp_path):
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+    called = []
+
+    def _boom(_cfg):
+        called.append(True)
+        raise RuntimeError("should not be called")
+
+    monkeypatch.setattr("klemma.cli._init_ai", _boom)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(klemma_cli, ["init", "--no-input"])
+
+    assert result.exit_code == 0
+    assert called == []


### PR DESCRIPTION
## Summary
- add `--outline` to `klemma init` to generate an outline after project setup
- skip gracefully with a warning when AI backend is not configured
- document the new flag and add CLI tests

## Testing
- `ruff check src/ tests/`
- `python -m pytest tests/ -q`

Part of #32

## Release Note

### Problem
`klemma init` currently scaffolds project files and configuration but stops short of producing any project structure. Users who want an initial outline must remember to run a second command after setup, which is easy to miss and adds friction in early project bootstrapping. This gap is most noticeable for new users who expect a single command to deliver both scaffolding and a first-pass outline.

### Academic Foundation
Not applicable for this change. This is a small UX/flow improvement that reuses existing outline generation logic without changing the underlying research methodology.

### Implementation
The CLI gained an opt-in `--outline` flag on `klemma init`. When provided, init attempts to initialize the AI backend and calls the existing outline generator (`skills.outliner.generate_outline`) to create `Outline_<project>.md` after setup. If AI is not configured or initialization fails, the command prints a warning and skips outline generation without failing the init flow. Docs were updated in `README.md`, `README_EN.md`, `docs/USER_GUIDE.md`, and `src/klemma/CLAUDE.md`, and CLI tests cover both the skip path and the default path.

### Results
`ruff` and `pytest` pass (371 tests). No behavioral change for `klemma init` without the flag. `klemma init --outline` now produces an outline when AI is available and exits cleanly with a warning otherwise.
