### PR TITLE
feat: allow multiple citekeys in embed

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -957,15 +957,15 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
 
 
 @main.command()
-@click.argument("citekey", required=False)
+@click.argument("citekeys", required=False, nargs=-1)
 @click.option("--dry-run", is_flag=True, help="Show how many would be embedded without calling API")
 @click.option("--backend", type=click.Choice(["s2", "local", "openai"]), help="Override embedding backend")
 @click.pass_context
-def embed(ctx, citekey, dry_run, backend):
+def embed(ctx, citekeys, dry_run, backend):
     """Backfill embeddings for sources with abstracts.
 
-    Without CITEKEY: embed all sources missing embeddings.
-    With CITEKEY: embed a specific source.
+    Without CITEKEYS: embed all sources missing embeddings.
+    With CITEKEYS: embed specific sources.
     Use --dry-run to preview without API calls.
     """
     kctx = _get_context(ctx)
@@ -987,12 +987,19 @@ def embed(ctx, citekey, dry_run, backend):
         return
 
     # Get candidates: sources with abstract but no embedding
-    if citekey:
-        source = state.get_source(citekey)
-        if not source:
-            console.print(f"[red]Source {citekey} not found[/red]")
+    if citekeys:
+        candidates = []
+        missing = []
+        for ck in citekeys:
+            source = state.get_source(ck)
+            if not source:
+                missing.append(ck)
+                continue
+            candidates.append(ck)
+        if missing:
+            console.print(f"[yellow]Missing citekeys: {', '.join(missing)}[/yellow]")
+        if not candidates:
             return
-        candidates = [citekey]
     else:
         # Find completed sources without embeddings
         candidates = state.get_sources_without_embeddings()

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (353 tests)
+## Current test suite (372 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
@@ -9,6 +9,8 @@
 - `test_mcp.py` (404 lines) — `ToolRegistry` CRUD + routing, `ToolInfo`, SPECTER MCP server creation (4 tools), embed/similar/batch tool logic via helpers, `compare_intents()` (LLM vs S2 accuracy, confusion matrix)
 - `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
+- `test_cli_init_outline.py` (37 lines) — `klemma init --outline` CLI behavior, AI-missing skip, no-outline no AI call
+- `test_cli_embed.py` (26 lines) — `klemma embed` multi-citekey CLI behavior and missing-key warnings
 - `test_repositories.py` (~130 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`)
 - `test_evaluation.py` (~320 lines) — 38 tests: pure metrics (intent_metrics, precision@K, recall@K, nDCG@K), dataset load/validate/roundtrip, runner integration (intent/gap/embedding benchmarks with seeded DB), export template, `test_run_gap_benchmark_with_reranked_gaps` (verifies reranked list bypasses DB)
 - `test_security_hardening.py` — path traversal and download safety tests

--- a/tests/test_cli_embed.py
+++ b/tests/test_cli_embed.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+from klemma.state import StateManager
+
+
+def test_embed_accepts_multiple_citekeys_and_warns_missing(tmp_path, monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem():
+        init_result = runner.invoke(klemma_cli, ["init", "--no-input"])
+        assert init_result.exit_code == 0
+
+        state = StateManager(Path(".klemma/data/klemma.db"))
+        state.register_sources(["exists1"])
+
+        result = runner.invoke(klemma_cli, ["embed", "exists1", "missing1", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Missing citekeys: missing1" in result.output
+    assert "Would embed 0 sources" in result.output
+    assert "sources have no abstract" in result.output


### PR DESCRIPTION
## Summary
- allow `klemma embed` to accept multiple citekeys (variadic args)
- warn on missing citekeys and skip sources without abstracts
- add CLI test coverage and update test docs

## Testing
- `ruff check src/ tests/`
- `python -m pytest tests/ -q`

Part of #40

## Release Note

### Problem
`klemma embed` only accepts a single citekey, so embedding a curated list requires running the command repeatedly. This is tedious for batch workflows and breaks when users naturally pass multiple citekeys as positional arguments, resulting in an “unexpected extra arguments” error.

### Academic Foundation
Not applicable for this change. This is a small CLI usability improvement that does not affect the underlying embedding methodology.

### Implementation
The `embed` command now accepts variadic citekeys via Click’s `nargs=-1`. When citekeys are provided, the command validates each against the DB, warns about missing keys, and proceeds with the remaining candidates. Entries without abstracts are skipped and counted in the summary, preserving the existing logic for auto-backfill when no citekeys are specified. A CLI test validates multi-citekey input and missing-key warnings, and test documentation is updated accordingly.

### Results
`ruff` and `pytest` pass (372 tests). Existing `klemma embed` behavior without citekeys is unchanged, while multi-citekey runs now succeed with clear warnings and summary counts.
