### PR TITLE
feat: ablation infrastructure + reasoning model support

### DIFF
--- a/src/klemma/ai_openai.py
+++ b/src/klemma/ai_openai.py
@@ -33,6 +33,22 @@ class OpenAIClient(AIProviderBase):
         )
         self._json_mode = config.json_mode
 
+    @property
+    def _is_reasoning_model(self) -> bool:
+        """Detect reasoning models that require different API parameters."""
+        m = self.model.lower()
+        return m.startswith(("o1", "o3", "o4", "gpt-5"))
+
+    def _token_kwargs(self, max_tokens: int) -> dict:
+        """Build the right token-limit kwarg for the model.
+
+        Reasoning models (o-series, gpt-5-*) require
+        ``max_completion_tokens`` instead of ``max_tokens``.
+        """
+        if self._is_reasoning_model:
+            return {"max_completion_tokens": max_tokens}
+        return {"max_tokens": max_tokens}
+
     def call(
         self,
         system: str,
@@ -47,14 +63,17 @@ class OpenAIClient(AIProviderBase):
             {"role": "user", "content": user},
         ]
 
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+            **self._token_kwargs(max_tokens),
+        }
+        if not self._is_reasoning_model:
+            kwargs["temperature"] = temperature
+
         for attempt in range(self.retries + 1):
             try:
-                response = self._client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                )
+                response = self._client.chat.completions.create(**kwargs)
                 return response.choices[0].message.content
             except Exception as e:
                 logger.warning(
@@ -81,15 +100,18 @@ class OpenAIClient(AIProviderBase):
             {"role": "user", "content": user},
         ]
 
+        kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "response_format": {"type": "json_object"},
+            **self._token_kwargs(max_tokens),
+        }
+        if not self._is_reasoning_model:
+            kwargs["temperature"] = temperature
+
         for attempt in range(self.retries + 1):
             try:
-                response = self._client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    response_format={"type": "json_object"},
-                )
+                response = self._client.chat.completions.create(**kwargs)
                 text = response.choices[0].message.content
                 if not text:
                     continue


### PR DESCRIPTION
## Summary

- Ablation infrastructure for systematic hypothesis testing (Issue #42): `AblationParams` model, CLI options (`--temperature`, `--max-recs`, `--fragments`, `--prompt-variant`), prompt hash tracking, few-shot support
- Frozen GT dataset mode threaded through `-d` benchmark flag
- OpenAI backend support for reasoning models (o-series, gpt-5): `max_completion_tokens` instead of `max_tokens`, temperature omitted
- Prompt regression tests (331 lines in `tests/test_prompts.py`)

## Release Note

### Problem
The ablation study initially produced misleading results — few-shot prompting appeared to improve F1 by +5.9pp. This was entirely an artifact of non-frozen ground truth: each run received a different GT extraction from the analyst model. Without infrastructure for controlled experiments, parameter tuning is guesswork.

Additionally, reasoning models (OpenAI o-series, gpt-5-mini) require different API parameters (`max_completion_tokens` instead of `max_tokens`, no custom temperature), causing failures when used with the existing OpenAI backend.

### Academic Foundation
Frozen GT protocol follows standard practice in NLP evaluation: held-out test sets must remain constant across experimental conditions [@kinneySemanticScholarOpen2025]. The ablation methodology (one-parameter-at-a-time with variance estimation) is informed by experimental design principles from [@singh2023scirepeval] (SciRepEval multi-format evaluation). Intent classification taxonomy follows [@cohan2019structural] (SciCite 3-class scheme).

### Implementation
- `evaluation/pipeline.py`: `AblationParams` pydantic model, `compute_prompt_hash()` for reproducibility
- `cli.py`: 4 new `--ablation-*` flags threaded through both `--auto` and `-d` benchmark modes
- `ai_openai.py`: `_is_reasoning_model` property, `_token_kwargs()` helper for model-specific parameters
- `prompts/reconstruct.md`: few-shot block with conditional Jinja2 rendering
- `tests/test_prompts.py`: 331-line regression suite covering all 15 prompt templates

### Results
- 35+ frozen-GT runs across 9 parameter configs and 7 models (gpt-4.1, gpt-5-mini, claude-sonnet-4.5, claude-sonnet-4.6, claude-opus-4.6, claude-haiku-4.5, qwen3.5:cloud)
- Key finding: intra-config variance (5-7pp F1) exceeds inter-config differences (2-3pp) — no parameter reliably beats baseline
- Best model balance: gpt-4.1 (F1=0.735, P=0.629); best intent accuracy: qwen3.5:cloud (0.846)
- Reasoning models (gpt-5-mini) add no value: F1=0.663, 67% failure rate, 2x latency
- 397 tests pass, lint clean

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `python -m pytest tests/ -q` — 397 passed
- [x] Ablation runs completed on frozen GT with 7 models
- [x] Issue #42 updated with complete results

Part of #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)