### PR TITLE
Consolidate AI backends to LiteLLM + add ~/.klemmarc.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ exports/
 
 # User-specific files (use config.example.yaml as template)
 config.yaml
+.klemmarc*
 PROJECT_LOG.md
 *.code-workspace
 secure-ai-assistant-roadmap.md

--- a/config.project.example.yaml
+++ b/config.project.example.yaml
@@ -17,12 +17,12 @@ obsidian:
   tags_folder: "Tags"                  # optional folder for tag notes
 
 ai:
-  model: "sonnet"                      # claude model: "opus", "sonnet", "haiku"
+  backend: "litellm"                   # recommended: litellm (100+ providers)
+  model: "anthropic/claude-sonnet-4-6" # litellm model format: provider/model
   language: "ru"                       # AI response language
-  # Uncomment for OpenAI-compatible backends:
-  # backend: "openai"
-  # base_url: "http://localhost:11434/v1"
-  # api_key_env: "OPENAI_API_KEY"
+  # For local models:
+  # model: "ollama/llama3"
+  # base_url: "http://localhost:11434"
 
 # --- Per-project settings (NOT inherited from parent) ---
 

--- a/config.system.example.yaml
+++ b/config.system.example.yaml
@@ -2,16 +2,22 @@
 # KLEMMA SYSTEM CONFIG — global defaults (~/.klemma/config.yaml)
 # =============================================================================
 # Shared settings for all klemma projects. Project-level configs override these.
+#
+# NOTE: Consider using ~/.klemmarc.yaml instead — it supports direct API keys
+# and is the recommended way to configure klemma globally.
+# See klemmarc.example.yaml for the full reference.
 
 zotero:
   # storage_path: ~/Zotero/storage     # local Zotero PDF storage
 
 ai:
-  model: "sonnet"                      # default AI model: "opus", "sonnet", "haiku"
+  backend: "litellm"                   # recommended: litellm (100+ providers)
+  model: "sonnet"                      # default AI model
   language: "ru"                       # default AI response language
   timeout: 300
   retries: 2
-  # Uncomment for OpenAI-compatible backends:
-  # backend: "openai"
-  # base_url: "http://localhost:11434/v1"
-  # api_key_env: "OPENAI_API_KEY"
+  # For specific providers via LiteLLM:
+  # model: "anthropic/claude-sonnet-4-6"
+  # model: "openai/gpt-4.1"
+  # model: "ollama/llama3"
+  # base_url: "http://localhost:11434"  # custom endpoint

--- a/klemmarc.example.yaml
+++ b/klemmarc.example.yaml
@@ -1,0 +1,47 @@
+# =============================================================================
+# KLEMMA GLOBAL CONFIG — ~/.klemmarc.yaml
+# =============================================================================
+# Single config file for all klemma projects. Overridden by project configs.
+# This file should have 0600 permissions because it may contain API keys.
+#
+# Merge order (later wins):
+# ~/.klemmarc.yaml < ~/.klemma/config.yaml < parent project < child project < CLI
+#
+# Install klemma with LiteLLM support:
+#   pip install klemma[litellm]
+
+# --- AI backend ---
+
+ai:
+  backend: "litellm"                    # recommended (100+ providers via LiteLLM)
+  model: "anthropic/claude-sonnet-4-6"  # format: provider/model-name
+  language: "ru"                        # AI response language
+  timeout: 300
+  retries: 2
+  # json_mode: true                     # structured JSON output (if model supports it)
+  # base_url: "http://localhost:11434"   # custom endpoint (Ollama, vLLM, etc.)
+
+# --- API keys ---
+# Direct API keys — no more env var juggling.
+# Only uncomment keys you actually use.
+
+# api_keys:
+#   openai: "sk-..."
+#   anthropic: "sk-ant-..."
+#   google: "AIza..."
+#   cohere: "..."
+#   mistral: "..."
+
+# --- Embeddings ---
+
+# embeddings:
+#   backend: "openai"                   # "s2" (free) | "local" | "openai"
+#   model: "text-embedding-3-small"
+
+# --- Common model examples ---
+# ai:
+#   model: "openai/gpt-4.1"            # OpenAI GPT-4.1
+#   model: "anthropic/claude-opus-4-6"  # Anthropic Claude Opus
+#   model: "ollama/llama3"              # Local Ollama
+#   model: "openai/o3"                  # OpenAI reasoning model
+#   model: "google/gemini-2.5-pro"      # Google Gemini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ litellm = ["litellm>=1.40"]
 embeddings = ["numpy>=1.24"]
 local-embeddings = ["numpy>=1.24", "sentence-transformers>=2.2"]
 mcp = ["mcp>=1.0"]
+recommended = ["litellm>=1.40"]
 all-ai = ["openai>=1.0", "litellm>=1.40"]
 
 [project.scripts]

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -17,25 +17,29 @@ Click CLI entry point. Defines 16 commands + hidden aliases.
 `KlemmaContext` dataclass — single object per CLI command invocation.
 Holds: `config`, `state`, `vault`, `ai` (optional), `embeddings` (optional), `library` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`.
 
-### config.py (636 lines)
-Pydantic config models + Git-style project discovery.
-Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig`, `EmbeddingsConfig`, `DissertationConfig`, `SystemConfig`, `ProjectConfig`.
+### config.py (711 lines)
+Pydantic config models + Git-style project discovery + klemmarc loading.
+Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig` (with `_resolved_api_keys` PrivateAttr), `EmbeddingsConfig`, `DissertationConfig`, `SystemConfig`, `ProjectConfig`.
+- `_load_klemmarc()` — load `~/.klemmarc.yaml` (or `.yml` / `.klemmarc`) global config
+- `_derive_provider(backend, model)` — extract provider name for api_keys lookup (e.g. `litellm` + `anthropic/claude-sonnet` → `"anthropic"`)
+- `_check_klemmarc_permissions()` — fix permissions on `~/.klemmarc*` if world-readable
 - `discover_project_root(start)` — traverse up from cwd to find nearest `.klemma/`
 - `discover_project_chain(start)` — find all project roots child-first, max depth 3
-- `resolve_effective_config(project_chain, config_override)` — merge: system < parent < child < CLI override
+- `resolve_effective_config(project_chain, config_override)` — merge: klemmarc < system < parent < child < CLI override; injects `api_keys` into `AIConfig._resolved_api_keys`
 - `load_project_context(project_chain, config)` — aggregate KLEMMA.md files parent-first
-- `ensure_system_home()` — auto-create `~/.klemma/` via `init_system()` on first run
+- `ensure_system_home()` — auto-create `~/.klemma/` via `init_system()` on first run; checks klemmarc permissions
 - `get_system_home()` / `get_klemma_home()` — returns `Path(KLEMMA_HOME)` or `~/.klemma`
 - `load_available_tags(klemma_home, config, project_chain?)` — reads `tags.yaml` with parent fallback
 - `resolve_prompt(name, klemma_home, project_chain?)` — 4-level: project → parent → system → shipped
 - `scan_project_files(project_root, max_chars?)` — scan .md/.tex/.bib/.txt files, returns [{name, path, size, content_preview}]
 - `update_project_config(project_root, updates)` — merge updates into .klemma/config.yaml project section
 - Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai", "embeddings"}` from parent projects
+- Default AI backend: `litellm` (was `claude`)
 
-### setup.py (263 lines)
-`klemma init` logic — creates per-directory `.klemma/` projects and `~/.klemma/` system config. Interactive wizard with auto-discovery.
+### setup.py (304 lines)
+`klemma init` logic — creates per-directory `.klemma/` projects, `~/.klemma/` system config, and `~/.klemmarc.yaml` global config. Interactive wizard with auto-discovery.
 - `init_project(project_dir, project_type)` — creates `.klemma/`, `KLEMMA.md`, updates `.gitignore`
-- `init_system(system_home)` — creates `~/.klemma/config.yaml` (AI defaults only)
+- `init_system(system_home)` — creates `~/.klemmarc.yaml` (0600, with api_keys template) + `~/.klemma/config.yaml` (legacy fallback)
 - `init_klemma_home()` — legacy alias for `init_system()`
 - Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`
 
@@ -63,12 +67,15 @@ Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`
 - `ClaudeClient` — subprocess wrapper for `claude -p --model <model>`
 - Retry logic with configurable timeout
 
-### ai_openai.py (105 lines)
-`OpenAIClient` — wraps OpenAI Python SDK. Supports structured JSON mode (`response_format`).
-Works with: OpenAI, Ollama, vLLM, LM Studio (via `base_url`).
+### ai_openai.py (71 lines)
+**DEPRECATED** — thin delegation wrapper around `LiteLLMClient`. Emits `DeprecationWarning`, prefixes bare model names with `openai/`, delegates all calls to LiteLLM.
 
-### ai_litellm.py (70 lines)
-`LiteLLMClient` — thin wrapper around `litellm.completion()`. Model format: `provider/model`.
+### ai_litellm.py (146 lines)
+`LiteLLMClient` — recommended AI backend via `litellm.completion()`. Model format: `provider/model`.
+- `_build_kwargs()` — single helper for all completion kwargs (model, tokens, temperature, base_url, api_key, response_format)
+- `_is_reasoning_model` — detects o-series/gpt-5 models, switches to `max_completion_tokens`
+- `call_json()` — supports structured JSON mode (`response_format`) when `json_mode=True`
+- `base_url` passthrough for custom endpoints (Ollama, vLLM, etc.)
 
 ### vault.py (263 lines)
 `VaultAdapter` — Obsidian vault file I/O.
@@ -82,7 +89,7 @@ Works with: OpenAI, Ollama, vLLM, LM Studio (via `base_url`).
 - `LocalLibrary` — wraps `PDFExtractor.load_entry_lookup()` (BBT JSON)
 - `create_library(config)` — factory, creates LocalLibrary from config
 
-### embeddings.py (257 lines)
+### embeddings.py (268 lines)
 `EmbeddingProvider` runtime-checkable protocol + 3 backends + utilities.
 - `EmbeddingProvider` protocol — `dim`, `model_name`, `embed(title, abstract) → list[float] | None`
 - `SemanticScholarEmbeddings` — free S2 API (768-dim SPECTER), rate-limited (throttle param)

--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -227,23 +227,23 @@ class ClaudeClient(AIProviderBase):
 def create_ai(config: AIConfig) -> AIProvider:
     """Create the right AI backend from config.
 
-    config.backend == "claude"  → ClaudeClient (default)
-    config.backend == "openai"  → OpenAIClient (OpenAI / Ollama / vLLM / LM Studio)
-    config.backend == "litellm" → LiteLLMClient (100+ providers via LiteLLM)
+    config.backend == "claude"  → ClaudeClient (interactive CLI)
+    config.backend == "litellm" → LiteLLMClient (recommended — 100+ providers)
+    config.backend == "openai"  → OpenAIClient (deprecated — delegates to LiteLLM)
     """
     backend = config.backend
 
     if backend == "claude":
         return ClaudeClient(config)
 
-    if backend == "openai":
-        from .ai_openai import OpenAIClient
-        return OpenAIClient(config)
-
     if backend == "litellm":
         from .ai_litellm import LiteLLMClient
         return LiteLLMClient(config)
 
+    if backend == "openai":
+        from .ai_openai import OpenAIClient
+        return OpenAIClient(config)
+
     raise ValueError(
-        f"Unknown AI backend: {backend!r}. Supported: claude, openai, litellm"
+        f"Unknown AI backend: {backend!r}. Supported: claude, litellm, openai"
     )

--- a/src/klemma/ai_litellm.py
+++ b/src/klemma/ai_litellm.py
@@ -1,20 +1,32 @@
 """LiteLLM AI backend — unified interface for 100+ providers.
 
 Model format: provider/model (e.g. "anthropic/claude-sonnet-4-5-20250929", "ollama/llama3").
+Bare model names (e.g. "gpt-4.1") also work — LiteLLM routes them to OpenAI.
 Install: pip install klemma[litellm]
 """
 
+import json
 import logging
+import re
 from typing import Optional
 
-from .ai import AIProviderBase
+from .ai import AIProviderBase, extract_json
 from .config import AIConfig
 
 logger = logging.getLogger(__name__)
 
+# Patterns for reasoning models that need max_completion_tokens instead of max_tokens
+_REASONING_RE = re.compile(r"^(o1|o3|o4|gpt-5)", re.IGNORECASE)
+
 
 class LiteLLMClient(AIProviderBase):
-    """AI backend using LiteLLM for multi-provider support."""
+    """AI backend using LiteLLM for multi-provider support.
+
+    Feature parity with OpenAIClient:
+    - json_mode (response_format)
+    - base_url passthrough
+    - reasoning model detection (o-series, gpt-5)
+    """
 
     def __init__(self, config: AIConfig):
         super().__init__(config)
@@ -28,11 +40,46 @@ class LiteLLMClient(AIProviderBase):
 
         self._litellm = _litellm
         self._litellm.request_timeout = config.timeout
+        self._api_key = config.api_key or None
+        self._base_url = config.base_url
+        self._json_mode = config.json_mode
 
-        if config.api_key:
-            self._api_key = config.api_key
+    @property
+    def _is_reasoning_model(self) -> bool:
+        """Detect reasoning models that require different API parameters."""
+        # Strip provider prefix (e.g. "openai/o3-mini" → "o3-mini")
+        bare = self.model.split("/")[-1] if "/" in self.model else self.model
+        return bool(_REASONING_RE.match(bare))
+
+    def _build_kwargs(
+        self,
+        messages: list[dict],
+        max_tokens: int,
+        temperature: float,
+        timeout: Optional[int] = None,
+        response_format: Optional[dict] = None,
+    ) -> dict:
+        """Build kwargs dict for litellm.completion() with all conditionals."""
+        kwargs: dict = {
+            "model": self.model,
+            "messages": messages,
+        }
+        # Token limit
+        if self._is_reasoning_model:
+            kwargs["max_completion_tokens"] = max_tokens
         else:
-            self._api_key = None
+            kwargs["max_tokens"] = max_tokens
+            kwargs["temperature"] = temperature
+        # Optional params
+        if timeout:
+            kwargs["timeout"] = timeout
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        if response_format:
+            kwargs["response_format"] = response_format
+        return kwargs
 
     def call(
         self,
@@ -47,21 +94,50 @@ class LiteLLMClient(AIProviderBase):
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ]
+        kwargs = self._build_kwargs(messages, max_tokens, temperature, timeout)
 
         for attempt in range(self.retries + 1):
             try:
-                kwargs = {
-                    "model": self.model,
-                    "messages": messages,
-                    "max_tokens": max_tokens,
-                    "temperature": temperature,
-                }
-                if timeout:
-                    kwargs["timeout"] = timeout
-                if self._api_key:
-                    kwargs["api_key"] = self._api_key
                 response = self._litellm.completion(**kwargs)
                 return response.choices[0].message.content
+            except Exception as e:
+                logger.warning(
+                    "LiteLLM error (attempt %d/%d): %s",
+                    attempt + 1, self.retries + 1, e,
+                )
+        return None
+
+    def call_json(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.2,
+        timeout: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Call API and parse JSON, optionally using structured JSON mode."""
+        if not self._json_mode:
+            return super().call_json(system, user, max_tokens, temperature, timeout)
+
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        kwargs = self._build_kwargs(
+            messages, max_tokens, temperature, timeout,
+            response_format={"type": "json_object"},
+        )
+
+        for attempt in range(self.retries + 1):
+            try:
+                response = self._litellm.completion(**kwargs)
+                text = response.choices[0].message.content
+                if not text:
+                    continue
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return extract_json(text)
             except Exception as e:
                 logger.warning(
                     "LiteLLM error (attempt %d/%d): %s",

--- a/src/klemma/ai_openai.py
+++ b/src/klemma/ai_openai.py
@@ -1,37 +1,54 @@
-"""OpenAI-compatible AI backend.
+"""OpenAI-compatible AI backend — DEPRECATED, delegates to LiteLLM.
 
-Works with: OpenAI API, Ollama (/v1), vLLM, LM Studio, llama-cpp-python server.
-Install: pip install klemma[openai]
+Use ``backend: litellm`` with ``model: openai/gpt-4.1`` instead.
+This module emits a DeprecationWarning and delegates all calls to LiteLLMClient
+with an ``openai/`` prefix on the model name.
 """
 
-import json
 import logging
+import warnings
 from typing import Optional
 
-from .ai import AIProviderBase, extract_json
+from .ai import AIProviderBase
 from .config import AIConfig
 
 logger = logging.getLogger(__name__)
 
 
 class OpenAIClient(AIProviderBase):
-    """AI backend using the OpenAI Python SDK (chat completions API)."""
+    """Deprecated OpenAI backend — thin wrapper around LiteLLMClient.
+
+    Emits DeprecationWarning on construction. Prefixes bare model names
+    with ``openai/`` so LiteLLM routes them correctly.
+    """
 
     def __init__(self, config: AIConfig):
+        warnings.warn(
+            "backend: openai is deprecated. Use backend: litellm with "
+            "model: openai/<model-name> instead (e.g. model: openai/gpt-4.1).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(config)
+
         try:
-            from openai import OpenAI
+            from .ai_litellm import LiteLLMClient
         except ImportError:
             raise ImportError(
-                "OpenAI backend requires the 'openai' package. "
-                "Install with: pip install klemma[openai]"
+                "OpenAI backend now requires the 'litellm' package (delegates to LiteLLM). "
+                "Install with: pip install klemma[litellm]"
             )
 
-        self._client = OpenAI(
-            api_key=config.api_key or "not-needed",
-            base_url=config.base_url,
-        )
-        self._json_mode = config.json_mode
+        # Prefix bare model names with openai/ for LiteLLM routing
+        prefixed_model = config.model
+        if "/" not in prefixed_model:
+            prefixed_model = f"openai/{prefixed_model}"
+
+        # Create a modified config for the delegate
+        delegate_config = config.model_copy(update={"model": prefixed_model, "backend": "litellm"})
+        # Preserve private attrs
+        delegate_config._resolved_api_keys = config._resolved_api_keys
+        self._delegate = LiteLLMClient(delegate_config)
 
     def call(
         self,
@@ -41,27 +58,7 @@ class OpenAIClient(AIProviderBase):
         temperature: float = 0.3,
         timeout: Optional[int] = None,
     ) -> Optional[str]:
-        """Call OpenAI-compatible chat completions API with retries."""
-        messages = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ]
-
-        for attempt in range(self.retries + 1):
-            try:
-                response = self._client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                )
-                return response.choices[0].message.content
-            except Exception as e:
-                logger.warning(
-                    "OpenAI API error (attempt %d/%d): %s",
-                    attempt + 1, self.retries + 1, e,
-                )
-        return None
+        return self._delegate.call(system, user, max_tokens, temperature, timeout)
 
     def call_json(
         self,
@@ -71,35 +68,4 @@ class OpenAIClient(AIProviderBase):
         temperature: float = 0.2,
         timeout: Optional[int] = None,
     ) -> Optional[dict]:
-        """Call API and parse JSON, optionally using structured JSON mode."""
-        if not self._json_mode:
-            return super().call_json(system, user, max_tokens, temperature, timeout)
-
-        # JSON mode: request structured output from the API
-        messages = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ]
-
-        for attempt in range(self.retries + 1):
-            try:
-                response = self._client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    response_format={"type": "json_object"},
-                )
-                text = response.choices[0].message.content
-                if not text:
-                    continue
-                try:
-                    return json.loads(text)
-                except json.JSONDecodeError:
-                    return extract_json(text)
-            except Exception as e:
-                logger.warning(
-                    "OpenAI API error (attempt %d/%d): %s",
-                    attempt + 1, self.retries + 1, e,
-                )
-        return None
+        return self._delegate.call_json(system, user, max_tokens, temperature, timeout)

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -69,7 +69,10 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
     emb_cfg = cfg.embeddings
     emb_provider = None
     if emb_cfg.backend:
-        emb_provider = create_embeddings(emb_cfg.model_dump())
+        emb_provider = create_embeddings(
+            emb_cfg.model_dump(),
+            api_keys=cfg.ai._resolved_api_keys or None,
+        )
 
     dissertation_context = load_project_context(project_chain, cfg)
     available_tags = load_available_tags(klemma_home, cfg, project_chain=project_chain)

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -8,11 +8,12 @@ Supports Git/NPM-style per-directory projects:
 
 import logging
 import os
+import stat
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +41,27 @@ def ensure_system_home() -> Path:
 
     Delegates to setup.init_system() for config creation to ensure
     consistent content with 'klemma init --global-only'.
+    Also checks ~/.klemmarc.yaml permissions (should be 0o600).
     """
     system_home = get_system_home()
     if not system_home.exists():
         from .setup import init_system
         init_system(system_home)
         logger.info("Created system config at %s", system_home)
+    _check_klemmarc_permissions()
     return system_home
+
+
+def _check_klemmarc_permissions():
+    """Fix permissions on ~/.klemmarc* if world-readable (contains secrets)."""
+    home = Path.home()
+    for name in _KLEMMARC_NAMES:
+        path = home / name
+        if path.exists():
+            mode = path.stat().st_mode
+            if mode & (stat.S_IRGRP | stat.S_IROTH):
+                path.chmod(0o600)
+                logger.warning("Fixed permissions on %s → 0600 (contains secrets)", path)
 
 
 # --- Project discovery (Git-style) ---
@@ -116,7 +131,7 @@ class ObsidianConfig(BaseModel):
 
 
 class AIConfig(BaseModel):
-    backend: str = "claude"  # "claude" | "openai" | "litellm"
+    backend: str = "litellm"  # "claude" | "litellm" | "openai" (deprecated)
     model: str = "opus"
     max_pdf_chars: int = 50000
     timeout: int = 180
@@ -125,10 +140,19 @@ class AIConfig(BaseModel):
     api_key_env: str = ""  # env var name for API key (e.g. "OPENAI_API_KEY")
     json_mode: bool = False  # use structured JSON mode when backend supports it
     language: str = "ru"  # AI response language (e.g. "en", "ru", "de")
+    _resolved_api_keys: dict = PrivateAttr(default_factory=dict)
 
     @property
     def api_key(self) -> Optional[str]:
-        """Resolve API key from environment variable."""
+        """Resolve API key: klemmarc api_keys → env var fallback.
+
+        Looks up the provider derived from backend+model in _resolved_api_keys
+        first, then falls back to os.environ.get(api_key_env).
+        """
+        provider = _derive_provider(self.backend, self.model)
+        key = self._resolved_api_keys.get(provider)
+        if key:
+            return key
         if self.api_key_env:
             return os.environ.get(self.api_key_env)
         return None
@@ -332,6 +356,44 @@ def _load_yaml(path: Path) -> dict:
         return yaml.safe_load(f) or {}
 
 
+# --- klemmarc global config ---
+
+_KLEMMARC_NAMES = (".klemmarc.yaml", ".klemmarc.yml", ".klemmarc")
+
+
+def _load_klemmarc() -> dict:
+    """Load ~/.klemmarc.yaml (or .yml / .klemmarc) global config.
+
+    Returns raw dict (including api_keys section). Empty dict if missing.
+    """
+    home = Path.home()
+    for name in _KLEMMARC_NAMES:
+        path = home / name
+        if path.exists():
+            return _load_yaml(path)
+    return {}
+
+
+def _derive_provider(backend: str, model: str) -> str:
+    """Extract provider name from backend+model for api_keys lookup.
+
+    Examples:
+        litellm + "anthropic/claude-sonnet" → "anthropic"
+        litellm + "gpt-4.1" (bare) → "openai"
+        "openai" backend → "openai"
+        "claude" backend → "anthropic"
+    """
+    if backend == "claude":
+        return "anthropic"
+    if backend == "openai":
+        return "openai"
+    # litellm: model may be "provider/model-name" or bare
+    if "/" in model:
+        return model.split("/", 1)[0]
+    # Bare model name → assume openai
+    return "openai"
+
+
 def load_config(config_path: str | Path | None = None) -> KlemmaConfig:
     """Load and validate configuration from YAML file.
 
@@ -362,10 +424,13 @@ def resolve_effective_config(
     project_chain: list[Path],
     config_override: Optional[str | Path] = None,
 ) -> tuple[KlemmaConfig, ProjectConfig, Path]:
-    """Resolve effective config by merging: system → parent → child → CLI override.
+    """Resolve effective config by merging: klemmarc → system → parent → child → CLI.
 
     project_chain is child-first: [child_root, parent_root].
     Can be empty if only config_override is given (fallback to override path).
+
+    Merge order (later wins):
+    ~/.klemmarc.yaml < ~/.klemma/config.yaml < parent project < child project < CLI override
 
     Selective inheritance: only shared resource keys (obsidian, zotero, ai)
     are inherited from parent. Project structure (project, tags, state, etc.)
@@ -373,6 +438,11 @@ def resolve_effective_config(
 
     Returns (merged_config, project_config, active_project_root).
     """
+    # 0. klemmarc base layer (global config with api_keys)
+    klemmarc_raw = _load_klemmarc()
+    api_keys = klemmarc_raw.pop("api_keys", {})
+    # Start from klemmarc (without api_keys — not part of KlemmaConfig schema)
+
     # 1. System defaults
     system_raw = _load_yaml(get_system_home() / "config.yaml")
 
@@ -389,8 +459,9 @@ def resolve_effective_config(
             inherited = {k: v for k, v in project_raw.items() if k in _INHERITED_KEYS}
             merged = _deep_merge(merged, inherited)
 
-    # 3. System provides defaults for unset keys
-    effective = _deep_merge(system_raw, merged)
+    # 3. Merge: klemmarc < system < projects
+    effective = _deep_merge(klemmarc_raw, system_raw)
+    effective = _deep_merge(effective, merged)
 
     # 4. CLI --config override wins over everything
     if config_override:
@@ -398,6 +469,10 @@ def resolve_effective_config(
         effective = _deep_merge(effective, override_raw)
 
     cfg = KlemmaConfig.model_validate(effective)
+
+    # Inject resolved api_keys (PrivateAttr, never serialized)
+    if api_keys:
+        cfg.ai._resolved_api_keys = api_keys
 
     # Determine project root
     if project_chain:

--- a/src/klemma/embeddings.py
+++ b/src/klemma/embeddings.py
@@ -182,10 +182,12 @@ class OpenAIEmbeddings:
         model: str = "text-embedding-3-small",
         api_key_env: str = "OPENAI_API_KEY",
         base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
     ):
         self.model_name = model
         self._api_key_env = api_key_env
         self._base_url = base_url
+        self._api_key = api_key  # direct key takes priority over env var
 
     def embed(self, title: str, abstract: str = "") -> Optional[list[float]]:
         """Embed using OpenAI API."""
@@ -197,7 +199,7 @@ class OpenAIEmbeddings:
                 "pip install klemma[openai]"
             )
         text = f"{title}. {abstract}" if abstract else title
-        api_key = os.environ.get(self._api_key_env)
+        api_key = self._api_key or os.environ.get(self._api_key_env)
         if not api_key:
             logger.warning("No API key found in %s", self._api_key_env)
             return None
@@ -217,7 +219,10 @@ class OpenAIEmbeddings:
 # ---------------------------------------------------------------------------
 
 
-def create_embeddings(config: dict) -> Optional[EmbeddingProvider]:
+def create_embeddings(
+    config: dict,
+    api_keys: Optional[dict] = None,
+) -> Optional[EmbeddingProvider]:
     """Create an EmbeddingProvider from config dict.
 
     Config keys:
@@ -227,18 +232,23 @@ def create_embeddings(config: dict) -> Optional[EmbeddingProvider]:
         base_url: custom endpoint (OpenAI only)
         throttle: seconds between S2 requests (default: 3.1)
 
+    api_keys: optional dict from klemmarc (e.g. {"openai": "sk-..."}).
+    Direct keys take priority over env vars.
+
     Returns None if backend is disabled or misconfigured.
     """
     if not config:
         return None
 
+    api_keys = api_keys or {}
     backend = config.get("backend", "s2")
 
     if backend == "s2":
-        api_key = None
-        env_var = config.get("api_key_env", "S2_API_KEY")
-        if env_var:
-            api_key = os.environ.get(env_var)
+        api_key = api_keys.get("s2")
+        if not api_key:
+            env_var = config.get("api_key_env", "S2_API_KEY")
+            if env_var:
+                api_key = os.environ.get(env_var)
         throttle = config.get("throttle", 3.1)
         return SemanticScholarEmbeddings(api_key=api_key, throttle=throttle)
 
@@ -251,6 +261,7 @@ def create_embeddings(config: dict) -> Optional[EmbeddingProvider]:
             model=config.get("model", "text-embedding-3-small"),
             api_key_env=config.get("api_key_env", "OPENAI_API_KEY"),
             base_url=config.get("base_url"),
+            api_key=api_keys.get("openai"),
         )
 
     logger.warning("Unknown embedding backend: %s", backend)

--- a/src/klemma/evaluation/pipeline.py
+++ b/src/klemma/evaluation/pipeline.py
@@ -138,12 +138,27 @@ def run_analyst_from_source(
         logger.error("PDF extraction failed for %s", citekey)
         return None
 
-    # Build library entries
+    # Build library entries with titles from citation_links
     all_sources = state.get_all_sources()
-    library_lines = [
-        f"- {s.get('id', '')}: {s.get('title', '')}"
-        for s in all_sources if s.get("id") != citekey
-    ]
+    # Resolve titles: citation_links stores target_title for each citekey
+    all_links = state.get_citation_links()
+    title_by_citekey: dict[str, str] = {}
+    for link in all_links:
+        ck = link.get("target_citekey")
+        title = link.get("target_title", "")
+        if ck and title and ck not in title_by_citekey:
+            title_by_citekey[ck] = title
+    library_lines = []
+    for s in all_sources:
+        sid = s.get("id", "")
+        if sid == citekey:
+            continue
+        title = title_by_citekey.get(sid, "")
+        if not title:
+            # Fallback: decode citekey slug (Author2023_Some_Title → Some Title)
+            parts = sid.split("_", 1)
+            title = parts[1].replace("_", " ") if len(parts) > 1 else sid
+        library_lines.append(f"- {sid}: {title}")
     library_entries = "\n".join(library_lines)
 
     gt = run_analyst(

--- a/src/klemma/evaluation/reconstruction.py
+++ b/src/klemma/evaluation/reconstruction.py
@@ -211,14 +211,21 @@ def run_reconstruction(
         return {"method": "reconstruction", "error": "AI call failed"}
 
     # Parse recommendations into prediction dicts
+    # Normalize section_ids: AI sometimes returns "I: Introduction" instead of "I"
+    gt_section_ids = {s.section_id for s in dataset.ground_truth.sections}
     predictions = []
     seen = set()
     for rec in data.get("recommendations", []):
-        section_id = rec.get("section_id", "")
+        section_id = rec.get("section_id", "").strip()
         citekey = rec.get("citekey", "")
         intent = rec.get("intent", "background")
         if not section_id or not citekey:
             continue
+        # Normalize: strip title suffix (e.g. "I: Introduction" → "I")
+        if section_id not in gt_section_ids and ":" in section_id:
+            prefix = section_id.split(":")[0].strip()
+            if prefix in gt_section_ids:
+                section_id = prefix
         key = (section_id, citekey)
         if key not in seen:
             seen.add(key)

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -225,8 +225,37 @@ def init_project(
     return {"created": created, "skipped": skipped}
 
 
+_KLEMMARC_TEMPLATE = """\
+# =============================================================================
+# KLEMMA GLOBAL CONFIG — ~/.klemmarc.yaml
+# =============================================================================
+# Single config file for all klemma projects. Overridden by project configs.
+# This file has 0600 permissions because it may contain API keys.
+
+ai:
+  backend: "litellm"                   # recommended: litellm (100+ providers)
+  model: "anthropic/claude-sonnet-4-6" # litellm model format: provider/model
+  language: "ru"
+  timeout: 300
+  retries: 2
+
+# Direct API keys — no more env var juggling.
+# Uncomment and fill in the keys you need:
+# api_keys:
+#   openai: "sk-..."
+#   anthropic: "sk-ant-..."
+#   google: "AIza..."
+
+# embeddings:
+#   backend: "openai"
+#   model: "text-embedding-3-small"
+"""
+
+_KLEMMARC_NAMES = (".klemmarc.yaml", ".klemmarc.yml", ".klemmarc")
+
+
 def init_system(system_home: Path) -> dict:
-    """Create ~/.klemma/ system directory with global config.
+    """Create ~/.klemma/ system directory with global config + ~/.klemmarc.yaml.
 
     Returns dict with keys: created, skipped.
     """
@@ -235,6 +264,18 @@ def init_system(system_home: Path) -> dict:
 
     system_home.mkdir(parents=True, exist_ok=True)
 
+    # ~/.klemmarc.yaml — new global config with api_keys
+    home = Path.home()
+    has_klemmarc = any((home / name).exists() for name in _KLEMMARC_NAMES)
+    if has_klemmarc:
+        skipped.append("~/.klemmarc.yaml")
+    else:
+        klemmarc_path = home / ".klemmarc.yaml"
+        klemmarc_path.write_text(_KLEMMARC_TEMPLATE, encoding="utf-8")
+        klemmarc_path.chmod(0o600)
+        created.append("~/.klemmarc.yaml")
+
+    # Legacy ~/.klemma/config.yaml — still created as minimal fallback
     config_target = system_home / "config.yaml"
     if config_target.exists():
         skipped.append("config.yaml")

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,8 +1,10 @@
 # Tests
 
-## Current test suite (397 tests)
+## Current test suite (432 tests)
 - `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
-- `test_ai_openai.py` (117 lines) — `OpenAIClient` with mocked openai SDK
+- `test_ai_litellm.py` (188 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry
+- `test_ai_openai.py` (127 lines) — deprecated `OpenAIClient`: DeprecationWarning, delegation to LiteLLMClient, model prefixing
+- `test_klemmarc.py` (244 lines) — `_load_klemmarc()`, `_derive_provider()`, `AIConfig.api_key` resolution, `resolve_effective_config()` with klemmarc, chmod 600 enforcement
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
 - `test_embeddings.py` (354 lines) — `EmbeddingProvider` protocol, `cosine_similarity`, `SemanticScholarEmbeddings`/`LocalSPECTEREmbeddings`/`OpenAIEmbeddings` with mocked backends, `create_embeddings()` factory
 - `test_citation_graph.py` (245 lines) — citation graph storage (`save_citation_links`, `get_citation_graph`), intent scoring for reference gaps, `_migrate_schema()` v1→v4

--- a/tests/test_ai_litellm.py
+++ b/tests/test_ai_litellm.py
@@ -1,0 +1,188 @@
+"""Tests for LiteLLM AI backend."""
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from klemma.config import AIConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(content="Hello from LiteLLM"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _create_client_with_mock(config, mock_litellm=None):
+    """Create LiteLLMClient with a mocked litellm module."""
+    if mock_litellm is None:
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = _make_mock_response()
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        import klemma.ai_litellm as mod
+        importlib.reload(mod)
+        client = mod.LiteLLMClient(config)
+
+    return client, mock_litellm
+
+
+# ---------------------------------------------------------------------------
+# Import guard
+# ---------------------------------------------------------------------------
+
+def test_litellm_import_error():
+    """Clean error when litellm package is not installed."""
+    with patch.dict(sys.modules, {"litellm": None}):
+        import klemma.ai_litellm as mod
+        importlib.reload(mod)
+
+        config = AIConfig(backend="litellm", model="anthropic/claude-sonnet-4-6")
+        with pytest.raises(ImportError, match="litellm"):
+            mod.LiteLLMClient(config)
+
+
+# ---------------------------------------------------------------------------
+# Basic call
+# ---------------------------------------------------------------------------
+
+def test_litellm_call():
+    config = AIConfig(backend="litellm", model="anthropic/claude-sonnet-4-6")
+    client, mock = _create_client_with_mock(config)
+
+    result = client.call("system prompt", "user prompt", max_tokens=1024, temperature=0.5)
+    assert result == "Hello from LiteLLM"
+
+    mock.completion.assert_called_once()
+    call_kwargs = mock.completion.call_args.kwargs
+    assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs["max_tokens"] == 1024
+    assert call_kwargs["temperature"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# JSON mode
+# ---------------------------------------------------------------------------
+
+def test_litellm_call_json_with_json_mode():
+    config = AIConfig(backend="litellm", model="gpt-4.1", json_mode=True)
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response('{"key": "value"}')
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    result = client.call_json("sys", "usr")
+    assert result == {"key": "value"}
+
+    call_kwargs = mock_litellm.completion.call_args.kwargs
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_litellm_call_json_without_json_mode():
+    """Without json_mode, call_json uses extract_json from base class."""
+    config = AIConfig(backend="litellm", model="gpt-4.1", json_mode=False)
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response(
+        'Some text\n{"key": "val"}'
+    )
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    result = client.call_json("sys", "usr")
+    assert result == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# base_url passthrough
+# ---------------------------------------------------------------------------
+
+def test_litellm_base_url():
+    config = AIConfig(
+        backend="litellm", model="ollama/llama3",
+        base_url="http://localhost:11434",
+    )
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr")
+    call_kwargs = mock.completion.call_args.kwargs
+    assert call_kwargs["base_url"] == "http://localhost:11434"
+
+
+# ---------------------------------------------------------------------------
+# api_key passthrough
+# ---------------------------------------------------------------------------
+
+def test_litellm_api_key():
+    config = AIConfig(backend="litellm", model="anthropic/claude-sonnet-4-6")
+    config._resolved_api_keys = {"anthropic": "sk-ant-test"}
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr")
+    call_kwargs = mock.completion.call_args.kwargs
+    assert call_kwargs["api_key"] == "sk-ant-test"
+
+
+def test_litellm_no_api_key_in_kwargs():
+    config = AIConfig(backend="litellm", model="ollama/llama3")
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr")
+    call_kwargs = mock.completion.call_args.kwargs
+    assert "api_key" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Reasoning model detection
+# ---------------------------------------------------------------------------
+
+def test_litellm_reasoning_model_o3():
+    config = AIConfig(backend="litellm", model="openai/o3-mini")
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr", max_tokens=4096, temperature=0.5)
+    call_kwargs = mock.completion.call_args.kwargs
+    assert "max_completion_tokens" in call_kwargs
+    assert "max_tokens" not in call_kwargs
+    assert "temperature" not in call_kwargs
+
+
+def test_litellm_reasoning_model_gpt5():
+    config = AIConfig(backend="litellm", model="gpt-5")
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr")
+    call_kwargs = mock.completion.call_args.kwargs
+    assert "max_completion_tokens" in call_kwargs
+
+
+def test_litellm_non_reasoning_model():
+    config = AIConfig(backend="litellm", model="anthropic/claude-sonnet-4-6")
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr", max_tokens=2048, temperature=0.3)
+    call_kwargs = mock.completion.call_args.kwargs
+    assert call_kwargs["max_tokens"] == 2048
+    assert call_kwargs["temperature"] == 0.3
+    assert "max_completion_tokens" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Retry on error
+# ---------------------------------------------------------------------------
+
+def test_litellm_retry_on_error():
+    config = AIConfig(backend="litellm", model="gpt-4.1", retries=2)
+    mock_litellm = MagicMock()
+    mock_litellm.completion.side_effect = Exception("API error")
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    result = client.call("sys", "usr")
+    assert result is None
+    assert mock_litellm.completion.call_count == 3

--- a/tests/test_ai_openai.py
+++ b/tests/test_ai_openai.py
@@ -1,7 +1,8 @@
-"""Tests for OpenAI-compatible AI backend."""
+"""Tests for OpenAI-compatible AI backend (deprecated — delegates to LiteLLM)."""
 
 import importlib
 import sys
+import warnings
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -19,99 +20,108 @@ def _make_mock_response(content="Hello from AI"):
     )
 
 
-def _create_client_with_mock(config, mock_client=None):
-    """Create OpenAIClient with a mocked openai SDK."""
-    if mock_client is None:
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = _make_mock_response()
+def _create_client_with_mock(config, mock_litellm=None):
+    """Create OpenAIClient with a mocked litellm module (since it delegates)."""
+    if mock_litellm is None:
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = _make_mock_response()
 
-    mock_openai_module = MagicMock()
-    mock_openai_module.OpenAI.return_value = mock_client
-
-    with patch.dict(sys.modules, {"openai": mock_openai_module}):
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        import klemma.ai_litellm as litellm_mod
         import klemma.ai_openai as mod
+        importlib.reload(litellm_mod)
         importlib.reload(mod)
-        client = mod.OpenAIClient(config)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            client = mod.OpenAIClient(config)
 
-    return client
+    return client, mock_litellm
 
 
 # ---------------------------------------------------------------------------
-# Import guard
+# Deprecation warning
 # ---------------------------------------------------------------------------
 
-def test_openai_import_error():
-    """Clean error when openai package is not installed."""
-    with patch.dict(sys.modules, {"openai": None}):
+def test_openai_emits_deprecation_warning():
+    """OpenAIClient should emit DeprecationWarning on construction."""
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response()
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        import klemma.ai_litellm as litellm_mod
         import klemma.ai_openai as mod
+        importlib.reload(litellm_mod)
         importlib.reload(mod)
 
         config = AIConfig(backend="openai", model="gpt-4o")
-        with pytest.raises(ImportError, match="openai"):
+        with pytest.warns(DeprecationWarning, match="backend: openai is deprecated"):
             mod.OpenAIClient(config)
 
 
 # ---------------------------------------------------------------------------
-# OpenAIClient with mocked SDK
+# Import guard (litellm required)
 # ---------------------------------------------------------------------------
 
-def test_openai_call():
-    config = AIConfig(backend="openai", model="gpt-4o", base_url="http://localhost:8000/v1")
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = _make_mock_response("Hello from AI")
+def test_openai_import_error_without_litellm():
+    """Clean error when litellm package is not installed."""
+    with patch.dict(sys.modules, {"litellm": None}):
+        import klemma.ai_litellm as litellm_mod
+        import klemma.ai_openai as mod
+        importlib.reload(litellm_mod)
+        importlib.reload(mod)
 
-    client = _create_client_with_mock(config, mock_client)
+        config = AIConfig(backend="openai", model="gpt-4o")
+        with pytest.raises(ImportError, match="litellm"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                mod.OpenAIClient(config)
+
+
+# ---------------------------------------------------------------------------
+# Delegation to LiteLLMClient
+# ---------------------------------------------------------------------------
+
+def test_openai_call_delegates_to_litellm():
+    config = AIConfig(backend="openai", model="gpt-4o")
+    client, mock = _create_client_with_mock(config)
 
     result = client.call("system prompt", "user prompt", max_tokens=1024, temperature=0.5)
     assert result == "Hello from AI"
 
-    mock_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4o",
-        messages=[
-            {"role": "system", "content": "system prompt"},
-            {"role": "user", "content": "user prompt"},
-        ],
-        max_tokens=1024,
-        temperature=0.5,
-    )
+    mock.completion.assert_called_once()
+    call_kwargs = mock.completion.call_args.kwargs
+    # Model should be prefixed with openai/
+    assert call_kwargs["model"] == "openai/gpt-4o"
 
 
-def test_openai_json_mode():
+def test_openai_model_already_prefixed():
+    """Model with provider/ prefix should not be double-prefixed."""
+    config = AIConfig(backend="openai", model="openai/gpt-4o")
+    client, mock = _create_client_with_mock(config)
+
+    client.call("sys", "usr")
+    call_kwargs = mock.completion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/gpt-4o"
+
+
+def test_openai_call_json_delegates():
     config = AIConfig(backend="openai", model="gpt-4o", json_mode=True)
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = _make_mock_response('{"key": "value"}')
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response('{"key": "value"}')
 
-    client = _create_client_with_mock(config, mock_client)
+    client, _ = _create_client_with_mock(config, mock_litellm)
 
     result = client.call_json("sys", "usr")
     assert result == {"key": "value"}
 
-    call_kwargs = mock_client.chat.completions.create.call_args
-    assert call_kwargs.kwargs.get("response_format") == {"type": "json_object"}
-
-
-def test_openai_call_json_fallback_no_json_mode():
-    """Without json_mode, call_json uses extract_json from base class."""
-    config = AIConfig(backend="openai", model="gpt-4o", json_mode=False)
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = _make_mock_response(
-        'Some text\n{"key": "val"}'
-    )
-
-    client = _create_client_with_mock(config, mock_client)
-
-    result = client.call_json("sys", "usr")
-    assert result == {"key": "val"}
-
 
 def test_openai_retry_on_error():
     config = AIConfig(backend="openai", model="gpt-4o", retries=2)
-    mock_client = MagicMock()
-    mock_client.chat.completions.create.side_effect = Exception("API error")
+    mock_litellm = MagicMock()
+    mock_litellm.completion.side_effect = Exception("API error")
 
-    client = _create_client_with_mock(config, mock_client)
+    client, _ = _create_client_with_mock(config, mock_litellm)
 
     result = client.call("sys", "usr")
     assert result is None
-    # Should have been called retries + 1 = 3 times
-    assert mock_client.chat.completions.create.call_count == 3
+    assert mock_litellm.completion.call_count == 3

--- a/tests/test_klemmarc.py
+++ b/tests/test_klemmarc.py
@@ -1,0 +1,244 @@
+"""Tests for klemmarc loading, provider derivation, and api_keys resolution."""
+
+from pathlib import Path
+
+import yaml
+
+from klemma.config import (
+    AIConfig,
+    _derive_provider,
+    _load_klemmarc,
+    resolve_effective_config,
+)
+
+# ---------------------------------------------------------------------------
+# _load_klemmarc
+# ---------------------------------------------------------------------------
+
+
+class TestLoadKlemmarc:
+    def test_loads_klemmarc_yaml(self, tmp_path, monkeypatch):
+        klemmarc = tmp_path / ".klemmarc.yaml"
+        klemmarc.write_text(
+            yaml.dump({"ai": {"model": "gpt-4.1"}, "api_keys": {"openai": "sk-test"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _load_klemmarc()
+        assert result["ai"]["model"] == "gpt-4.1"
+        assert result["api_keys"]["openai"] == "sk-test"
+
+    def test_loads_klemmarc_yml(self, tmp_path, monkeypatch):
+        klemmarc = tmp_path / ".klemmarc.yml"
+        klemmarc.write_text(yaml.dump({"ai": {"model": "test"}}), encoding="utf-8")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _load_klemmarc()
+        assert result["ai"]["model"] == "test"
+
+    def test_loads_dotfile_klemmarc(self, tmp_path, monkeypatch):
+        klemmarc = tmp_path / ".klemmarc"
+        klemmarc.write_text(yaml.dump({"ai": {"timeout": 999}}), encoding="utf-8")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _load_klemmarc()
+        assert result["ai"]["timeout"] == 999
+
+    def test_yaml_takes_priority_over_yml(self, tmp_path, monkeypatch):
+        (tmp_path / ".klemmarc.yaml").write_text(
+            yaml.dump({"ai": {"model": "yaml"}}), encoding="utf-8"
+        )
+        (tmp_path / ".klemmarc.yml").write_text(
+            yaml.dump({"ai": {"model": "yml"}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _load_klemmarc()
+        assert result["ai"]["model"] == "yaml"
+
+    def test_returns_empty_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _load_klemmarc()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _derive_provider
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProvider:
+    def test_litellm_with_prefix(self):
+        assert _derive_provider("litellm", "anthropic/claude-sonnet") == "anthropic"
+
+    def test_litellm_bare_model(self):
+        assert _derive_provider("litellm", "gpt-4.1") == "openai"
+
+    def test_litellm_openai_prefix(self):
+        assert _derive_provider("litellm", "openai/gpt-4.1") == "openai"
+
+    def test_litellm_google_prefix(self):
+        assert _derive_provider("litellm", "google/gemini-2.5-pro") == "google"
+
+    def test_openai_backend(self):
+        assert _derive_provider("openai", "gpt-4o") == "openai"
+
+    def test_claude_backend(self):
+        assert _derive_provider("claude", "opus") == "anthropic"
+
+    def test_litellm_ollama(self):
+        assert _derive_provider("litellm", "ollama/llama3") == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# AIConfig.api_key
+# ---------------------------------------------------------------------------
+
+
+class TestAIConfigApiKey:
+    def test_api_keys_priority_over_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+        config = AIConfig(backend="litellm", model="gpt-4.1", api_key_env="OPENAI_API_KEY")
+        config._resolved_api_keys = {"openai": "klemmarc-key"}
+        assert config.api_key == "klemmarc-key"
+
+    def test_env_fallback_when_no_resolved_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+        config = AIConfig(backend="litellm", model="gpt-4.1", api_key_env="OPENAI_API_KEY")
+        assert config.api_key == "env-key"
+
+    def test_none_when_no_key_at_all(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        config = AIConfig(backend="litellm", model="gpt-4.1")
+        assert config.api_key is None
+
+    def test_anthropic_key_for_litellm_anthropic_model(self):
+        config = AIConfig(backend="litellm", model="anthropic/claude-sonnet-4-6")
+        config._resolved_api_keys = {"anthropic": "sk-ant-test"}
+        assert config.api_key == "sk-ant-test"
+
+    def test_api_keys_not_in_model_dump(self):
+        config = AIConfig(backend="litellm", model="gpt-4.1")
+        config._resolved_api_keys = {"openai": "secret"}
+        dumped = config.model_dump()
+        assert "api_keys" not in dumped
+        assert "_resolved_api_keys" not in dumped
+        assert "secret" not in str(dumped)
+
+    def test_default_backend_is_litellm(self):
+        config = AIConfig()
+        assert config.backend == "litellm"
+
+
+# ---------------------------------------------------------------------------
+# resolve_effective_config with klemmarc
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffectiveConfigKlemmarc:
+    def test_klemmarc_merged_as_base_layer(self, tmp_path, monkeypatch):
+        """klemmarc values are used when no other config provides them."""
+        # Setup klemmarc
+        klemmarc = tmp_path / ".klemmarc.yaml"
+        klemmarc.write_text(
+            yaml.dump({
+                "ai": {"model": "anthropic/claude-sonnet-4-6", "timeout": 999},
+                "api_keys": {"anthropic": "sk-ant-test"},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Setup system home (empty)
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        (system_home / "config.yaml").write_text("", encoding="utf-8")
+        monkeypatch.setattr("klemma.config.get_system_home", lambda: system_home)
+
+        # Setup project
+        project = tmp_path / "myproject"
+        klemma_dir = project / ".klemma"
+        klemma_dir.mkdir(parents=True)
+        (klemma_dir / "config.yaml").write_text(
+            yaml.dump({"project": {"type": "paper"}}), encoding="utf-8"
+        )
+
+        cfg, _, _ = resolve_effective_config([project])
+        assert cfg.ai.model == "anthropic/claude-sonnet-4-6"
+        assert cfg.ai.timeout == 999
+        assert cfg.ai._resolved_api_keys == {"anthropic": "sk-ant-test"}
+
+    def test_project_overrides_klemmarc(self, tmp_path, monkeypatch):
+        """Project-level ai settings override klemmarc."""
+        klemmarc = tmp_path / ".klemmarc.yaml"
+        klemmarc.write_text(
+            yaml.dump({"ai": {"model": "anthropic/claude-sonnet-4-6"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        (system_home / "config.yaml").write_text("", encoding="utf-8")
+        monkeypatch.setattr("klemma.config.get_system_home", lambda: system_home)
+
+        project = tmp_path / "myproject"
+        klemma_dir = project / ".klemma"
+        klemma_dir.mkdir(parents=True)
+        (klemma_dir / "config.yaml").write_text(
+            yaml.dump({"ai": {"model": "ollama/llama3"}}), encoding="utf-8"
+        )
+
+        cfg, _, _ = resolve_effective_config([project])
+        assert cfg.ai.model == "ollama/llama3"
+
+    def test_legacy_fallback_when_no_klemmarc(self, tmp_path, monkeypatch):
+        """When no klemmarc exists, legacy system config still works."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        system_home = tmp_path / ".klemma"
+        system_home.mkdir()
+        (system_home / "config.yaml").write_text(
+            yaml.dump({"ai": {"model": "sonnet", "timeout": 300}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("klemma.config.get_system_home", lambda: system_home)
+
+        project = tmp_path / "myproject"
+        klemma_dir = project / ".klemma"
+        klemma_dir.mkdir(parents=True)
+        (klemma_dir / "config.yaml").write_text("", encoding="utf-8")
+
+        cfg, _, _ = resolve_effective_config([project])
+        assert cfg.ai.model == "sonnet"
+        assert cfg.ai.timeout == 300
+
+
+# ---------------------------------------------------------------------------
+# chmod 600 enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestKlemmarcPermissions:
+    def test_check_fixes_world_readable(self, tmp_path, monkeypatch):
+        from klemma.config import _check_klemmarc_permissions
+
+        klemmarc = tmp_path / ".klemmarc.yaml"
+        klemmarc.write_text("ai:\n  model: test\n", encoding="utf-8")
+        klemmarc.chmod(0o644)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _check_klemmarc_permissions()
+
+        mode = klemmarc.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_check_leaves_correct_permissions(self, tmp_path, monkeypatch):
+        from klemma.config import _check_klemmarc_permissions
+
+        klemmarc = tmp_path / ".klemmarc.yaml"
+        klemmarc.write_text("ai:\n  model: test\n", encoding="utf-8")
+        klemmarc.chmod(0o600)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _check_klemmarc_permissions()
+
+        mode = klemmarc.stat().st_mode & 0o777
+        assert mode == 0o600


### PR DESCRIPTION
## Summary

- Consolidate 3 AI backends to 2: `claude` (interactive CLI) + `litellm` (all API models via LiteLLM)
- Add `~/.klemmarc.yaml` as a single global config file with direct API key storage — no more env var juggling
- Deprecate `backend: openai` (thin wrapper that delegates to LiteLLM with `DeprecationWarning`)
- Fix two critical evaluation bugs that caused 0% reconstruction scores

## Changes

**config.py** — `_load_klemmarc()`, `_derive_provider()`, `AIConfig._resolved_api_keys` (PrivateAttr), merge order: `klemmarc < system < project < CLI`, permission enforcement (chmod 600)

**ai_litellm.py** — Full rewrite with json_mode, base_url, reasoning model detection (o-series/gpt-5), `_build_kwargs()` helper

**ai_openai.py** — Replaced with thin deprecation wrapper delegating to `LiteLLMClient`

**setup.py** — Creates `~/.klemmarc.yaml` (0600) in `init_system()`

**embeddings.py** — `api_key` passthrough from klemmarc `api_keys`

**Default backend** changed from `claude` to `litellm`

**evaluation/pipeline.py** — Library entries passed to analyst now include titles from `citation_links` (sources table has no title column, so analyst couldn't match bibliography to library)

**evaluation/reconstruction.py** — Normalize section_ids in AI predictions (e.g. `"I: Introduction"` → `"I"`) to match GT section_ids

## Benchmark impact

| Paper | Before fix | After fix |
|---|---|---|
| gaoRetrieval | F1=0.000 | **F1=0.681** |
| skarlinskiLanguageAgents | F1=0.000 | **F1=0.694** |
| kangThreddy | F1=0.857 | F1=0.857 (stable) |

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 432 passed (was 397, +35 new)
- [x] Smoke test: `~/.klemmarc.yaml` with `api_keys.openai` — key resolves, benchmarks run
- [x] Benchmark: 3 papers benchmarked with reconstruction F1 > 0.68
- [ ] Smoke test: `backend: openai` in project config → deprecation warning, still works

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)