### PR TITLE
feat(evaluation): ablation infrastructure for Issue #42

### DIFF
--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -52,7 +52,7 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 `pdf_text`, `library_entries`, `paper_citekey`, `paper_title`
 
 ### reconstruct.md
-`sections` (list of {section_id, title}), `sources` (list of {citekey, title, year, fragments: [{intent, text}]})
+`paper_title`, `abstract`, `keywords`, `sections` (list of {section_id, title, description}), `sources` (list of {citekey, title, year, abstract, fragments: [{intent, text}]}), `max_recs_per_section` (int, optional — caps recommendations per section), `examples` (list of {section_id, section_title, citekey, intent, justification}, optional — few-shot golden examples for ablation)
 
 ## Conventions
 - All templates in Russian (dissertation language) except `extract.md` (English for international papers)

--- a/prompts/reconstruct.md
+++ b/prompts/reconstruct.md
@@ -61,8 +61,23 @@ Rules:
 - A source can appear in multiple sections with different intents
 - Prefer specific fragment evidence over general relevance
 - Use section descriptions to understand what each section needs
+{% if max_recs_per_section %}
+- Recommend at most {{ max_recs_per_section }} sources per section — only the most relevant
+{% else %}
 - Be thorough: if a source is relevant to a section, include it
+{% endif %}
 - Order recommendations by confidence (most confident first within each section)
+{% if examples %}
+
+## Examples
+
+Here are examples of correct citation assignments for similar papers:
+
+{% for ex in examples %}
+**Section {{ ex.section_id }}: {{ ex.section_title }}**
+→ {{ ex.citekey }} ({{ ex.intent }}): {{ ex.justification }}
+{% endfor %}
+{% endif %}
 
 ## Output Format
 

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -4,7 +4,7 @@ Foundation layer: config, state, AI providers, vault, library abstraction, CLI e
 
 ## Modules
 
-### cli.py (2947 lines)
+### cli.py (2993 lines)
 Click CLI entry point. Defines 16 commands + hidden aliases.
 - `_init_components(config_path)` — creates `KlemmaContext` via Git-style project discovery
 - `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -2249,7 +2249,7 @@ def _print_project_tree(root: Path, indent: int = 0, current: Path | None = None
 # --- Benchmark: evaluation framework ---
 
 
-def _run_auto_mode(kctx, paper_citekey, skip_prepare):
+def _run_auto_mode(kctx, paper_citekey, skip_prepare, ablation=None):
     """Run full autonomous benchmark pipeline."""
     from .evaluation.pipeline import run_auto_benchmark
 
@@ -2262,6 +2262,13 @@ def _run_auto_mode(kctx, paper_citekey, skip_prepare):
     target = paper_citekey or "[auto-select]"
     console.print(f"[bold]Auto benchmark: {target}[/bold]")
 
+    if ablation:
+        params = ablation.to_snapshot()
+        non_default = {k: v for k, v in params.items()
+                       if v is not None and k != "prompt_variant"}
+        if non_default or params.get("prompt_variant") != "default":
+            console.print(f"[dim]Ablation: {params}[/dim]")
+
     with console.status("Running autonomous benchmark pipeline...", spinner="arc"):
         result = run_auto_benchmark(
             kctx.state, ai, kctx.config,
@@ -2269,6 +2276,7 @@ def _run_auto_mode(kctx, paper_citekey, skip_prepare):
             paper_citekey=paper_citekey,
             skip_prepare=skip_prepare,
             storage_path=kctx.config.zotero.storage_path,
+            ablation=ablation,
         )
 
     if result.results.get("error"):
@@ -2553,11 +2561,21 @@ def _print_benchmark_compare(state, id_a: str, id_b: str):
               help="Citekey for --auto mode (default: top candidate)")
 @click.option("--skip-prepare", is_flag=True,
               help="Skip reference preparation in --auto mode")
+@click.option("--temperature", "ablation_temperature", type=float, default=None,
+              help="Override AI temperature for ablation (default: 0.2)")
+@click.option("--max-recs", "ablation_max_recs", type=int, default=None,
+              help="Max recommendations per section (default: uncapped)")
+@click.option("--fragments", "ablation_fragments", type=int, default=None,
+              help="Fragments per source for context (default: 5)")
+@click.option("--prompt-variant", "ablation_variant", type=click.Choice(["default", "fewshot"]),
+              default=None, help="Prompt variant for ablation (default: default)")
 @click.pass_context
 def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
               analyst_citekey, reconstruct, history, compare, export_history_path,
               candidates, candidates_limit, prepare_citekey,
-              auto_mode, auto_paper, skip_prepare):
+              auto_mode, auto_paper, skip_prepare,
+              ablation_temperature, ablation_max_recs, ablation_fragments,
+              ablation_variant):
     """Run evaluation benchmarks against annotated ground truth.
 
     Multi-format evaluation (Singh et al. 2023 — SciRepEval):
@@ -2644,7 +2662,24 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
 
     # --- Auto mode: full autonomous pipeline ---
     if auto_mode:
-        _run_auto_mode(kctx, auto_paper, skip_prepare)
+        from .evaluation.pipeline import AblationParams
+
+        ablation = None
+        if any(v is not None for v in [ablation_temperature, ablation_max_recs,
+                                        ablation_fragments, ablation_variant]):
+            kwargs = {}
+            if ablation_temperature is not None:
+                kwargs["temperature"] = ablation_temperature
+            if ablation_max_recs is not None:
+                kwargs["max_recs_per_section"] = ablation_max_recs
+            if ablation_fragments is not None:
+                kwargs["fragments_per_source"] = ablation_fragments
+            if ablation_variant == "fewshot":
+                ablation = AblationParams.with_fewshot(**kwargs)
+            else:
+                ablation = AblationParams(**kwargs)
+
+        _run_auto_mode(kctx, auto_paper, skip_prepare, ablation=ablation)
         return
 
     # --- Analyst mode: extract ground truth from a paper ---
@@ -2719,7 +2754,10 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
     if ds.reconstruction and ds.reconstruction.ground_truth:
         paper_citekey = ds.reconstruction.ground_truth.paper_citekey
 
+    from .evaluation.pipeline import compute_prompt_hash
+
     summary = build_results_summary(results)
+    prompt_hash = compute_prompt_hash("reconstruct.md", kctx.klemma_home)
     run_id = kctx.state.save_benchmark_run(
         dataset_path=dataset,
         dataset_hash=ds_hash,
@@ -2734,6 +2772,7 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
         klemma_version=__version__,
         config_snapshot={
             "ai": {"backend": kctx.config.ai.backend, "model": kctx.config.ai.model},
+            "prompt_hash": prompt_hash,
         },
     )
     console.print(f"[dim]Run {run_id} saved ({duration:.1f}s)[/dim]")

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -2724,6 +2724,31 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
     # Determine effective metrics filter
     effective_metrics = "reconstruct" if reconstruct else metrics
 
+    # Build ablation params for -d mode (same logic as --auto)
+    from .evaluation.pipeline import AblationParams, compute_prompt_hash
+
+    ablation = None
+    if any(v is not None for v in [ablation_temperature, ablation_max_recs,
+                                    ablation_fragments, ablation_variant]):
+        kwargs = {}
+        if ablation_temperature is not None:
+            kwargs["temperature"] = ablation_temperature
+        if ablation_max_recs is not None:
+            kwargs["max_recs_per_section"] = ablation_max_recs
+        if ablation_fragments is not None:
+            kwargs["fragments_per_source"] = ablation_fragments
+        if ablation_variant == "fewshot":
+            ablation = AblationParams.with_fewshot(**kwargs)
+        else:
+            ablation = AblationParams(**kwargs)
+
+    if ablation:
+        params = ablation.to_snapshot()
+        non_default = {k: v for k, v in params.items()
+                       if v is not None and k != "prompt_variant"}
+        if non_default or params.get("prompt_variant") != "default":
+            console.print(f"[dim]Ablation: {params}[/dim]")
+
     # Initialize AI if reconstruction benchmark is requested
     ai = None
     if (effective_metrics in ("all", "reconstruct")) and ds.reconstruction:
@@ -2735,6 +2760,7 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
     results = run_all(
         kctx.state, ds, effective_metrics,
         reranked_gaps=reranked_gaps, ai=ai, klemma_home=kctx.klemma_home,
+        ablation=ablation,
     )
 
     duration = time.monotonic() - t_start
@@ -2754,10 +2780,9 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
     if ds.reconstruction and ds.reconstruction.ground_truth:
         paper_citekey = ds.reconstruction.ground_truth.paper_citekey
 
-    from .evaluation.pipeline import compute_prompt_hash
-
     summary = build_results_summary(results)
     prompt_hash = compute_prompt_hash("reconstruct.md", kctx.klemma_home)
+    effective_ablation = ablation or AblationParams()
     run_id = kctx.state.save_benchmark_run(
         dataset_path=dataset,
         dataset_hash=ds_hash,
@@ -2772,6 +2797,8 @@ def benchmark(ctx, dataset, metrics, export_path, json_output, semantic,
         klemma_version=__version__,
         config_snapshot={
             "ai": {"backend": kctx.config.ai.backend, "model": kctx.config.ai.model},
+            "frozen_gt": True,
+            "ablation": effective_ablation.to_snapshot(),
             "prompt_hash": prompt_hash,
         },
     )

--- a/src/klemma/evaluation/CLAUDE.md
+++ b/src/klemma/evaluation/CLAUDE.md
@@ -34,12 +34,12 @@ Benchmark runners — orchestrate DB queries + metric computation.
 - `run_all(state, dataset, metrics_filter, reranked_gaps?, ai?, klemma_home?)` — dispatch to selected runners; includes reconstruction when `metrics_filter` is `"all"` or `"reconstruct"`
 - `build_results_summary(results)` — flatten headline metrics from results dict into flat `{"reconstruction.f1": 0.624, ...}` dict for persistence
 
-### reconstruction.py (~200 lines)
+### reconstruction.py (~230 lines)
 Citation reconstruction benchmark — end-to-end recommendation quality.
 - `run_analyst(ai, pdf_text, library_entries, paper_citekey, paper_title, klemma_home)` — extract ground truth citation map from a paper's PDF via AI
 - `compute_baseline(state, dataset)` — evaluate DB-only fragment assignments against ground truth
-- `run_reconstruction(ai, state, dataset, klemma_home)` — AI-driven citation recommendation against ground truth
-- `run_reconstruction_benchmark(state, dataset, ai?, klemma_home?)` — full benchmark: ground truth stats + baseline + optional AI reconstruction
+- `run_reconstruction(ai, state, dataset, klemma_home, ablation?)` — AI-driven citation recommendation against ground truth; ablation params override temperature, fragments_per_source, and prompt variables (max_recs_per_section, few-shot examples)
+- `run_reconstruction_benchmark(state, dataset, ai?, klemma_home?, ablation?)` — full benchmark: ground truth stats + baseline + optional AI reconstruction with ablation support
 
 ### candidates.py (~97 lines)
 Benchmark candidate discovery from citation graph.
@@ -61,11 +61,13 @@ Auto-fetch missing referenced PDFs before benchmarking.
 - `ReferenceStatus` / `PrepareResult` — Pydantic models
 - `prepare_benchmark(state, citekey, storage_path, dry_run?)` — query citation_links, resolve PDFs, optionally acquire via `acquire_paper_local`
 
-### pipeline.py (~210 lines)
+### pipeline.py (~260 lines)
 Full autonomous benchmark pipeline composing all evaluation steps.
+- `compute_prompt_hash(prompt_name, klemma_home?)` — SHA-256 prefix (12 hex chars) of a prompt template file for change detection between runs
+- `AblationParams` — Pydantic model for ablation experiments (Issue #42): `temperature`, `max_recs_per_section`, `fragments_per_source`, `prompt_variant` ("default"/"fewshot"), `examples`. Defaults match current behavior. `to_snapshot()` serializes for config_snapshot. `with_fewshot(**kwargs)` factory creates params with built-in golden examples
 - `AutoBenchmarkResult` — Pydantic model: paper_citekey, prepare_result, results, run_id, comparison
 - `run_analyst_from_source(state, ai, citekey, config, klemma_home?)` — shared helper: find PDF → extract text → run analyst → build ReconstructionDataset
-- `run_auto_benchmark(state, ai, config, ...)` — full pipeline: select candidate → prepare → analyst → benchmark → persist → compare with previous run
+- `run_auto_benchmark(state, ai, config, ..., ablation?)` — full pipeline: select candidate → prepare → analyst → benchmark → persist → compare. Config snapshot includes ablation params + prompt hash
 
 ## Design rationale
 
@@ -125,11 +127,12 @@ Triggered automatically when embeddings are configured in `status --verbose` and
 
 ```
 klemma benchmark --auto [--paper <citekey>] [--skip-prepare]
+    [--temperature 0.3] [--max-recs 3] [--fragments 10] [--prompt-variant fewshot]
   1. Select: explicit --paper or discover_candidates()[0]
   2. Prepare: resolve missing refs (arXiv/CrossRef/Unpaywall) → acquire PDFs
   3. Analyst: run_analyst_from_source() → ReconstructionDataset
-  4. Benchmark: run_reconstruction_benchmark()
-  5. Persist: save_benchmark_run() with git commit + config snapshot
+  4. Benchmark: run_reconstruction_benchmark(ablation=AblationParams)
+  5. Persist: save_benchmark_run() with git commit + config snapshot + ablation params + prompt hash
   6. Compare: delta with previous run for same paper
 
 klemma benchmark --candidates [-k N]

--- a/src/klemma/evaluation/__init__.py
+++ b/src/klemma/evaluation/__init__.py
@@ -12,6 +12,7 @@ from .dataset import (
     load_dataset,
 )
 from .metrics import intent_metrics, ndcg_at_k, precision_at_k, recall_at_k, reconstruction_metrics
+from .pipeline import AblationParams, compute_prompt_hash
 from .runners import (
     build_results_summary,
     run_all,
@@ -21,7 +22,9 @@ from .runners import (
 )
 
 __all__ = [
+    "AblationParams",
     "BenchmarkDataset",
+    "compute_prompt_hash",
     "GapSample",
     "IntentSample",
     "ReconstructionDataset",

--- a/src/klemma/evaluation/pipeline.py
+++ b/src/klemma/evaluation/pipeline.py
@@ -6,6 +6,7 @@ analyst (extract ground truth) → benchmark → persist → compare.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import shutil
 from pathlib import Path
@@ -21,6 +22,71 @@ if TYPE_CHECKING:
     from klemma.state import StateManager
 
 logger = logging.getLogger(__name__)
+
+
+def compute_prompt_hash(prompt_name: str, klemma_home: Optional[Path] = None) -> str:
+    """Compute SHA-256 prefix of a prompt template file.
+
+    Returns first 12 hex chars — enough to detect template changes between runs.
+    """
+    from klemma.config import _SHIPPED_PROMPTS_DIR, resolve_prompt
+
+    prompt_path = (
+        resolve_prompt(prompt_name, klemma_home)
+        if klemma_home
+        else _SHIPPED_PROMPTS_DIR / prompt_name
+    )
+    try:
+        content = prompt_path.read_bytes()
+        return hashlib.sha256(content).hexdigest()[:12]
+    except (OSError, FileNotFoundError):
+        return ""
+
+
+class AblationParams(BaseModel):
+    """Overridable parameters for ablation experiments (Issue #42).
+
+    Defaults match current behavior so passing AblationParams() changes nothing.
+    """
+    temperature: float = 0.2
+    max_recs_per_section: Optional[int] = None  # None = uncapped (current)
+    fragments_per_source: int = 5
+    prompt_variant: str = "default"  # "default" | "fewshot"
+
+    # Few-shot golden examples (populated when prompt_variant == "fewshot")
+    examples: list[dict] = []
+
+    def to_snapshot(self) -> dict:
+        """Serialize for config_snapshot storage."""
+        return {
+            "temperature": self.temperature,
+            "max_recs_per_section": self.max_recs_per_section,
+            "fragments_per_source": self.fragments_per_source,
+            "prompt_variant": self.prompt_variant,
+        }
+
+    @classmethod
+    def with_fewshot(cls, **kwargs) -> AblationParams:
+        """Create params with built-in few-shot golden examples."""
+        examples = [
+            {
+                "section_id": "2.1",
+                "section_title": "Citation Intent Classification",
+                "citekey": "cohan2019",
+                "intent": "method",
+                "justification": "SciCite provides the 3-class intent taxonomy "
+                "(background/method/result_comparison) used in this work",
+            },
+            {
+                "section_id": "3.2",
+                "section_title": "Evaluation Metrics",
+                "citekey": "singh2023",
+                "intent": "method",
+                "justification": "SciRepEval's multi-format evaluation design "
+                "justifies separate metrics per task type",
+            },
+        ]
+        return cls(prompt_variant="fewshot", examples=examples, **kwargs)
 
 
 class AutoBenchmarkResult(BaseModel):
@@ -110,6 +176,7 @@ def run_auto_benchmark(
     paper_citekey: Optional[str] = None,
     skip_prepare: bool = False,
     storage_path: str = "",
+    ablation: Optional[AblationParams] = None,
 ) -> AutoBenchmarkResult:
     """Run full autonomous benchmark pipeline.
 
@@ -164,9 +231,11 @@ def run_auto_benchmark(
         return result
 
     # 4. Benchmark
+    effective_ablation = ablation or AblationParams()
     t_start = time.monotonic()
     bench_results = run_reconstruction_benchmark(
         state, dataset, ai=ai, klemma_home=klemma_home,
+        ablation=effective_ablation,
     )
     duration = time.monotonic() - t_start
 
@@ -183,6 +252,8 @@ def run_auto_benchmark(
     except Exception:
         pass
 
+    prompt_hash = compute_prompt_hash("reconstruct.md", klemma_home)
+
     run_id = state.save_benchmark_run(
         metrics_filter="reconstruct",
         ai_backend=config.ai.backend,
@@ -196,6 +267,8 @@ def run_auto_benchmark(
         config_snapshot={
             "ai": {"backend": config.ai.backend, "model": config.ai.model},
             "auto": True,
+            "ablation": effective_ablation.to_snapshot(),
+            "prompt_hash": prompt_hash,
         },
     )
     result.run_id = run_id

--- a/src/klemma/evaluation/reconstruction.py
+++ b/src/klemma/evaluation/reconstruction.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Optional
 
 from .dataset import ReconstructionDataset, ReconstructionGroundTruth
 from .metrics import reconstruction_metrics
+from .pipeline import AblationParams
 
 if TYPE_CHECKING:
     from klemma.ai import AIProvider
@@ -130,14 +131,21 @@ def run_reconstruction(
     state: StateManager,
     dataset: ReconstructionDataset,
     klemma_home: Optional[Path] = None,
+    ablation: Optional[AblationParams] = None,
 ) -> dict:
     """Run AI-driven citation reconstruction.
 
     Provides the paper outline and fragment library to AI, which recommends
     citation assignments blind to the actual paper text.
+
+    Args:
+        ablation: Override default parameters for ablation experiments.
+            Controls temperature, fragments_per_source, max_recs_per_section,
+            and prompt variant (few-shot examples).
     """
     from klemma.config import _SHIPPED_PROMPTS_DIR, resolve_prompt
 
+    params = ablation or AblationParams()
     gt = dataset.ground_truth
 
     # Build section list with descriptions from ground truth
@@ -155,7 +163,9 @@ def run_reconstruction(
     sources = []
     for citekey in gt_citekeys:
         source_info = state.get_source(citekey)
-        frags = state.get_fragments(source_id=citekey, limit=5)
+        frags = state.get_fragments(
+            source_id=citekey, limit=params.fragments_per_source,
+        )
         sources.append({
             "citekey": citekey,
             "title": source_info.get("title", "") if source_info else "",
@@ -182,6 +192,8 @@ def run_reconstruction(
         keywords=gt.keywords,
         sections=sections,
         sources=sources,
+        max_recs_per_section=params.max_recs_per_section,
+        examples=params.examples,
     )
 
     system = (
@@ -190,7 +202,10 @@ def run_reconstruction(
         "Output only valid JSON."
     )
 
-    data = ai.call_json(system, user_prompt, max_tokens=4096)
+    data = ai.call_json(
+        system, user_prompt, max_tokens=4096,
+        temperature=params.temperature,
+    )
     if not data:
         logger.error("Reconstruction prompt failed")
         return {"method": "reconstruction", "error": "AI call failed"}
@@ -228,11 +243,16 @@ def run_reconstruction_benchmark(
     dataset: ReconstructionDataset,
     ai: Optional[AIProvider] = None,
     klemma_home: Optional[Path] = None,
+    ablation: Optional[AblationParams] = None,
 ) -> dict:
     """Run full reconstruction benchmark: ground truth stats + baseline + optional AI.
 
     Returns a dict with ground_truth summary, baseline metrics, and
     (if AI provided) reconstruction metrics.
+
+    Args:
+        ablation: Override default parameters for ablation experiments.
+            Passed through to run_reconstruction().
     """
     gt = dataset.ground_truth
     in_library = sum(
@@ -255,7 +275,7 @@ def run_reconstruction_benchmark(
 
     if ai:
         result["reconstruction"] = run_reconstruction(
-            ai, state, dataset, klemma_home
+            ai, state, dataset, klemma_home, ablation=ablation,
         )
 
     return result

--- a/src/klemma/evaluation/runners.py
+++ b/src/klemma/evaluation/runners.py
@@ -206,6 +206,7 @@ def run_all(
     reranked_gaps: list[dict] | None = None,
     ai: object | None = None,
     klemma_home: object | None = None,
+    ablation: object | None = None,
 ) -> dict:
     """Run selected benchmarks and return combined results.
 
@@ -217,6 +218,7 @@ def run_all(
             Passed through to run_gap_benchmark() when provided.
         ai: AIProvider instance (needed for reconstruction benchmark).
         klemma_home: Path to resolve prompt templates.
+        ablation: AblationParams for reconstruction benchmark overrides.
     """
     results: dict = {}
 
@@ -233,6 +235,7 @@ def run_all(
         from .reconstruction import run_reconstruction_benchmark
         results["reconstruction"] = run_reconstruction_benchmark(
             state, dataset.reconstruction, ai=ai, klemma_home=klemma_home,
+            ablation=ablation,
         )
 
     return results

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (372 tests)
+## Current test suite (397 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
 - `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
@@ -18,6 +18,7 @@
 - `test_candidates.py` (116 lines) — 10 tests: candidate ranking by citation coverage, benchmarked penalization, limit, has_pdf flag, format_candidate_hint output
 - `test_prepare.py` (251 lines) — 19 tests: _titles_match (exact/case/partial/no match/empty), resolve_arxiv (success/no match/error), resolve_crossref_doi, resolve_unpaywall, resolve_pdf_url (arxiv first/fallback/no resolution), prepare_benchmark (dry_run/no links/unfetchable/actual fetch)
 - `test_auto_pipeline.py` (199 lines) — 8 tests: run_analyst_from_source (success/missing source/no pdf), run_auto_benchmark (explicit paper/analyst failure/auto-select/no candidates/comparison)
+- `test_prompts.py` (~270 lines) — 25 tests: all 12 prompt templates render without Jinja2 errors, coverage check (all shipped templates have test contexts), reconstruct.md ablation variants (default/max_recs/fewshot/combined), prompt hash determinism + uniqueness, AblationParams defaults + to_snapshot + with_fewshot factory
 
 ## Patterns
 - pytest + `unittest.mock` (`patch`, `MagicMock`)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,331 @@
+"""Prompt template regression tests (T1-PT).
+
+Validates that all Jinja2 templates render without error and that
+ablation-related template features work correctly.
+"""
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Template
+
+from klemma.evaluation.pipeline import AblationParams, compute_prompt_hash
+
+PROMPTS_DIR = Path(__file__).parent.parent / "prompts"
+
+# Minimal context per template — just enough to avoid undefined variable errors.
+# Each key is a prompt filename, value is the render kwargs.
+TEMPLATE_CONTEXTS = {
+    "morning.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Test context",
+        "current_chapter": "3",
+        "chapter_name": "Methods",
+        "current_deadline": "2026-06-01",
+        "days_until_deadline": 90,
+        "days_without_progress": 0,
+        "streak": 5,
+        "yesterday_plan": None,
+        "chapter_plan": "",
+        "library_summary": "",
+        "coverage": {"chapters": {"3": 5}},
+        "min_sources": 10,
+        "gaps": [],
+        "fragment_stats": {"total": 100, "by_chapter": {"3": 50}},
+        "next_reading": None,
+        "writing_constraints": "",
+        "language": "ru",
+    },
+    "extract.md": {
+        "title": "Test Paper",
+        "authors": "Smith, J.",
+        "year": "2024",
+        "journal": "Nature",
+        "doi": "10.1234/test",
+        "abstract": "An abstract",
+        "pdf_text": "Paper text...",
+        "dissertation_context": "Context",
+        "available_tags": ["NLP", "ML"],
+    },
+    "annotate.md": {
+        "title": "Test Paper",
+        "authors": "Smith, J.",
+        "year": "2024",
+        "journal": "Nature",
+        "abstract": "Abstract",
+        "pdf_text": "Text",
+        "library_context": "",
+        "dissertation_context": "",
+        "available_tags": [],
+    },
+    "research.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Context",
+        "target_section": "3.2",
+        "chapter_num": 3,
+        "chapter_name": "Methods",
+        "section_text": "Section not written yet.",
+        "full_chapter_draft": "",
+        "chapter_plan": "",
+        "fragments": "[]",
+        "source_summaries": "[]",
+        "coverage": {"chapters": {"3": 5}},
+        "min_sources": 10,
+        "gaps": [],
+        "fragment_stats": {"total": 100, "by_chapter": {"3": 50}},
+        "language": "ru",
+    },
+    "research_incremental.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Context",
+        "target_section": "3.2",
+        "chapter_num": 3,
+        "chapter_name": "Methods",
+        "previous_date": "2026-01-01",
+        "previous_text": "",
+        "new_citekeys": [],
+        "previous_fragment_count": 50,
+        "current_fragment_count": 75,
+        "user_notes": "",
+        "section_text": "Section not written yet.",
+        "full_chapter_draft": "",
+        "fragments": "[]",
+        "source_summaries": "[]",
+        "coverage": {"chapters": {"3": 5}},
+        "min_sources": 10,
+        "gaps": [],
+        "language": "ru",
+    },
+    "librarian.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Context",
+        "current_chapter": 3,
+        "chapter_name": "Methods",
+        "deadline": "2026-06-01",
+        "days_remaining": 90,
+        "mode": "status",
+        "summary": {
+            "total": 10, "completed": 8, "pending": 2, "failed": 0,
+            "fragments_total": 100, "avg_quality": 3.5, "avg_fragments": 10.0,
+            "zero_sections": [],
+        },
+        "chapters": {"3": 5},
+        "quality_data": {},
+        "ref_gaps": [],
+        "sources_compact": "",
+        "sources_shown": 0,
+        "sources_total": 10,
+        "sources_omitted": False,
+        "language": "ru",
+    },
+    "librarian_prune.md": {
+        "source_count": 10,
+        "sources_compact": [],
+    },
+    "agent.md": {
+        "parent_context": "",
+        "project_type": "dissertation",
+        "project_context": "Context",
+        "chapters_label": "chapters",
+        "chapters": {"3": "Methods"},
+        "chapters_label_singular": "chapter",
+        "scientific_results": {},
+        "priority_terms": [],
+        "current_section": "3.2",
+        "current_chapter": "3",
+        "chapter_name": "Methods",
+        "current_deadline": "2026-06-01",
+        "days_until_deadline": 90,
+        "coverage": {"chapters": {"3": 5}},
+        "min_sources": 10,
+        "gaps": [],
+        "fragment_stats": {"total": 100, "by_chapter": {"3": 50}},
+        "sources": [],
+        "today_plan": None,
+        "next_reading": None,
+        "project_root": "/tmp",
+        "vault_path": "/tmp/vault",
+        "outline_content": "",
+        "report_index": [],
+        "project_file_list": [],
+        "today": "2026-02-26",
+        "language": "ru",
+    },
+    "outline.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Context",
+        "project_files": [],
+        "library_summary": "",
+        "custom_prompt": "",
+        "language": "ru",
+    },
+    "outline_incremental.md": {
+        "project_type": "dissertation",
+        "dissertation_context": "Context",
+        "project_files": [],
+        "library_summary": "",
+        "previous_outline": "",
+        "user_notes": "",
+        "previous_date": "2026-01-01",
+        "custom_prompt": "",
+        "language": "ru",
+    },
+    "analyst.md": {
+        "pdf_text": "Paper text...",
+        "library_entries": "- smith2020: Some Paper",
+        "paper_citekey": "jones2024",
+        "paper_title": "Test Paper",
+    },
+    "reconstruct.md": {
+        "paper_title": "Test Paper",
+        "abstract": "An abstract",
+        "keywords": ["NLP", "citations"],
+        "sections": [
+            {"section_id": "1", "title": "Introduction", "description": "Background"},
+            {"section_id": "2", "title": "Methods", "description": "Our approach"},
+        ],
+        "sources": [
+            {
+                "citekey": "smith2020",
+                "title": "Smith et al.",
+                "year": "2020",
+                "abstract": "A paper about things",
+                "fragments": [
+                    {"intent": "background", "text": "This is a background fragment"},
+                    {"intent": "method", "text": "This is a method fragment"},
+                ],
+            },
+        ],
+    },
+}
+
+
+class TestAllTemplatesRender:
+    """Every shipped prompt template must render without Jinja2 errors."""
+
+    @pytest.mark.parametrize("template_name", sorted(TEMPLATE_CONTEXTS.keys()))
+    def test_template_renders(self, template_name):
+        path = PROMPTS_DIR / template_name
+        assert path.exists(), f"Template {template_name} not found in {PROMPTS_DIR}"
+
+        raw = path.read_text(encoding="utf-8")
+        t = Template(raw)
+        result = t.render(**TEMPLATE_CONTEXTS[template_name])
+
+        assert len(result) > 0, f"Template {template_name} rendered empty"
+
+    def test_all_shipped_templates_have_contexts(self):
+        """Ensure we have test contexts for every .md file (except CLAUDE.md)."""
+        shipped = {
+            p.name
+            for p in PROMPTS_DIR.glob("*.md")
+            if p.name != "CLAUDE.md"
+        }
+        tested = set(TEMPLATE_CONTEXTS.keys())
+        missing = shipped - tested
+        assert not missing, f"Templates without test contexts: {missing}"
+
+
+class TestReconstructAblationVariants:
+    """Reconstruct prompt renders correctly with ablation variables."""
+
+    def _render(self, **extra):
+        raw = (PROMPTS_DIR / "reconstruct.md").read_text(encoding="utf-8")
+        ctx = {**TEMPLATE_CONTEXTS["reconstruct.md"], **extra}
+        return Template(raw).render(**ctx)
+
+    def test_default_no_max_recs(self):
+        result = self._render()
+        assert "Be thorough" in result
+        assert "at most" not in result
+
+    def test_max_recs_per_section(self):
+        result = self._render(max_recs_per_section=3)
+        assert "at most 3 sources per section" in result
+        assert "Be thorough" not in result
+
+    def test_no_examples_by_default(self):
+        result = self._render()
+        assert "## Examples" not in result
+
+    def test_fewshot_examples(self):
+        examples = [
+            {
+                "section_id": "2.1",
+                "section_title": "Related Work",
+                "citekey": "jones2021",
+                "intent": "background",
+                "justification": "Provides survey of the field",
+            },
+        ]
+        result = self._render(examples=examples)
+        assert "## Examples" in result
+        assert "jones2021" in result
+        assert "Related Work" in result
+
+    def test_fewshot_and_max_recs_together(self):
+        examples = [
+            {
+                "section_id": "1",
+                "section_title": "Intro",
+                "citekey": "test2020",
+                "intent": "method",
+                "justification": "Used their algorithm",
+            },
+        ]
+        result = self._render(max_recs_per_section=5, examples=examples)
+        assert "at most 5 sources" in result
+        assert "## Examples" in result
+        assert "test2020" in result
+
+
+class TestPromptHash:
+    """Prompt hash is deterministic and changes when content changes."""
+
+    def test_hash_deterministic(self):
+        h1 = compute_prompt_hash("reconstruct.md")
+        h2 = compute_prompt_hash("reconstruct.md")
+        assert h1 == h2
+        assert len(h1) == 12
+
+    def test_hash_different_templates(self):
+        h1 = compute_prompt_hash("reconstruct.md")
+        h2 = compute_prompt_hash("analyst.md")
+        assert h1 != h2
+
+    def test_hash_missing_template(self):
+        h = compute_prompt_hash("nonexistent_template.md")
+        assert h == ""
+
+
+class TestAblationParams:
+    """AblationParams model defaults and factory methods."""
+
+    def test_defaults_match_current_behavior(self):
+        p = AblationParams()
+        assert p.temperature == 0.2
+        assert p.max_recs_per_section is None
+        assert p.fragments_per_source == 5
+        assert p.prompt_variant == "default"
+        assert p.examples == []
+
+    def test_to_snapshot(self):
+        p = AblationParams(temperature=0.7, max_recs_per_section=3)
+        snap = p.to_snapshot()
+        assert snap["temperature"] == 0.7
+        assert snap["max_recs_per_section"] == 3
+        assert snap["fragments_per_source"] == 5
+        assert snap["prompt_variant"] == "default"
+
+    def test_with_fewshot_factory(self):
+        p = AblationParams.with_fewshot(temperature=0.5)
+        assert p.prompt_variant == "fewshot"
+        assert p.temperature == 0.5
+        assert len(p.examples) == 2
+        assert p.examples[0]["citekey"] == "cohan2019"
+
+    def test_with_fewshot_and_max_recs(self):
+        p = AblationParams.with_fewshot(max_recs_per_section=3)
+        assert p.prompt_variant == "fewshot"
+        assert p.max_recs_per_section == 3
+        assert len(p.examples) > 0


### PR DESCRIPTION
## Summary
- **AblationParams model** with overridable parameters (temperature, max_recs_per_section, fragments_per_source, prompt_variant) threaded through `run_reconstruction()` → `run_reconstruction_benchmark()` → `run_auto_benchmark()`
- **Prompt hash tracking** (SHA-256 prefix) in config_snapshot for detecting template changes between runs
- **Few-shot + max_recs** conditional Jinja2 blocks in `reconstruct.md` — precision lever for reducing over-prediction
- **CLI options** `--temperature`, `--max-recs`, `--fragments`, `--prompt-variant` on `klemma benchmark --auto` AND `-d` dataset mode
- **25 prompt regression tests** covering all 12 templates + ablation variants + hash determinism
- **Frozen GT support**: ablation params now work in `-d` mode with frozen ground truth datasets, recording `frozen_gt` flag and ablation snapshot in config_snapshot

Part of #42

## Experiment Results (Frozen GT Protocol)

### Phase 1 (non-frozen GT): misleading results
| Config | F1 | Macro-P | Macro-R | Notes |
|--------|-----|---------|---------|-------|
| baseline | 0.660 | 0.493 | 1.000 | kinney, non-frozen |
| fewshot | 0.719 | 0.610 | 0.875 | **appeared +5.9pp** |
| max_recs=3 | 0.568 | 0.458 | 0.750 | clearly harmful |

### Phase 2 (frozen GT): corrected results
| Config | F1 | Macro-P | Macro-R | Paper |
|--------|-----|---------|---------|-------|
| **baseline** | **0.761** | **0.656** | **0.906** | kinney |
| fewshot | 0.731 | 0.627 | 0.875 | kinney |
| max_recs=3 | 0.631 | 0.500 | 0.854 | kinney |
| baseline | 0.222 | 0.333 | 0.167 | citesee |
| fewshot | 0.222 | 0.333 | 0.167 | citesee |
| max_recs=3 | 0.222 | 0.333 | 0.167 | citesee |

**Key finding**: Zero-shot baseline is best. Few-shot hurts by -3pp F1. The Phase 1 improvement was an artifact of analyst non-determinism (GT varied between runs). Frozen GT protocol eliminates this confound.

## Release Note

### Problem
The benchmark pipeline had hardcoded parameters (temperature=0.2, fragments=5, uncapped recommendations), making it impossible to run ablation experiments. Additionally, the `-d` dataset mode didn't support ablation params, preventing controlled experiments with frozen ground truth that eliminate analyst non-determinism.

### Academic Foundation
The ablation study design follows Issue #42's hypothesis matrix derived from SciCite (Cohan et al. 2019) for intent classification, SciRepEval (Singh et al. 2023) for multi-format evaluation, and GAPMAP few-shot methodology. The frozen GT protocol addresses a critical methodological confound: AI analyst output varies across runs, making non-frozen ablation comparisons unreliable.

### Implementation
- `AblationParams` Pydantic model in `evaluation/pipeline.py` with `to_snapshot()` serialization and `with_fewshot()` factory
- `compute_prompt_hash()` utility for template change detection
- Conditional blocks in `prompts/reconstruct.md`: `{% if max_recs_per_section %}` caps output density, `{% if examples %}` adds golden section→citation mappings
- 4 CLI options on `klemma benchmark` — work with both `--auto` and `-d` modes
- `frozen_gt: true` + `ablation` snapshot recorded in `config_snapshot` for reproducibility
- `tests/test_prompts.py` with 25 tests

### Results
- 397 tests passing, 0 ruff violations
- 6 ablation runs across 2 papers with frozen GT
- Phase 1→2 methodology correction: few-shot effect reversed from +5.9pp to -3pp
- Zero-shot baseline confirmed as best configuration (F1=0.761)

## Test plan
- [x] `ruff check src/ tests/` — 0 violations
- [x] `python -m pytest tests/ -q` — 397 passed
- [x] All 12 prompt templates render without Jinja2 errors
- [x] `AblationParams()` defaults match current behavior (no regression)
- [x] Prompt hash is deterministic across runs
- [x] Run ablations on kinney2025 with frozen GT (3 configs)
- [x] Run ablations on citesee2023 with frozen GT (3 configs)
- [x] Frozen GT results match across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)