### PR TITLE
feat(ai): normalize backend contracts with error taxonomy and observability

### DIFF
--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -59,22 +59,29 @@ Tables:
 
 Key methods: `register_sources()`, `get_by_section()` (JOIN on `source_sections`), `get_coverage_stats()`, `get_gap_summary()`, `save_plan()`, `save_citation_links()`, `get_citation_graph()`, `save_embedding()`, `get_embeddings()`, `save_prune_verdicts()`, `get_prune_verdicts()`, `save_benchmark_run()`, `get_benchmark_runs()`, `compare_benchmark_runs()`.
 
-### ai.py (249 lines)
+### errors.py (32 lines)
+Klemma error taxonomy for AI backends.
+- `KlemmaAIError` — base class with `retryable` flag and optional `cause` chaining
+- `AITimeoutError` (retryable), `AIRateLimitError` (retryable), `AIAuthError` (fatal), `AIResponseError` (fatal)
+
+### ai.py (351 lines)
 `AIProvider` protocol → `AIProviderBase` → `ClaudeClient` + `create_ai()` factory.
-- `AIProvider.call()` / `call_json()` — main interface for AI calls
+- `AICallResult` — dataclass with `text`, `duration_ms`, `input_tokens`, `output_tokens`, `retries_used`, `model`, `error`; truthy when `text is not None`
+- `AIProvider.call()` / `call_json()` / `call_with_meta()` — main interface for AI calls
+- `call_with_meta()` — returns `AICallResult` with timing/tokens/error metadata; base wraps `call()`, backends override with structured error mapping
 - `AIProviderBase.render_prompt()` — Jinja2 template rendering
 - `extract_json()` — parses JSON from markdown code blocks and unstructured text
-- `ClaudeClient` — subprocess wrapper for `claude -p --model <model>`
-- Retry logic with configurable timeout
+- `ClaudeClient` — subprocess wrapper for `claude -p --model <model>` with structured error tracking (timeout, CLI error, FileNotFoundError)
 
 ### ai_openai.py (71 lines)
 **DEPRECATED** — thin delegation wrapper around `LiteLLMClient`. Emits `DeprecationWarning`, prefixes bare model names with `openai/`, delegates all calls to LiteLLM.
 
-### ai_litellm.py (146 lines)
+### ai_litellm.py (230 lines)
 `LiteLLMClient` — recommended AI backend via `litellm.completion()`. Model format: `provider/model`.
 - `_build_kwargs()` — single helper for all completion kwargs (model, tokens, temperature, base_url, api_key, response_format)
 - `_is_reasoning_model` — detects o-series/gpt-5 models, switches to `max_completion_tokens`
 - `call_json()` — supports structured JSON mode (`response_format`) when `json_mode=True`
+- `call_with_meta()` — structured error mapping: `AuthenticationError` (fatal, no retry), `Timeout`/`RateLimitError` (retryable), token extraction from `response.usage`
 - `base_url` passthrough for custom endpoints (Ollama, vLLM, etc.)
 
 ### vault.py (263 lines)

--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -247,6 +247,62 @@ class ClaudeClient(AIProviderBase):
                 logger.error("Error (attempt %d/%d): %s", attempt + 1, self.retries + 1, e)
         return None
 
+    def call_with_meta(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.3,
+        timeout: Optional[int] = None,
+    ) -> AICallResult:
+        """Call Claude CLI with structured error tracking."""
+        effective_timeout = timeout or self.timeout
+        prompt = f"{system}\n\n---\n\n{user}"
+
+        t0 = time.monotonic()
+        retries_used = 0
+        last_error = ""
+
+        for attempt in range(self.retries + 1):
+            try:
+                result = subprocess.run(
+                    ["claude", "-p", "--model", self.model, prompt],
+                    capture_output=True, text=True, timeout=effective_timeout,
+                )
+                if result.returncode != 0:
+                    retries_used = attempt + 1
+                    last_error = f"cli_error: exit {result.returncode}"
+                    logger.warning(
+                        "Claude CLI error (attempt %d/%d): %s",
+                        attempt + 1, self.retries + 1, result.stderr[:200],
+                    )
+                    continue
+                elapsed = int((time.monotonic() - t0) * 1000)
+                return AICallResult(
+                    text=result.stdout, duration_ms=elapsed,
+                    retries_used=retries_used, model=self.model,
+                )
+            except subprocess.TimeoutExpired:
+                retries_used = attempt + 1
+                last_error = f"timeout: {effective_timeout}s"
+                logger.warning("Timeout (attempt %d/%d)", attempt + 1, self.retries + 1)
+            except FileNotFoundError:
+                elapsed = int((time.monotonic() - t0) * 1000)
+                return AICallResult(
+                    text=None, duration_ms=elapsed, model=self.model,
+                    error="claude CLI not found",
+                )
+            except Exception as e:
+                retries_used = attempt + 1
+                last_error = f"error: {e}"
+                logger.error("Error (attempt %d/%d): %s", attempt + 1, self.retries + 1, e)
+
+        elapsed = int((time.monotonic() - t0) * 1000)
+        return AICallResult(
+            text=None, duration_ms=elapsed, model=self.model,
+            retries_used=retries_used, error=last_error or "all retries exhausted",
+        )
+
     @property
     def interactive_available(self) -> bool:
         return True

--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -7,6 +7,8 @@ Optional backends: OpenAI-compatible API, LiteLLM.
 import json
 import logging
 import subprocess
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Protocol, runtime_checkable
 
@@ -56,6 +58,22 @@ def extract_json(text: str) -> Optional[dict]:
         return None
 
 
+@dataclass
+class AICallResult:
+    """Result of an AI call with metadata for observability."""
+
+    text: Optional[str] = None
+    duration_ms: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    retries_used: int = 0
+    model: str = ""
+    error: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return self.text is not None
+
+
 # ---------------------------------------------------------------------------
 # Protocol
 # ---------------------------------------------------------------------------
@@ -87,6 +105,15 @@ class AIProvider(Protocol):
         temperature: float = 0.2,
         timeout: Optional[int] = None,
     ) -> Optional[dict]: ...
+
+    def call_with_meta(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.3,
+        timeout: Optional[int] = None,
+    ) -> AICallResult: ...
 
     def render_prompt(self, template_path: Path, **kwargs) -> str: ...
 
@@ -133,6 +160,25 @@ class AIProviderBase:
         if not text:
             return None
         return extract_json(text)
+
+    def call_with_meta(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.3,
+        timeout: Optional[int] = None,
+    ) -> AICallResult:
+        """Call the backend and return result with metadata."""
+        t0 = time.monotonic()
+        text = self.call(system, user, max_tokens=max_tokens, temperature=temperature, timeout=timeout)
+        elapsed = int((time.monotonic() - t0) * 1000)
+        return AICallResult(
+            text=text,
+            duration_ms=elapsed,
+            model=self.model,
+            error=None if text else "all retries exhausted",
+        )
 
     def render_prompt(self, template_path: Path, **kwargs) -> str:
         """Load a prompt template and render with Jinja2."""

--- a/src/klemma/ai_litellm.py
+++ b/src/klemma/ai_litellm.py
@@ -8,9 +8,10 @@ Install: pip install klemma[litellm]
 import json
 import logging
 import re
+import time
 from typing import Optional
 
-from .ai import AIProviderBase, extract_json
+from .ai import AICallResult, AIProviderBase, extract_json
 from .config import AIConfig
 
 logger = logging.getLogger(__name__)
@@ -144,3 +145,86 @@ class LiteLLMClient(AIProviderBase):
                     attempt + 1, self.retries + 1, e,
                 )
         return None
+
+    def call_with_meta(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.3,
+        timeout: Optional[int] = None,
+    ) -> AICallResult:
+        """Call LiteLLM with structured error handling and token tracking."""
+
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        kwargs = self._build_kwargs(messages, max_tokens, temperature, timeout)
+
+        t0 = time.monotonic()
+        retries_used = 0
+        last_error = ""
+
+        for attempt in range(self.retries + 1):
+            try:
+                response = self._litellm.completion(**kwargs)
+                elapsed = int((time.monotonic() - t0) * 1000)
+                text = response.choices[0].message.content
+
+                # Extract token usage if available
+                usage = getattr(response, "usage", None)
+                input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+                output_tokens = (
+                    getattr(usage, "completion_tokens", 0) if usage else 0
+                )
+
+                return AICallResult(
+                    text=text,
+                    duration_ms=elapsed,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    retries_used=retries_used,
+                    model=self.model,
+                )
+            except self._litellm.AuthenticationError as e:
+                # Fatal — do not retry
+                elapsed = int((time.monotonic() - t0) * 1000)
+                logger.error("Auth error: %s", e)
+                return AICallResult(
+                    text=None,
+                    duration_ms=elapsed,
+                    model=self.model,
+                    retries_used=retries_used,
+                    error=f"auth: {e}",
+                )
+            except self._litellm.Timeout as e:
+                retries_used = attempt + 1
+                last_error = f"timeout: {e}"
+                logger.warning(
+                    "Timeout (attempt %d/%d)", attempt + 1, self.retries + 1
+                )
+            except self._litellm.RateLimitError as e:
+                retries_used = attempt + 1
+                last_error = f"rate_limit: {e}"
+                logger.warning(
+                    "Rate limit (attempt %d/%d)", attempt + 1, self.retries + 1
+                )
+            except Exception as e:
+                retries_used = attempt + 1
+                last_error = f"error: {e}"
+                logger.warning(
+                    "LiteLLM error (attempt %d/%d): %s",
+                    attempt + 1,
+                    self.retries + 1,
+                    e,
+                )
+
+        elapsed = int((time.monotonic() - t0) * 1000)
+        return AICallResult(
+            text=None,
+            duration_ms=elapsed,
+            model=self.model,
+            retries_used=retries_used,
+            error=last_error or "all retries exhausted",
+        )

--- a/src/klemma/errors.py
+++ b/src/klemma/errors.py
@@ -1,0 +1,32 @@
+"""Klemma error taxonomy for AI backend contracts."""
+
+
+class KlemmaAIError(Exception):
+    """Base class for all AI backend errors."""
+
+    retryable: bool = False
+
+    def __init__(self, message: str, *, cause: BaseException | None = None):
+        super().__init__(message)
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class AITimeoutError(KlemmaAIError):
+    """AI call exceeded timeout — retryable."""
+    retryable = True
+
+
+class AIRateLimitError(KlemmaAIError):
+    """AI provider rate limit hit — retryable."""
+    retryable = True
+
+
+class AIAuthError(KlemmaAIError):
+    """Authentication/authorization failure — fatal."""
+    retryable = False
+
+
+class AIResponseError(KlemmaAIError):
+    """AI returned unparseable or empty response — fatal."""
+    retryable = False

--- a/src/klemma/evaluation/CLAUDE.md
+++ b/src/klemma/evaluation/CLAUDE.md
@@ -34,12 +34,13 @@ Benchmark runners — orchestrate DB queries + metric computation.
 - `run_all(state, dataset, metrics_filter, reranked_gaps?, ai?, klemma_home?)` — dispatch to selected runners; includes reconstruction when `metrics_filter` is `"all"` or `"reconstruct"`
 - `build_results_summary(results)` — flatten headline metrics from results dict into flat `{"reconstruction.f1": 0.624, ...}` dict for persistence
 
-### reconstruction.py (~230 lines)
+### reconstruction.py (~329 lines)
 Citation reconstruction benchmark — end-to-end recommendation quality.
+- `AICallStats` — dataclass accumulator for AI call metadata (total_calls, duration_ms, input/output tokens, errors); `record(result)` accepts `AICallResult`, `to_dict()` for serialization
 - `run_analyst(ai, pdf_text, library_entries, paper_citekey, paper_title, klemma_home)` — extract ground truth citation map from a paper's PDF via AI
 - `compute_baseline(state, dataset)` — evaluate DB-only fragment assignments against ground truth
-- `run_reconstruction(ai, state, dataset, klemma_home, ablation?)` — AI-driven citation recommendation against ground truth; ablation params override temperature, fragments_per_source, and prompt variables (max_recs_per_section, few-shot examples)
-- `run_reconstruction_benchmark(state, dataset, ai?, klemma_home?, ablation?)` — full benchmark: ground truth stats + baseline + optional AI reconstruction with ablation support
+- `run_reconstruction(ai, state, dataset, klemma_home, ablation?, stats?)` — AI-driven citation recommendation using `call_with_meta()` for structured error handling and token tracking; ablation params override temperature, fragments_per_source, and prompt variables
+- `run_reconstruction_benchmark(state, dataset, ai?, klemma_home?, ablation?, stats?)` — full benchmark: ground truth stats + baseline + optional AI reconstruction; passes stats through to run_reconstruction
 
 ### candidates.py (~97 lines)
 Benchmark candidate discovery from citation graph.

--- a/src/klemma/evaluation/candidates.py
+++ b/src/klemma/evaluation/candidates.py
@@ -48,21 +48,7 @@ def discover_candidates(
     if benchmarked_citekeys is None:
         benchmarked_citekeys = state.get_benchmarked_citekeys()
 
-    with state._conn() as conn:
-        cur = conn.execute("""
-            SELECT s.id, s.pdf_path,
-                   COUNT(DISTINCT CASE WHEN cl.in_library=1
-                         THEN cl.target_title_hash END) as in_lib,
-                   COUNT(DISTINCT cl.target_title_hash) as total,
-                   COUNT(DISTINCT cl.citation_intent) as intent_div
-            FROM sources s
-            JOIN citation_links cl ON cl.source_id = s.id
-            WHERE s.status = 'completed'
-            GROUP BY s.id
-            HAVING in_lib >= 3
-            ORDER BY in_lib DESC
-        """)
-        rows = cur.fetchall()
+    rows = state.get_benchmark_candidates()
 
     candidates = []
     for row in rows:

--- a/src/klemma/evaluation/pipeline.py
+++ b/src/klemma/evaluation/pipeline.py
@@ -246,11 +246,14 @@ def run_auto_benchmark(
         return result
 
     # 4. Benchmark
+    from .reconstruction import AICallStats
+
     effective_ablation = ablation or AblationParams()
+    call_stats = AICallStats()
     t_start = time.monotonic()
     bench_results = run_reconstruction_benchmark(
         state, dataset, ai=ai, klemma_home=klemma_home,
-        ablation=effective_ablation,
+        ablation=effective_ablation, stats=call_stats,
     )
     duration = time.monotonic() - t_start
 
@@ -284,6 +287,7 @@ def run_auto_benchmark(
             "auto": True,
             "ablation": effective_ablation.to_snapshot(),
             "prompt_hash": prompt_hash,
+            "call_stats": call_stats.to_dict(),
         },
     )
     result.run_id = run_id

--- a/src/klemma/evaluation/reconstruction.py
+++ b/src/klemma/evaluation/reconstruction.py
@@ -13,6 +13,7 @@ assignments using only the outline + fragment library (blind to paper text).
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -21,10 +22,38 @@ from .metrics import reconstruction_metrics
 from .pipeline import AblationParams
 
 if TYPE_CHECKING:
-    from klemma.ai import AIProvider
+    from klemma.ai import AICallResult, AIProvider
     from klemma.state import StateManager
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AICallStats:
+    """Accumulates stats from AI calls during reconstruction."""
+
+    total_calls: int = 0
+    total_duration_ms: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def record(self, result: AICallResult) -> None:
+        self.total_calls += 1
+        self.total_duration_ms += result.duration_ms
+        self.total_input_tokens += result.input_tokens
+        self.total_output_tokens += result.output_tokens
+        if result.error:
+            self.errors.append(result.error)
+
+    def to_dict(self) -> dict:
+        return {
+            "total_calls": self.total_calls,
+            "total_duration_ms": self.total_duration_ms,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "errors": self.errors,
+        }
 
 
 def run_analyst(
@@ -132,6 +161,7 @@ def run_reconstruction(
     dataset: ReconstructionDataset,
     klemma_home: Optional[Path] = None,
     ablation: Optional[AblationParams] = None,
+    stats: Optional[AICallStats] = None,
 ) -> dict:
     """Run AI-driven citation reconstruction.
 
@@ -142,6 +172,7 @@ def run_reconstruction(
         ablation: Override default parameters for ablation experiments.
             Controls temperature, fragments_per_source, max_recs_per_section,
             and prompt variant (few-shot examples).
+        stats: Optional accumulator for AI call metadata (timing, tokens).
     """
     from klemma.config import _SHIPPED_PROMPTS_DIR, resolve_prompt
 
@@ -202,13 +233,21 @@ def run_reconstruction(
         "Output only valid JSON."
     )
 
-    data = ai.call_json(
+    from klemma.ai import extract_json
+
+    meta = ai.call_with_meta(
         system, user_prompt, max_tokens=4096,
         temperature=params.temperature,
     )
+    if stats:
+        stats.record(meta)
+    if not meta.text:
+        logger.error("Reconstruction prompt failed: %s", meta.error)
+        return {"method": "reconstruction", "error": meta.error or "AI call failed"}
+    data = extract_json(meta.text)
     if not data:
-        logger.error("Reconstruction prompt failed")
-        return {"method": "reconstruction", "error": "AI call failed"}
+        logger.error("Reconstruction JSON parse failed")
+        return {"method": "reconstruction", "error": "JSON parse failed"}
 
     # Parse recommendations into prediction dicts
     # Normalize section_ids: AI sometimes returns "I: Introduction" instead of "I"
@@ -251,6 +290,7 @@ def run_reconstruction_benchmark(
     ai: Optional[AIProvider] = None,
     klemma_home: Optional[Path] = None,
     ablation: Optional[AblationParams] = None,
+    stats: Optional[AICallStats] = None,
 ) -> dict:
     """Run full reconstruction benchmark: ground truth stats + baseline + optional AI.
 
@@ -260,6 +300,7 @@ def run_reconstruction_benchmark(
     Args:
         ablation: Override default parameters for ablation experiments.
             Passed through to run_reconstruction().
+        stats: Optional accumulator for AI call metadata (timing, tokens).
     """
     gt = dataset.ground_truth
     in_library = sum(
@@ -282,7 +323,7 @@ def run_reconstruction_benchmark(
 
     if ai:
         result["reconstruction"] = run_reconstruction(
-            ai, state, dataset, klemma_home, ablation=ablation,
+            ai, state, dataset, klemma_home, ablation=ablation, stats=stats,
         )
 
     return result

--- a/src/klemma/repositories/citations.py
+++ b/src/klemma/repositories/citations.py
@@ -108,6 +108,28 @@ class CitationsRepository(BaseRepository):
                 "most_connected_internal": most_connected,
             }
 
+    def get_benchmark_candidates(self) -> list[dict]:
+        """Find sources with 3+ in-library citations for benchmark candidacy.
+
+        Returns rows with: id, pdf_path, in_lib, total, intent_div.
+        Scoring and filtering done by caller (evaluation.candidates).
+        """
+        with self._conn() as conn:
+            cur = conn.execute("""
+                SELECT s.id, s.pdf_path,
+                       COUNT(DISTINCT CASE WHEN cl.in_library=1
+                             THEN cl.target_title_hash END) as in_lib,
+                       COUNT(DISTINCT cl.target_title_hash) as total,
+                       COUNT(DISTINCT cl.citation_intent) as intent_div
+                FROM sources s
+                JOIN citation_links cl ON cl.source_id = s.id
+                WHERE s.status = 'completed'
+                GROUP BY s.id
+                HAVING in_lib >= 3
+                ORDER BY in_lib DESC
+            """)
+            return [dict(row) for row in cur.fetchall()]
+
     def get_co_cited(self, citekey: str) -> list[dict]:
         """Find works frequently co-cited with the given citekey."""
         with self._conn() as conn:

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -419,6 +419,9 @@ class StateManager:
     def get_key_author_groups(self, min_papers: int = 2) -> list[dict]:
         return self.citations.get_key_author_groups(min_papers)
 
+    def get_benchmark_candidates(self) -> list[dict]:
+        return self.citations.get_benchmark_candidates()
+
     # ── Plans delegation ──────────────────────────────────────────────────
 
     def save_plan(self, dissertation_task: str, assistant_task: str, reading_target: str = "",

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,9 +1,11 @@
 # Tests
 
-## Current test suite (432 tests)
-- `test_ai.py` (111 lines) — `extract_json()`, `AIProviderBase`, `create_ai()` factory, `ClaudeClient` detection
-- `test_ai_litellm.py` (188 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry
+## Current test suite (472 tests)
+- `test_errors.py` (33 lines) — `KlemmaAIError` hierarchy, `retryable` classification, cause chaining
+- `test_ai.py` (170 lines) — `extract_json()`, `AIProviderBase`, `AICallResult` dataclass, `call_with_meta()` base + Claude, `create_ai()` factory
+- `test_ai_litellm.py` (265 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry, `call_with_meta()` with structured error mapping + token extraction
 - `test_ai_openai.py` (127 lines) — deprecated `OpenAIClient`: DeprecationWarning, delegation to LiteLLMClient, model prefixing
+- `test_ai_contract.py` (203 lines) — parametrized contract tests: all 3 backends (Claude/LiteLLM/OpenAI) satisfy same behavioral contract (call → str|None, call_json → dict|None, call_with_meta → AICallResult, protocol conformance)
 - `test_klemmarc.py` (244 lines) — `_load_klemmarc()`, `_derive_provider()`, `AIConfig.api_key` resolution, `resolve_effective_config()` with klemmarc, chmod 600 enforcement
 - `test_project_discovery.py` (645 lines) — 42 tests for Git-style project discovery, config merging, context aggregation, prompt resolution, tags inheritance, setup, and deep merge
 - `test_embeddings.py` (354 lines) — `EmbeddingProvider` protocol, `cosine_similarity`, `SemanticScholarEmbeddings`/`LocalSPECTEREmbeddings`/`OpenAIEmbeddings` with mocked backends, `create_embeddings()` factory

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,5 +1,6 @@
 """Tests for AI provider abstraction: extract_json, AIProviderBase, factory."""
 
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -168,3 +169,51 @@ def test_base_call_with_meta_on_failure():
     result = base.call_with_meta("sys", "usr")
     assert result.text is None
     assert result.error == "all retries exhausted"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeClient.call_with_meta()
+# ---------------------------------------------------------------------------
+
+@patch.object(ClaudeClient, "check_cli_available", return_value=True)
+def test_claude_call_with_meta_success(mock_check):
+    config = AIConfig(backend="claude")
+    client = ClaudeClient(config)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="response text", stderr="",
+        )
+        result = client.call_with_meta("sys", "usr")
+
+    assert isinstance(result, AICallResult)
+    assert result.text == "response text"
+    assert result.duration_ms >= 0
+    assert result.error is None
+
+
+@patch.object(ClaudeClient, "check_cli_available", return_value=True)
+def test_claude_call_with_meta_timeout(mock_check):
+    config = AIConfig(backend="claude", retries=0)
+    client = ClaudeClient(config)
+
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("claude", 180)):
+        result = client.call_with_meta("sys", "usr")
+
+    assert result.text is None
+    assert "timeout" in result.error.lower()
+
+
+@patch.object(ClaudeClient, "check_cli_available", return_value=True)
+def test_claude_call_with_meta_cli_error(mock_check):
+    config = AIConfig(backend="claude", retries=0)
+    client = ClaudeClient(config)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="error output",
+        )
+        result = client.call_with_meta("sys", "usr")
+
+    assert result.text is None
+    assert result.error is not None

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from klemma.ai import (
+    AICallResult,
     AIProvider,
     AIProviderBase,
     ClaudeClient,
@@ -109,3 +110,61 @@ def test_create_ai_unknown_backend():
     config = AIConfig(backend="unknown")
     with pytest.raises(ValueError, match="Unknown AI backend"):
         create_ai(config)
+
+
+# ---------------------------------------------------------------------------
+# AICallResult
+# ---------------------------------------------------------------------------
+
+def test_aicallresult_fields():
+    r = AICallResult(
+        text="hello",
+        duration_ms=150,
+        input_tokens=10,
+        output_tokens=5,
+        retries_used=0,
+        model="gpt-4.1",
+    )
+    assert r.text == "hello"
+    assert r.duration_ms == 150
+    assert r.input_tokens == 10
+    assert r.output_tokens == 5
+    assert r.retries_used == 0
+    assert r.model == "gpt-4.1"
+    assert r.error is None
+
+
+def test_aicallresult_failed():
+    r = AICallResult(text=None, duration_ms=3000, model="gpt-4.1", error="timeout")
+    assert r.text is None
+    assert r.error == "timeout"
+
+
+def test_aicallresult_bool():
+    """Truthy when text is present, falsy when None."""
+    assert bool(AICallResult(text="ok", duration_ms=1, model="m"))
+    assert not bool(AICallResult(text=None, duration_ms=1, model="m"))
+
+
+def test_base_call_with_meta_delegates():
+    """AIProviderBase.call_with_meta() wraps call() with timing."""
+    config = AIConfig()
+    base = AIProviderBase(config)
+    base.call = lambda system, user, max_tokens=8192, temperature=0.3, timeout=None: "response text"
+
+    result = base.call_with_meta("sys", "usr")
+    assert isinstance(result, AICallResult)
+    assert result.text == "response text"
+    assert result.duration_ms >= 0
+    assert result.retries_used == 0
+    assert result.model == config.model
+
+
+def test_base_call_with_meta_on_failure():
+    config = AIConfig()
+    base = AIProviderBase(config)
+    base.call = lambda system, user, max_tokens=8192, temperature=0.3, timeout=None: None
+
+    result = base.call_with_meta("sys", "usr")
+    assert result.text is None
+    assert result.error == "all retries exhausted"

--- a/tests/test_ai_contract.py
+++ b/tests/test_ai_contract.py
@@ -1,0 +1,203 @@
+"""Parametrized contract tests for all AI backends.
+
+Proves that Claude, LiteLLM, and OpenAI (deprecated) backends all satisfy
+the same behavioral contract: return types, error handling, retry semantics.
+"""
+
+import importlib
+import subprocess
+import sys
+import warnings
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from klemma.ai import AICallResult, AIProvider, ClaudeClient
+from klemma.config import AIConfig
+
+# ---------------------------------------------------------------------------
+# Backend fixtures
+# ---------------------------------------------------------------------------
+
+def _make_litellm_response(content="ok", input_tokens=10, output_tokens=5):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=input_tokens, completion_tokens=output_tokens),
+    )
+
+
+@pytest.fixture
+def claude_client():
+    """ClaudeClient with mocked subprocess."""
+    with patch.object(ClaudeClient, "check_cli_available", return_value=True):
+        config = AIConfig(backend="claude", retries=1)
+        client = ClaudeClient(config)
+    return client
+
+
+@pytest.fixture
+def litellm_client():
+    """LiteLLMClient with mocked litellm module."""
+    mock = MagicMock()
+    mock.completion.return_value = _make_litellm_response()
+    mock.Timeout = type("Timeout", (Exception,), {})
+    mock.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    with patch.dict(sys.modules, {"litellm": mock}):
+        import klemma.ai_litellm as mod
+        importlib.reload(mod)
+        config = AIConfig(backend="litellm", model="gpt-4.1", retries=1)
+        client = mod.LiteLLMClient(config)
+    client._mock = mock
+    return client
+
+
+@pytest.fixture
+def openai_client():
+    """OpenAIClient (deprecated) with mocked litellm."""
+    mock = MagicMock()
+    mock.completion.return_value = _make_litellm_response()
+    mock.Timeout = type("Timeout", (Exception,), {})
+    mock.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    with patch.dict(sys.modules, {"litellm": mock}):
+        import klemma.ai_litellm as litellm_mod
+        import klemma.ai_openai as mod
+        importlib.reload(litellm_mod)
+        importlib.reload(mod)
+        config = AIConfig(backend="openai", model="gpt-4o", retries=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            client = mod.OpenAIClient(config)
+    client._mock = mock
+    return client
+
+
+ALL_BACKENDS = ["claude_client", "litellm_client", "openai_client"]
+
+
+# ---------------------------------------------------------------------------
+# Contract: call() returns Optional[str]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_returns_string_on_success(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="hello", stderr="",
+            )
+            result = client.call("sys", "usr")
+    else:
+        result = client.call("sys", "usr")
+
+    assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_returns_none_on_failure(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("x", 1)):
+            result = client.call("sys", "usr")
+    else:
+        client._mock.completion.side_effect = Exception("fail")
+        result = client.call("sys", "usr")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Contract: call_json() returns Optional[dict]
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_json_returns_dict(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout='{"k": "v"}', stderr="",
+            )
+            result = client.call_json("sys", "usr")
+    else:
+        client._mock.completion.return_value = _make_litellm_response('{"k": "v"}')
+        result = client.call_json("sys", "usr")
+
+    assert isinstance(result, dict)
+    assert result["k"] == "v"
+
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_json_returns_none_on_failure(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("x", 1)):
+            result = client.call_json("sys", "usr")
+    else:
+        client._mock.completion.side_effect = Exception("fail")
+        result = client.call_json("sys", "usr")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Contract: call_with_meta() returns AICallResult
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_with_meta_returns_aicallresult(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="resp", stderr="",
+            )
+            result = client.call_with_meta("sys", "usr")
+    else:
+        result = client.call_with_meta("sys", "usr")
+
+    assert isinstance(result, AICallResult)
+    assert result.text is not None
+    assert result.duration_ms >= 0
+    assert result.error is None
+
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_call_with_meta_failure_has_error(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    if isinstance(client, ClaudeClient):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("x", 1)):
+            result = client.call_with_meta("sys", "usr")
+    else:
+        client._mock.completion.side_effect = Exception("fail")
+        result = client.call_with_meta("sys", "usr")
+
+    assert isinstance(result, AICallResult)
+    assert result.text is None
+    assert result.error is not None
+    assert len(result.error) > 0
+
+
+# ---------------------------------------------------------------------------
+# Contract: protocol conformance
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend_fixture", ALL_BACKENDS)
+def test_is_ai_provider(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    assert isinstance(client, AIProvider)
+
+
+# ---------------------------------------------------------------------------
+# Contract: empty response → None from call_json
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend_fixture", ["litellm_client", "openai_client"])
+def test_call_json_empty_response_returns_none(backend_fixture, request):
+    client = request.getfixturevalue(backend_fixture)
+    client._mock.completion.return_value = _make_litellm_response("")
+    result = client.call_json("sys", "usr")
+    assert result is None

--- a/tests/test_ai_litellm.py
+++ b/tests/test_ai_litellm.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from klemma.ai import AICallResult
 from klemma.config import AIConfig
 
 # ---------------------------------------------------------------------------
@@ -186,3 +187,100 @@ def test_litellm_retry_on_error():
     result = client.call("sys", "usr")
     assert result is None
     assert mock_litellm.completion.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# call_with_meta
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response_with_usage(content="Hello", input_tokens=50, output_tokens=20):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=input_tokens, completion_tokens=output_tokens),
+    )
+
+
+def test_litellm_call_with_meta_returns_result():
+    config = AIConfig(backend="litellm", model="gpt-4.1")
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response_with_usage(
+        "response", input_tokens=100, output_tokens=50,
+    )
+    # Need to define exception types so they exist on the mock
+    mock_litellm.Timeout = type("Timeout", (Exception,), {})
+    mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    result = client.call_with_meta("sys", "usr")
+    assert isinstance(result, AICallResult)
+    assert result.text == "response"
+    assert result.input_tokens == 100
+    assert result.output_tokens == 50
+    assert result.duration_ms >= 0
+    assert result.error is None
+    assert result.model == "gpt-4.1"
+
+
+def test_litellm_call_with_meta_timeout():
+    config = AIConfig(backend="litellm", model="gpt-4.1", retries=0)
+    mock_litellm = MagicMock()
+    mock_litellm.Timeout = type("Timeout", (Exception,), {})
+    mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    mock_litellm.completion.side_effect = mock_litellm.Timeout("timed out")
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+    result = client.call_with_meta("sys", "usr")
+    assert result.text is None
+    assert "timeout" in result.error.lower()
+
+
+def test_litellm_call_with_meta_rate_limit():
+    config = AIConfig(backend="litellm", model="gpt-4.1", retries=0)
+    mock_litellm = MagicMock()
+    mock_litellm.Timeout = type("Timeout", (Exception,), {})
+    mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    mock_litellm.completion.side_effect = mock_litellm.RateLimitError("429")
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+    result = client.call_with_meta("sys", "usr")
+    assert result.text is None
+    assert "rate" in result.error.lower()
+
+
+def test_litellm_call_with_meta_auth_error():
+    config = AIConfig(backend="litellm", model="gpt-4.1", retries=2)
+    mock_litellm = MagicMock()
+    mock_litellm.Timeout = type("Timeout", (Exception,), {})
+    mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    mock_litellm.completion.side_effect = mock_litellm.AuthenticationError("bad key")
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+    result = client.call_with_meta("sys", "usr")
+    assert result.text is None
+    assert "auth" in result.error.lower()
+    # Auth errors should NOT retry
+    assert mock_litellm.completion.call_count == 1
+
+
+def test_litellm_call_with_meta_retries_counted():
+    config = AIConfig(backend="litellm", model="gpt-4.1", retries=2)
+    mock_litellm = MagicMock()
+    mock_litellm.Timeout = type("Timeout", (Exception,), {})
+    mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+    mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    # Fail twice, succeed on third
+    mock_litellm.completion.side_effect = [
+        Exception("err1"),
+        Exception("err2"),
+        _make_mock_response_with_usage("ok"),
+    ]
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+    result = client.call_with_meta("sys", "usr")
+    assert result.text == "ok"
+    assert result.retries_used == 2

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,36 @@
+"""Tests for klemma error taxonomy."""
+from klemma.errors import (
+    AIAuthError,
+    AIRateLimitError,
+    AIResponseError,
+    AITimeoutError,
+    KlemmaAIError,
+)
+
+
+def test_error_hierarchy():
+    """All AI errors are KlemmaAIError subclasses."""
+    assert issubclass(AITimeoutError, KlemmaAIError)
+    assert issubclass(AIRateLimitError, KlemmaAIError)
+    assert issubclass(AIAuthError, KlemmaAIError)
+    assert issubclass(AIResponseError, KlemmaAIError)
+
+
+def test_retryable_classification():
+    """Timeout and rate-limit are retryable; auth and response are not."""
+    assert AITimeoutError("t").retryable is True
+    assert AIRateLimitError("r").retryable is True
+    assert AIAuthError("a").retryable is False
+    assert AIResponseError("resp").retryable is False
+
+
+def test_error_preserves_cause():
+    """Original exception is preserved as __cause__."""
+    original = ValueError("root")
+    err = AITimeoutError("timed out", cause=original)
+    assert err.__cause__ is original
+
+
+def test_error_str():
+    err = AIRateLimitError("429 too many requests")
+    assert "429 too many requests" in str(err)

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from klemma.ai import AICallResult
 from klemma.evaluation.dataset import (
     BenchmarkDataset,
     PaperSection,
@@ -369,14 +370,17 @@ class TestRunReconstruction:
 
         # Mock AI to return correct recommendations
         mock_ai = MagicMock()
-        mock_ai.call_json.return_value = {
-            "recommendations": [
-                {"section_id": "1", "citekey": "sourceA",
-                 "intent": "background", "justification": "test"},
-                {"section_id": "2", "citekey": "sourceB",
-                 "intent": "method", "justification": "test"},
-            ]
-        }
+        mock_ai.call_with_meta.return_value = AICallResult(
+            text=json.dumps({
+                "recommendations": [
+                    {"section_id": "1", "citekey": "sourceA",
+                     "intent": "background", "justification": "test"},
+                    {"section_id": "2", "citekey": "sourceB",
+                     "intent": "method", "justification": "test"},
+                ]
+            }),
+            duration_ms=100, model="test",
+        )
         mock_ai.render_prompt.return_value = "rendered prompt"
 
         dataset = _make_dataset()
@@ -388,24 +392,29 @@ class TestRunReconstruction:
     def test_ai_failure(self, state):
         state.register_sources(["sourceA"])
         mock_ai = MagicMock()
-        mock_ai.call_json.return_value = None
+        mock_ai.call_with_meta.return_value = AICallResult(
+            text=None, duration_ms=100, model="test", error="timeout",
+        )
         mock_ai.render_prompt.return_value = "rendered prompt"
 
         dataset = _make_dataset()
         result = run_reconstruction(mock_ai, state, dataset)
-        assert result.get("error") == "AI call failed"
+        assert "error" in result
 
     def test_deduplicates_ai_recommendations(self, state):
         state.register_sources(["sourceA"])
         mock_ai = MagicMock()
-        mock_ai.call_json.return_value = {
-            "recommendations": [
-                {"section_id": "1", "citekey": "sourceA",
-                 "intent": "background", "justification": "first"},
-                {"section_id": "1", "citekey": "sourceA",
-                 "intent": "method", "justification": "duplicate"},
-            ]
-        }
+        mock_ai.call_with_meta.return_value = AICallResult(
+            text=json.dumps({
+                "recommendations": [
+                    {"section_id": "1", "citekey": "sourceA",
+                     "intent": "background", "justification": "first"},
+                    {"section_id": "1", "citekey": "sourceA",
+                     "intent": "method", "justification": "duplicate"},
+                ]
+            }),
+            duration_ms=100, model="test",
+        )
         mock_ai.render_prompt.return_value = "rendered prompt"
 
         dataset = _make_dataset(samples=[
@@ -434,12 +443,15 @@ class TestRunReconstructionBenchmark:
     def test_full_benchmark_with_ai(self, state):
         state.register_sources(["sourceA", "sourceB"])
         mock_ai = MagicMock()
-        mock_ai.call_json.return_value = {
-            "recommendations": [
-                {"section_id": "1", "citekey": "sourceA",
-                 "intent": "background", "justification": "test"},
-            ]
-        }
+        mock_ai.call_with_meta.return_value = AICallResult(
+            text=json.dumps({
+                "recommendations": [
+                    {"section_id": "1", "citekey": "sourceA",
+                     "intent": "background", "justification": "test"},
+                ]
+            }),
+            duration_ms=100, model="test",
+        )
         mock_ai.render_prompt.return_value = "rendered prompt"
 
         dataset = _make_dataset()


### PR DESCRIPTION
## Summary
- Add `KlemmaAIError` hierarchy (timeout/rate-limit/auth/response) with retryable classification
- Add `AICallResult` dataclass with timing, tokens, retries metadata
- Add `call_with_meta()` to all backends (LiteLLM: structured litellm exception mapping + token extraction; Claude: subprocess error mapping)
- Wire `AICallStats` into benchmark pipeline `config_snapshot`
- Add parametrized contract tests proving all 3 backends satisfy same behavioral contract

Part of #29

## Test plan
- [ ] `ruff check src/ tests/` — clean
- [ ] `python -m pytest tests/ -q` — 472 passed
- [ ] Contract tests verify all 3 backends (Claude/LiteLLM/OpenAI) satisfy same contract
- [ ] Existing benchmark tests updated for new `call_with_meta` pattern
- [ ] Smoke test: `klemma benchmark --auto` records `call_stats` in config_snapshot

## Release Note

### Problem
AI backend errors were caught as bare `Exception`, losing diagnostic information. No way to distinguish retryable (timeout, rate limit) from fatal (auth) errors. Benchmark runs had no token/timing metadata, making cost and latency analysis impossible.

### Academic Foundation
Chen 2025's promptware engineering principles: AI calls as auditable contracts with structured observability. Reproducibility requirements from Kastrin et al. 2025 demand that benchmark infrastructure records not just outcomes but execution metadata.

### Implementation
- `errors.py`: `KlemmaAIError` base with `retryable` flag, 4 subclasses
- `ai.py`: `AICallResult` dataclass, `call_with_meta()` on protocol + base + ClaudeClient
- `ai_litellm.py`: maps `litellm.Timeout/RateLimitError/AuthenticationError` to taxonomy, extracts `usage` tokens
- `reconstruction.py`: `AICallStats` accumulator, wired through benchmark pipeline to `config_snapshot.call_stats`
- `test_ai_contract.py`: 23 parametrized tests across all backends

### Results
- 472 tests pass (was 432), +40 new tests across 4 test files
- Lint clean
- All existing benchmarks continue to work with new call pattern
- `config_snapshot` now includes `call_stats: {total_calls, total_duration_ms, total_input_tokens, total_output_tokens, errors}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)