### PR TITLE
feat: fragment RAG for klemma ask (Epic-B #28)

### DIFF
--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -40,7 +40,7 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 `source_count`, `sources_compact`
 
 ### agent.md
-`dissertation_context`, `chapters`, `scientific_results`, `priority_terms`, `current_chapter`, `chapter_name`, `current_section`, `current_deadline`, `days_until_deadline`, `sources`, `coverage`, `gaps`, `min_sources`, `fragment_stats`, `today_plan`, `next_reading`, `vault_path`, `today`, `project_root`, `outline_content`, `report_index` (list of {name, size}), `project_file_list` (list of {name, size})
+`dissertation_context`, `chapters`, `scientific_results`, `priority_terms`, `current_chapter`, `chapter_name`, `current_section`, `current_deadline`, `days_until_deadline`, `sources`, `coverage`, `gaps`, `min_sources`, `fragment_stats`, `today_plan`, `next_reading`, `vault_path`, `today`, `project_root`, `outline_content`, `report_index` (list of {name, size}), `project_file_list` (list of {name, size}), `relevant_fragments` (list of fragment dicts with citekey, fragment_text, citation_intent, similarity — populated via RAG when embeddings+query available)
 
 ### outline.md
 `project_type`, `dissertation_context`, `project_files` (list of {name, path, size, content_preview}), `library_summary`, `custom_prompt`, `language`

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -72,6 +72,15 @@ No critical gaps.
 - @{{ s.id }}: [{% if s.primary_chapter %}Ch.{{ s.primary_chapter }}, {% endif %}S{{ s.primary_section or "-" }}] quality={{ s.quality_score or 0 }}, fragments={{ s.fragment_count or 0 }}
 {% endfor %}
 
+{% if relevant_fragments %}
+
+## Relevant Fragments ({{ relevant_fragments | length }})
+
+{% for f in relevant_fragments %}
+- @{{ f.citekey }} [{{ f.citation_intent or "?" }}] (sim={{ f.similarity }}): {{ f.fragment_text[:300] }}
+{% endfor %}
+{% endif %}
+
 ## Today's Plan
 
 {% if today_plan %}

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -44,12 +44,12 @@ Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig` (with `
 - Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`
 
 ### state.py (542 lines)
-SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v4), auto-migrates via `_migrate_schema()`. All 64 public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
+SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v5), auto-migrates via `_migrate_schema()`. All 64 public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
 
 Tables:
 - `sources` — Zotero entries (citekey, title, status, chapter, quality, pdf_path, `embedding` BLOB float32, `embedding_model` TEXT)
 - `source_sections` — junction table: source_id × section (multi-section support)
-- `fragments` — extracted citation fragments (text, type, chapter, section, relevance, page, `citation_intent`: background/method/result_comparison)
+- `fragments` — extracted citation fragments (text, type, chapter, section, relevance, page, `citation_intent`: background/method/result_comparison, `embedding` BLOB float32, `embedding_model` TEXT)
 - `reference_gaps` — missing references from bibliographies (status: open/resolved, score, `citation_intent`, intent-weighted scoring)
 - `citation_links` — citation graph: source_id → target (title_hash MD5 for dedup, citation_intent, in_library flag)
 - `daily_plans` — generated daily plans

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1001,12 +1001,14 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
 @click.argument("citekeys", required=False, nargs=-1)
 @click.option("--dry-run", is_flag=True, help="Show how many would be embedded without calling API")
 @click.option("--backend", type=click.Choice(["s2", "local", "openai"]), help="Override embedding backend")
+@click.option("--fragments", is_flag=True, help="Embed fragments instead of sources")
 @click.pass_context
-def embed(ctx, citekeys, dry_run, backend):
+def embed(ctx, citekeys, dry_run, backend, fragments):
     """Backfill embeddings for sources with abstracts.
 
     Without CITEKEYS: embed all sources missing embeddings.
     With CITEKEYS: embed specific sources.
+    Use --fragments to embed fragment text instead of source title+abstract.
     Use --dry-run to preview without API calls.
     """
     kctx = _get_context(ctx)
@@ -1025,6 +1027,40 @@ def embed(ctx, citekeys, dry_run, backend):
             "Set embeddings.backend in config.yaml (s2, local, openai) "
             "or use --backend flag."
         )
+        return
+
+    if fragments:
+        # Fragment embedding mode
+        candidates = state.get_unembedded_fragments()
+        if not candidates:
+            console.print("[green]All fragments already have embeddings.[/green]")
+            return
+        if dry_run:
+            console.print(f"[blue]Would embed {len(candidates)} fragments[/blue]")
+            return
+
+        embedded = 0
+        failed = 0
+        from rich.progress import Progress
+        with Progress(console=console) as progress:
+            task = progress.add_task("Embedding fragments...", total=len(candidates))
+            for frag in candidates:
+                try:
+                    vec = emb.embed(frag["fragment_text"])
+                    if vec:
+                        state.save_fragment_embedding(frag["id"], vec, emb.model_name)
+                        embedded += 1
+                    else:
+                        failed += 1
+                except Exception as e:
+                    console.print(f"  [red]Fragment {frag['id']}: {e}[/red]")
+                    failed += 1
+                progress.advance(task)
+
+        console.print(f"\n[green]Embedded: {embedded}[/green]", end="")
+        if failed:
+            console.print(f" | [red]Failed: {failed}[/red]", end="")
+        console.print()
         return
 
     # Get candidates: sources with abstract but no embedding

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1844,7 +1844,17 @@ def ask(ctx, query, section, chapter):
             klemma_home=kctx.klemma_home,
             project_name=kctx.project_name,
             project_root=kctx.project_root,
+            embeddings=kctx.embeddings,
+            query=query,
         )
+
+    # Show RAG status
+    if kctx.embeddings:
+        frag_stats = state.get_fragment_embedding_stats()
+        if frag_stats["embedded"] > 0:
+            console.print(f"[dim]RAG: {frag_stats['embedded']} fragment embeddings available[/dim]")
+        else:
+            console.print("[dim]RAG: no fragment embeddings (run klemma embed --fragments)[/dim]")
 
     console.print(f"[dim]Query: {query}[/dim]")
 

--- a/src/klemma/repositories/CLAUDE.md
+++ b/src/klemma/repositories/CLAUDE.md
@@ -37,10 +37,15 @@ Source lifecycle, sections, Zotero key management, vault sync.
 - `sync_source_sections()` — vault frontmatter bidirectional sync
 - `rename_source()`, `delete_source()` — cascade operations
 
-### fragments.py (~120 lines)
-Fragment CRUD and citation intent coverage.
+### fragments.py (~250 lines)
+Fragment CRUD, citation intent coverage, and fragment-level embeddings.
 - `save_fragments()`, `get_fragments()`, `get_fragment_stats()`
 - `get_intent_coverage()` — section x intent matrix
+- `save_fragment_embedding()` — store vector BLOB (struct.pack float32)
+- `get_fragment_embeddings(model?)` — return `{fragment_id: vector}`
+- `get_fragment_embedding_stats()` — coverage stats (total, embedded, by model)
+- `get_unembedded_fragments()` — fragments missing embeddings
+- `retrieve_similar_fragments(query_embedding, top_k, model?)` — top-K cosine retrieval
 
 ### embeddings_store.py (~100 lines)
 Vector BLOB storage with model versioning.

--- a/src/klemma/repositories/fragments.py
+++ b/src/klemma/repositories/fragments.py
@@ -1,5 +1,6 @@
 """Fragment repository — CRUD and intent coverage stats."""
 
+import struct
 from typing import Optional
 
 from .base import BaseRepository
@@ -134,3 +135,117 @@ class FragmentRepository(BaseRepository):
                     result[sec][intent] = row["cnt"]
                     result[sec]["total"] += row["cnt"]
             return result
+
+    def save_fragment_embedding(
+        self, fragment_id: int, embedding: list[float], model: str
+    ):
+        """Store fragment embedding vector as BLOB with model name."""
+        blob = struct.pack(f"{len(embedding)}f", *embedding)
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE fragments SET embedding=?, embedding_model=? WHERE id=?",
+                (blob, model, fragment_id),
+            )
+
+    def get_fragment_embeddings(
+        self, model: Optional[str] = None
+    ) -> dict[int, list[float]]:
+        """Get all fragment embeddings, optionally filtered by model.
+        Returns {fragment_id: vector}.
+        """
+        with self._conn() as conn:
+            if model:
+                cur = conn.execute(
+                    "SELECT id, embedding FROM fragments "
+                    "WHERE embedding IS NOT NULL AND embedding_model=?",
+                    (model,),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT id, embedding FROM fragments WHERE embedding IS NOT NULL"
+                )
+            result = {}
+            for row in cur.fetchall():
+                blob = row["embedding"]
+                n = len(blob) // 4
+                result[row["id"]] = list(struct.unpack(f"{n}f", blob))
+            return result
+
+    def get_fragment_embedding_stats(self) -> dict:
+        """Get fragment embedding coverage stats."""
+        with self._conn() as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) as cnt FROM fragments"
+            ).fetchone()["cnt"]
+            embedded = conn.execute(
+                "SELECT COUNT(*) as cnt FROM fragments WHERE embedding IS NOT NULL"
+            ).fetchone()["cnt"]
+            models: dict[str, int] = {}
+            cur = conn.execute(
+                "SELECT embedding_model, COUNT(*) as cnt FROM fragments "
+                "WHERE embedding IS NOT NULL GROUP BY embedding_model"
+            )
+            for row in cur.fetchall():
+                models[row["embedding_model"] or "unknown"] = row["cnt"]
+            return {"total": total, "embedded": embedded, "models": models}
+
+    def get_unembedded_fragments(self, limit: int = 100000) -> list[dict]:
+        """Get fragments without embeddings. Returns id, source_id, fragment_text."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT f.id, f.source_id, f.fragment_text, s.id as citekey
+                   FROM fragments f
+                   JOIN sources s ON f.source_id = s.id
+                   WHERE f.embedding IS NULL
+                   LIMIT ?""",
+                (limit,),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
+    def retrieve_similar_fragments(
+        self,
+        query_embedding: list[float],
+        top_k: int = 10,
+        model: Optional[str] = None,
+    ) -> list[dict]:
+        """Retrieve top-K fragments by cosine similarity to query vector.
+        Returns fragment dicts enriched with 'similarity' and 'citekey' fields.
+        """
+        from ..embeddings import cosine_similarity
+
+        all_emb = self.get_fragment_embeddings(model=model)
+        if not all_emb:
+            return []
+
+        scored: list[tuple[int, float]] = []
+        for frag_id, vec in all_emb.items():
+            sim = cosine_similarity(query_embedding, vec)
+            scored.append((frag_id, sim))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+        top_ids = scored[:top_k]
+
+        if not top_ids:
+            return []
+
+        with self._conn() as conn:
+            placeholders = ",".join("?" * len(top_ids))
+            id_list = [t[0] for t in top_ids]
+            cur = conn.execute(
+                f"""SELECT f.id, f.source_id, f.fragment_text, f.fragment_type,
+                           f.chapter, f.section, f.relevance_score, f.usage_hint,
+                           f.page_number, f.citation_intent, s.id as citekey
+                    FROM fragments f
+                    JOIN sources s ON f.source_id = s.id
+                    WHERE f.id IN ({placeholders})""",
+                id_list,
+            )
+            frag_map = {row["id"]: dict(row) for row in cur.fetchall()}
+
+        results = []
+        for frag_id, sim in top_ids:
+            if frag_id in frag_map:
+                frag = frag_map[frag_id]
+                frag["similarity"] = round(sim, 4)
+                results.append(frag)
+        return results

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -38,9 +38,9 @@ Library health analysis. Three modes: `status` (health), `recommend` (section-fo
 - Prune mode: `prompts/librarian_prune.md` → AI generates drop/maybe verdicts → `state.save_prune_verdicts()`
 - `list_prune_verdicts()` / `clear_prune_verdict()` — CLI for browsing/clearing verdicts
 
-### agent.py (212 lines)
+### agent.py (~230 lines)
 Builds full project context for interactive Claude sessions.
-- `build_agent_context(project_root=...)` — gathers sources, coverage, gaps, fragments, plan, reading queue + scans project_root for reports/files → `prompts/agent.md` → system prompt
+- `build_agent_context(project_root=..., embeddings=?, query=?)` — gathers sources, coverage, gaps, fragments, plan, reading queue + scans project_root for reports/files → optional fragment RAG (embeds query → top-K retrieval) → `prompts/agent.md` → system prompt
 - `_scan_project_reports(project_root)` — finds Outline/Research/Library/Agent reports + project files (.md, .tex, .bib, .pdf, .doc, .docx)
 - For Claude backend: launches `claude --system-prompt` interactively
 - For non-Claude backends: `ai.call()` with full context → terminal output

--- a/src/klemma/skills/agent.py
+++ b/src/klemma/skills/agent.py
@@ -78,6 +78,8 @@ def build_agent_context(
     klemma_home: Optional[Path] = None,
     project_name: str = "",
     project_root: Optional[Path] = None,
+    embeddings=None,
+    query: Optional[str] = None,
 ) -> str:
     """Build a rich system prompt with full research context for the agent.
 
@@ -170,6 +172,18 @@ def build_agent_context(
         report_index = scan["report_index"]
         project_file_list = scan["project_files"]
 
+    # Fragment RAG: retrieve relevant fragments when embeddings + query available
+    relevant_fragments = []
+    if embeddings and query:
+        try:
+            query_vec = embeddings.embed(query)
+            if query_vec:
+                relevant_fragments = state.retrieve_similar_fragments(
+                    query_vec, top_k=10, model=embeddings.model_name
+                )
+        except Exception:
+            logger.debug("Fragment RAG retrieval failed", exc_info=True)
+
     # Render prompt
     prompt_path = (
         resolve_prompt("agent.md", klemma_home)
@@ -206,6 +220,7 @@ def build_agent_context(
         outline_content=outline_content,
         report_index=report_index,
         project_file_list=project_file_list,
+        relevant_fragments=relevant_fragments,
         range=range,
     )
 

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -183,7 +183,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 4  # bump this when adding new migrations
+        target = 5  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -253,6 +253,19 @@ class StateManager:
                 "CREATE INDEX IF NOT EXISTS idx_benchmark_runs_paper "
                 "ON benchmark_runs(paper_citekey)"
             )
+
+        if version < 5:
+            existing_frag = {
+                row[1] for row in conn.execute("PRAGMA table_info(fragments)")
+            }
+            if "embedding" not in existing_frag:
+                conn.execute(
+                    "ALTER TABLE fragments ADD COLUMN embedding BLOB"
+                )
+            if "embedding_model" not in existing_frag:
+                conn.execute(
+                    "ALTER TABLE fragments ADD COLUMN embedding_model TEXT"
+                )
 
         conn.execute(f"PRAGMA user_version = {target}")
 
@@ -353,6 +366,23 @@ class StateManager:
 
     def get_intent_coverage(self) -> dict[str, dict[str, int]]:
         return self.fragments.get_intent_coverage()
+
+    def save_fragment_embedding(self, fragment_id: int, embedding: list[float], model: str):
+        return self.fragments.save_fragment_embedding(fragment_id, embedding, model)
+
+    def get_fragment_embeddings(self, model: Optional[str] = None) -> dict[int, list[float]]:
+        return self.fragments.get_fragment_embeddings(model)
+
+    def get_fragment_embedding_stats(self) -> dict:
+        return self.fragments.get_fragment_embedding_stats()
+
+    def get_unembedded_fragments(self, limit: int = 100000) -> list[dict]:
+        return self.fragments.get_unembedded_fragments(limit)
+
+    def retrieve_similar_fragments(
+        self, query_embedding: list[float], top_k: int = 10, model: Optional[str] = None
+    ) -> list[dict]:
+        return self.fragments.retrieve_similar_fragments(query_embedding, top_k, model)
 
     # ── Embedding delegation ──────────────────────────────────────────────
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (472 tests)
+## Current test suite (484 tests)
 - `test_errors.py` (33 lines) — `KlemmaAIError` hierarchy, `retryable` classification, cause chaining
 - `test_ai.py` (170 lines) — `extract_json()`, `AIProviderBase`, `AICallResult` dataclass, `call_with_meta()` base + Claude, `create_ai()` factory
 - `test_ai_litellm.py` (265 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry, `call_with_meta()` with structured error mapping + token extraction
@@ -14,8 +14,9 @@
 - `test_intent_scoring.py` (422 lines) — intent-weighted reference gap scoring, intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
 - `test_cli_init_outline.py` (37 lines) — `klemma init --outline` CLI behavior, AI-missing skip, no-outline no AI call
-- `test_cli_embed.py` (26 lines) — `klemma embed` multi-citekey CLI behavior and missing-key warnings
-- `test_repositories.py` (~130 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`)
+- `test_cli_embed.py` (~70 lines) — `klemma embed` multi-citekey CLI behavior, missing-key warnings, `--fragments` flag (embed + dry-run)
+- `test_repositories.py` (~240 lines) — repository composition, facade delegation, per-repo CRUD roundtrips, new public methods (`get_existing_source_ids`, `get_sources_without_embeddings`), fragment embedding save/retrieve roundtrip, embedding stats, unembedded fragments, top-K cosine retrieval
+- `test_agent_rag.py` (~80 lines) — 4 tests: agent context with fragments (RAG), without embeddings, no fragment embeddings, embed failure graceful degradation
 - `test_evaluation.py` (~320 lines) — 38 tests: pure metrics (intent_metrics, precision@K, recall@K, nDCG@K), dataset load/validate/roundtrip, runner integration (intent/gap/embedding benchmarks with seeded DB), export template, `test_run_gap_benchmark_with_reranked_gaps` (verifies reranked list bypasses DB)
 - `test_security_hardening.py` — path traversal and download safety tests
 - `test_benchmark_history.py` (179 lines) — 17 tests: benchmark run save/get roundtrip, ordering, paper filtering, latest_run, compare deltas, migration idempotency, schema version, build_results_summary, compute_dataset_hash

--- a/tests/test_agent_rag.py
+++ b/tests/test_agent_rag.py
@@ -1,0 +1,100 @@
+"""Tests for fragment RAG in agent context."""
+
+from unittest.mock import MagicMock
+
+
+def _make_state(tmp_path):
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+    sm.mark_completed("paper1", note_path="@paper1.md")
+    sm.save_fragments("paper1", [
+        {"text": "Ice forecast accuracy improved by 15%", "type": "result", "section": "1.1",
+         "citation_intent": "result_comparison"},
+    ])
+    frags = sm.get_fragments(source_id="paper1")
+    sm.save_fragment_embedding(frags[0]["id"], [1.0, 0.0, 0.0], "test-model")
+    return sm
+
+
+def test_agent_context_with_fragments(tmp_path):
+    """When embeddings + query provided, agent context includes relevant fragments."""
+    sm = _make_state(tmp_path)
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "test-model"
+    mock_emb.embed.return_value = [1.0, 0.0, 0.0]
+
+    from klemma.config import KlemmaConfig
+    from klemma.skills.agent import build_agent_context
+
+    config = KlemmaConfig()
+
+    context = build_agent_context(
+        config, sm, MagicMock(),
+        embeddings=mock_emb,
+        query="ice forecast validation",
+    )
+
+    assert "Relevant Fragments" in context
+    assert "Ice forecast accuracy improved by 15%" in context
+    assert "paper1" in context
+
+
+def test_agent_context_without_embeddings(tmp_path):
+    """Without embeddings, no fragment section in context."""
+    sm = _make_state(tmp_path)
+
+    from klemma.config import KlemmaConfig
+    from klemma.skills.agent import build_agent_context
+
+    config = KlemmaConfig()
+
+    context = build_agent_context(config, sm, MagicMock())
+
+    assert "Relevant Fragments" not in context
+
+
+def test_agent_context_no_fragment_embeddings(tmp_path):
+    """With embeddings but no fragment embeddings, no fragment section."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "test-model"
+    mock_emb.embed.return_value = [1.0, 0.0, 0.0]
+
+    from klemma.config import KlemmaConfig
+    from klemma.skills.agent import build_agent_context
+
+    config = KlemmaConfig()
+    context = build_agent_context(
+        config, sm, MagicMock(),
+        embeddings=mock_emb,
+        query="test query",
+    )
+
+    assert "Relevant Fragments" not in context
+
+
+def test_agent_context_embed_failure_graceful(tmp_path):
+    """If embedding provider fails, RAG degrades gracefully."""
+    sm = _make_state(tmp_path)
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "test-model"
+    mock_emb.embed.side_effect = RuntimeError("API down")
+
+    from klemma.config import KlemmaConfig
+    from klemma.skills.agent import build_agent_context
+
+    config = KlemmaConfig()
+    context = build_agent_context(
+        config, sm, MagicMock(),
+        embeddings=mock_emb,
+        query="test query",
+    )
+
+    # Should not crash, just no fragments
+    assert "Relevant Fragments" not in context

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 4
+        assert version == 5
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 4
+        assert version == 5
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_cli_embed.py
+++ b/tests/test_cli_embed.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -23,3 +24,64 @@ def test_embed_accepts_multiple_citekeys_and_warns_missing(tmp_path, monkeypatch
     assert "Missing citekeys: missing1" in result.output
     assert "Would embed 0 sources" in result.output
     assert "sources have no abstract" in result.output
+
+
+def test_embed_fragments_flag(tmp_path):
+    """klemma embed --fragments embeds un-embedded fragments."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["paper1"])
+    sm.mark_completed("paper1", "notes/paper1.md")
+    sm.save_fragments("paper1", [
+        {"text": "Ice forecast accuracy", "type": "result"},
+        {"text": "Neural networks for prediction", "type": "method"},
+    ])
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "test-model"
+    mock_emb.embed.return_value = [0.1, 0.2, 0.3]
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.embeddings = mock_emb
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = None
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["embed", "--fragments"])
+
+    assert result.exit_code == 0, result.output
+    assert "Embedded: 2" in result.output
+    assert mock_emb.embed.call_count == 2
+
+    # Verify fragments now have embeddings
+    stats = sm.get_fragment_embedding_stats()
+    assert stats["embedded"] == 2
+
+
+def test_embed_fragments_dry_run(tmp_path):
+    """klemma embed --fragments --dry-run shows count without embedding."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["paper1"])
+    sm.save_fragments("paper1", [{"text": "Fragment A", "type": "result"}])
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.embeddings = MagicMock()
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = None
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["embed", "--fragments", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Would embed 1 fragments" in result.output

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -183,3 +183,105 @@ class TestRepositoryComposition:
         deleted = state.delete_fragments("facade-del")
         assert deleted == 1
         assert state.fragments.get_fragment_stats()["total"] == 0
+
+
+def test_migration_v5_fragment_embedding_columns(tmp_path):
+    """Migration v5 adds embedding + embedding_model to fragments."""
+    import sqlite3
+
+    from klemma.state import StateManager
+    db = tmp_path / "test.db"
+    StateManager(db)
+    conn = sqlite3.connect(db)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(fragments)")}
+    conn.close()
+    assert "embedding" in cols
+    assert "embedding_model" in cols
+
+
+def test_fragment_embedding_save_retrieve_roundtrip(tmp_path):
+    """Save and retrieve a fragment embedding."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+    sm.save_fragments("paper1", [{"text": "Ice forecast accuracy improved", "type": "result"}])
+    frags = sm.get_fragments(source_id="paper1")
+    frag_id = frags[0]["id"]
+
+    vec = [0.1, 0.2, 0.3, 0.4]
+    sm.save_fragment_embedding(frag_id, vec, "test-model")
+
+    result = sm.get_fragment_embeddings(model="test-model")
+    assert frag_id in result
+    assert len(result[frag_id]) == 4
+    assert abs(result[frag_id][0] - 0.1) < 1e-5
+
+
+def test_fragment_embedding_stats(tmp_path):
+    """Fragment embedding coverage stats."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+    sm.save_fragments("paper1", [
+        {"text": "Fragment A", "type": "result"},
+        {"text": "Fragment B", "type": "method"},
+    ])
+    frags = sm.get_fragments(source_id="paper1")
+    sm.save_fragment_embedding(frags[0]["id"], [0.1, 0.2], "test-model")
+
+    stats = sm.get_fragment_embedding_stats()
+    assert stats["total"] >= 2
+    assert stats["embedded"] == 1
+    assert stats["models"]["test-model"] == 1
+
+
+def test_get_unembedded_fragments(tmp_path):
+    """Get fragments that don't have embeddings yet."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+    sm.save_fragments("paper1", [
+        {"text": "Fragment A", "type": "result"},
+        {"text": "Fragment B", "type": "method"},
+    ])
+    frags = sm.get_fragments(source_id="paper1")
+    sm.save_fragment_embedding(frags[0]["id"], [0.1, 0.2], "test-model")
+
+    unembedded = sm.get_unembedded_fragments()
+    assert len(unembedded) == 1
+    assert unembedded[0]["fragment_text"] == "Fragment B"
+
+
+def test_retrieve_similar_fragments(tmp_path):
+    """Top-K retrieval returns fragments ranked by cosine similarity."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    sm.register_sources(["paper1"])
+    sm.save_fragments("paper1", [
+        {"text": "Ice forecast validation methods", "type": "method", "section": "1.1"},
+        {"text": "Neural network architecture", "type": "method", "section": "2.1"},
+        {"text": "Satellite data processing", "type": "background", "section": "1.2"},
+    ])
+    frags = sm.get_fragments(source_id="paper1")
+
+    sm.save_fragment_embedding(frags[0]["id"], [1.0, 0.0, 0.0], "test")
+    sm.save_fragment_embedding(frags[1]["id"], [0.0, 1.0, 0.0], "test")
+    sm.save_fragment_embedding(frags[2]["id"], [0.7, 0.3, 0.0], "test")
+
+    query_vec = [1.0, 0.0, 0.0]
+    results = sm.retrieve_similar_fragments(query_vec, top_k=2, model="test")
+
+    assert len(results) == 2
+    assert results[0]["id"] == frags[0]["id"]
+    assert results[0]["similarity"] > 0.99
+    assert results[1]["id"] == frags[2]["id"]
+    assert "fragment_text" in results[0]
+    assert "citekey" in results[0]
+
+
+def test_retrieve_similar_fragments_empty(tmp_path):
+    """Retrieval with no embeddings returns empty list."""
+    from klemma.state import StateManager
+    sm = StateManager(tmp_path / "test.db")
+    results = sm.retrieve_similar_fragments([1.0, 0.0], top_k=5)
+    assert results == []


### PR DESCRIPTION
## Summary

- DB migration v5: `embedding BLOB` + `embedding_model TEXT` on fragments table
- `FragmentRepository`: 5 new methods (save/get/stats/unembedded/retrieve)
- Top-K cosine similarity retrieval for fragments
- `klemma embed --fragments` CLI command for batch embedding
- `build_agent_context()` enhanced with optional fragment RAG
- `klemma ask` shows RAG status and injects relevant fragments
- Backward compatible: no fragment embeddings = current behavior unchanged

Part of #28

## Release Note

### Problem
`klemma ask` provides the research agent with source metadata (citekey, quality score, fragment count) but no actual fragment text. The agent answers from general knowledge rather than grounded citations. With 2340+ extracted citation fragments, klemma holds rich evidence that remains invisible to the interactive agent.

### Academic Foundation
ILCiteR (Sahu & Ostendorf 2022) establishes fragment-level embeddings as the highest-quality lever for citation recommendation. SPECTER (Cohan et al. 2020) and SciRepEval (Singh et al. 2023) validate that scientific text embeddings generalize well to short passages. PaperQA (Lala et al. 2023) demonstrates that focused fragment context outperforms full-document retrieval for research question answering.

### Implementation
- **Migration v5** adds `embedding BLOB` and `embedding_model TEXT` columns to the `fragments` table, following the same `struct.pack` float32 pattern as source-level embeddings
- **FragmentRepository** gains 5 methods: `save_fragment_embedding()`, `get_fragment_embeddings()`, `get_fragment_embedding_stats()`, `get_unembedded_fragments()`, and `retrieve_similar_fragments()` (in-memory cosine similarity, ~7.5MB for 2500 fragments at 768-dim)
- **`klemma embed --fragments`** batch-embeds all un-embedded fragments using the configured `EmbeddingProvider`, passing `fragment_text` directly as input
- **`build_agent_context()`** accepts optional `embeddings` + `query` params: embeds the query → retrieves top-10 fragments → injects `## Relevant Fragments` section into `agent.md` with citekey, citation intent, and similarity score
- **Graceful fallback**: if embedding provider is unavailable, embed fails, or no fragments have embeddings, the agent prompt remains identical to current behavior

### Results
- 12 new tests (6 repository + 2 CLI + 4 agent RAG), total suite: 484 tests passing
- Lint clean (ruff)
- Zero behavior change for users without fragment embeddings configured

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 484 passed
- [ ] Manual: `klemma embed --fragments --dry-run` shows fragment count
- [ ] Manual: `klemma ask "query"` shows RAG status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)