### PR TITLE
feat: klemma init --non-interactive mode (#54)

### DIFF
--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -13,6 +13,7 @@ Click CLI entry point. Defines 16 commands + hidden aliases.
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
 - Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`
 - `init --outline` generates an outline after project setup (requires AI backend)
+- `init` non-interactive mode: `--name`, `--description`, `--keywords`, `--language` flags auto-skip wizard; `--non-interactive` is alias for `--no-input`
 - `--model` override available on: `research`, `ask`, `library`, `process` — overrides `cfg.ai.model` per invocation
 
 ### context.py (41 lines)
@@ -38,9 +39,9 @@ Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig` (with `
 - Selective inheritance: only `_INHERITED_KEYS = {"obsidian", "zotero", "ai", "embeddings"}` from parent projects
 - Default AI backend: `litellm` (was `claude`)
 
-### setup.py (304 lines)
-`klemma init` logic — creates per-directory `.klemma/` projects, `~/.klemma/` system config, and `~/.klemmarc.yaml` global config. Interactive wizard with auto-discovery.
-- `init_project(project_dir, project_type)` — creates `.klemma/`, `KLEMMA.md`, updates `.gitignore`
+### setup.py (338 lines)
+`klemma init` logic — creates per-directory `.klemma/` projects, `~/.klemma/` system config, and `~/.klemmarc.yaml` global config. Interactive wizard with auto-discovery; non-interactive mode via CLI flags.
+- `init_project(project_dir, project_type, values?)` — creates `.klemma/`, `KLEMMA.md`, updates `.gitignore`; accepts `InitValues` from wizard or CLI flags
 - `init_system(system_home)` — creates `~/.klemmarc.yaml` (0600, with api_keys template) + `~/.klemma/config.yaml` (legacy fallback)
 - `init_klemma_home()` — legacy alias for `init_system()`
 - Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -510,16 +510,24 @@ def main(ctx, config):
               help="Project type")
 @click.option("--global-only", is_flag=True, help="Only create/update ~/.klemma/ system config")
 @click.option("--no-input", is_flag=True, help="Skip interactive prompts, use defaults")
+@click.option("--non-interactive", is_flag=True, help="Alias for --no-input")
 @click.option("--force", is_flag=True, help="Re-run wizard even if project exists (prefills from current config)")
 @click.option("--outline", is_flag=True, help="Generate outline after init (requires AI)")
+@click.option("--name", "project_name", default=None, help="Project title (non-interactive)")
+@click.option("--description", "-d", default=None, help="Project description (non-interactive)")
+@click.option("--keywords", "-k", default=None, help="Comma-separated keywords (non-interactive)")
+@click.option("--language", "-l", default=None, help="AI language: ru or en (non-interactive)")
 @click.pass_context
-def init(ctx, project_type, global_only, no_input, force, outline):
+def init(ctx, project_type, global_only, no_input, non_interactive, force, outline,
+         project_name, description, keywords, language):
     """Initialize a new klemma project in current directory.
 
     Creates .klemma/ and KLEMMA.md in the current directory.
     Also ensures ~/.klemma/ system config exists.
 
     Runs an interactive setup wizard by default. Use --no-input to skip prompts.
+    Pass --name, --description, --keywords, --language for non-interactive setup
+    with custom values (auto-implies --no-input).
 
     \b
     Examples:
@@ -528,8 +536,18 @@ def init(ctx, project_type, global_only, no_input, force, outline):
       klemma init --no-input         # skip prompts, use defaults
       klemma init --force            # re-run wizard, prefill from existing config
       klemma init --global-only      # only create system config
+      klemma init --type paper --name "My Paper" --language en
     """
-    from .setup import init_project, init_system
+    from .setup import InitValues, init_project, init_system
+
+    # --non-interactive is an alias for --no-input
+    if non_interactive:
+        no_input = True
+
+    # If any value flags provided, auto-imply non-interactive mode
+    has_value_flags = any(v is not None for v in [project_name, description, keywords, language])
+    if has_value_flags:
+        no_input = True
 
     system_home = ensure_system_home()
 
@@ -567,6 +585,16 @@ def init(ctx, project_type, global_only, no_input, force, outline):
     if not no_input:
         values = _interactive_init(project_type, prefill=prefill)
         project_type = values.project_type
+    elif has_value_flags:
+        # Build InitValues from CLI flags
+        kw_list = [k.strip() for k in keywords.split(",") if k.strip()] if keywords else []
+        values = InitValues(
+            project_type=project_type,
+            title=project_name or "",
+            description=description or "",
+            keywords=kw_list,
+            language=language or "ru",
+        )
 
     result = init_project(project_dir, project_type=project_type, values=values)
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -14,6 +14,7 @@
 - `test_intent_scoring.py` (~490 lines) — intent-weighted reference gap scoring, configurable section weights (`TestSectionWeights`), intent coverage matrix, fragment citation intent classification
 - `test_interactive_init.py` (347 lines) — interactive `klemma init` wizard, auto-discovery, config generation
 - `test_cli_init_outline.py` (37 lines) — `klemma init --outline` CLI behavior, AI-missing skip, no-outline no AI call
+- `test_cli_init_non_interactive.py` (~100 lines) — 6 tests: `klemma init` non-interactive mode (#54) — --name creates project, CLI flags populate config.yaml, KLEMMA.md content, --non-interactive alias, minimal init, no wizard prompts
 - `test_cli_embed.py` (~70 lines) — `klemma embed` multi-citekey CLI behavior, missing-key warnings, `--fragments` flag (embed + dry-run)
 - `test_cli_model_override.py` (~96 lines) — `--model` CLI override: verifies override reaches `create_ai()`, default model preserved without flag
 - `test_db_inheritance.py` (~195 lines) — 15 tests: DB inheritance (#55) — parent sources/fragments/embeddings/gaps visible through child, child wins on duplicate, write isolation, coverage stats aggregation, RAG across both DBs, disabled/absent parent

--- a/tests/test_cli_init_non_interactive.py
+++ b/tests/test_cli_init_non_interactive.py
@@ -1,0 +1,118 @@
+"""Tests for klemma init --non-interactive mode (#54).
+
+Verifies CLI flags (--name, --description, --keywords, --language)
+create projects without TTY interaction.
+"""
+
+import yaml
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+
+
+def test_init_with_name_creates_project(monkeypatch, tmp_path):
+    """--name flag auto-implies non-interactive and sets title."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(klemma_cli, [
+            "init", "--type", "paper", "--name", "My Paper",
+        ])
+
+    assert result.exit_code == 0
+    assert "Initialized klemma paper project" in result.output
+
+
+def test_init_non_interactive_creates_config_with_values(monkeypatch, tmp_path):
+    """CLI flags populate config.yaml correctly."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem() as td:
+        result = runner.invoke(klemma_cli, [
+            "init", "--type", "paper",
+            "--name", "Ice Sheet Analysis",
+            "--description", "Modeling ice sheet dynamics",
+            "--keywords", "ice sheets, climate, GrIS",
+            "--language", "en",
+        ])
+        assert result.exit_code == 0
+
+        from pathlib import Path
+
+        cfg = yaml.safe_load((Path(td) / ".klemma" / "config.yaml").read_text())
+        assert cfg["project"]["type"] == "paper"
+        assert cfg["project"]["title"] == "Ice Sheet Analysis"
+        assert cfg["project"]["description"] == "Modeling ice sheet dynamics"
+        assert cfg["project"]["priority_terms"] == ["ice sheets", "climate", "GrIS"]
+        assert cfg["ai"]["language"] == "en"
+
+
+def test_init_non_interactive_creates_klemma_md(monkeypatch, tmp_path):
+    """CLI flags populate KLEMMA.md with title and keywords."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem() as td:
+        runner.invoke(klemma_cli, [
+            "init", "--type", "paper",
+            "--name", "My Research Paper",
+            "--keywords", "NLP, transformers",
+        ])
+
+        from pathlib import Path
+
+        md = (Path(td) / "KLEMMA.md").read_text()
+        assert "My Research Paper" in md
+        assert "NLP, transformers" in md
+
+
+def test_init_non_interactive_flag_alias(monkeypatch, tmp_path):
+    """--non-interactive is an alias for --no-input."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(klemma_cli, [
+            "init", "--non-interactive", "--type", "thesis",
+        ])
+
+    assert result.exit_code == 0
+    assert "Initialized klemma thesis project" in result.output
+
+
+def test_init_non_interactive_minimal(monkeypatch, tmp_path):
+    """--name alone is sufficient for non-interactive init."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    with runner.isolated_filesystem() as td:
+        result = runner.invoke(klemma_cli, [
+            "init", "--name", "Quick Project",
+        ])
+        assert result.exit_code == 0
+
+        from pathlib import Path
+
+        cfg = yaml.safe_load((Path(td) / ".klemma" / "config.yaml").read_text())
+        assert cfg["project"]["title"] == "Quick Project"
+        # Default language is ru
+        assert cfg["ai"]["language"] == "ru"
+
+
+def test_init_non_interactive_no_wizard_prompts(monkeypatch, tmp_path):
+    """Value flags must not trigger interactive prompts."""
+    runner = CliRunner()
+    monkeypatch.setenv("KLEMMA_HOME", str(tmp_path / ".klemma_home"))
+
+    # Run without TTY input — should succeed without prompting
+    with runner.isolated_filesystem():
+        result = runner.invoke(klemma_cli, [
+            "init", "--type", "paper", "--name", "Test",
+        ], input=None)
+
+    assert result.exit_code == 0
+    # No wizard output
+    assert "Project type" not in result.output
+    assert "Project title" not in result.output


### PR DESCRIPTION
Part of #54

## Summary
- Add `--name`, `--description`, `--keywords`, `--language` CLI flags to `klemma init`
- When any value flag is provided, auto-skip interactive wizard and build config from flags
- `--non-interactive` added as alias for `--no-input`
- 6 new tests covering config generation, KLEMMA.md population, alias, and no-wizard verification

Usage:
```bash
klemma init --type paper --name "My Paper" --language en
klemma init --type paper --name "Ice Sheets" --description "Analysis of dynamics" --keywords "ice, climate"
klemma init --non-interactive --type thesis
```

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/test_cli_init_non_interactive.py -q` — 6 pass
- [x] `python -m pytest tests/ -q` — 559 pass

## Release Note

### Problem
`klemma init` required an interactive TTY to run its setup wizard. This made it impossible to create projects from scripts, CI/CD pipelines, or the upcoming CiteQ SaaS backend (WebContext). The only workaround was manually creating `.klemma/config.yaml` and `KLEMMA.md`.

### Academic Foundation
Non-interactive project initialization is a standard requirement for research tool automation. CiteQ SaaS roadmap requires programmatic project creation for multi-tenant user onboarding, following patterns from tools like `git init` and `npm init -y`.

### Implementation
- `src/klemma/cli.py`: Added 4 new CLI options (`--name`, `--description`, `--keywords`, `--language`) and `--non-interactive` alias. When value flags are present, builds `InitValues` from CLI args instead of launching wizard.
- No changes to `setup.py` — reuses existing `InitValues` dataclass and `init_project()` function.
- `tests/test_cli_init_non_interactive.py`: 6 tests covering full lifecycle.

### Results
- 559 tests pass (+6 new), lint clean
- `klemma init --type paper --name "Test" --language en` works without TTY
- Config and KLEMMA.md populated correctly from CLI flags
- Zero breaking changes to existing interactive workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)