### PR TITLE
fix: save klemma ask output to notes/agents/

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -145,7 +145,7 @@ Rules:
 2. When searching for papers, follow the Academic Search section below
 3. Reference @citekey when mentioning known sources
 4. When working with project files — path: {{ project_root or vault_path }}
-5. **ALWAYS save query results to a note** — even if the user doesn't explicitly ask
+5. **Do NOT save query results to a file** — the CLI saves output automatically to `notes/agents/`. Do not create Agent_*.md files yourself.
 6. **NEVER modify config files** (.klemma/config.yaml, ~/.klemma/config.yaml, KLEMMA.md) without explicit user request. Config is managed via `klemma init` and manual editing. If a config value seems missing, check `klemma info` first — it may be inherited from parent/system config via deep merge.
 7. **NEVER write custom scripts** that bypass klemma CLI (no direct SQLite writes, no raw file manipulation of .klemma/ or Zotero storage). If a klemma command fails, report the error to the user — do not work around it.
 8. **Always use `klemma` directly** — not `python -m klemma`. The CLI entry point is installed and available in PATH.
@@ -153,12 +153,6 @@ Rules:
 {% if parent_context %}
 9. **Distinguish parent and current project context.** The parent project context is provided for background only. Your primary focus is the current project ({{ project_type }}). Structure your output according to the current project's structure, not the parent's.
 {% endif %}
-
-Saving results:
-{% if project_root %}- Path: {{ project_root }}/notes/agents/Agent_{% if project_name %}{{ project_name }}_{% endif %}{{ today }}_<brief_name>.md
-{% else %}- Path: {{ vault_path }}/Agent/Agent_{% if project_name %}{{ project_name }}_{% endif %}{{ today }}_<brief_name>.md
-{% endif %}- Format: YAML frontmatter (type: agent, date: {{ today }}, query: <user query>) + markdown body
-- For long sessions with multiple queries — use unique suffixes (_literature, _search, _analysis, etc.)
 
 ## Academic Search
 

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -2016,10 +2016,6 @@ def ask(ctx, query, section, chapter, model):
 
     from .skills.agent import build_agent_context, update_agents_index
 
-    # Ensure notes/agents/ exists before launching agent
-    if kctx.project_root:
-        (kctx.project_root / "notes" / "agents").mkdir(parents=True, exist_ok=True)
-
     with console.status("Сборка контекста исследования", spinner="dots"):
         context = build_agent_context(
             cfg, state, vault, section=section, chapter=chapter,
@@ -2042,10 +2038,22 @@ def ask(ctx, query, section, chapter, model):
 
     console.print(f"[dim]Query: {query}[/dim]")
 
+    response = None
     if ai.interactive_available:
-        import subprocess
+        import subprocess as _sp
 
-        subprocess.run(["claude", "--system-prompt", context, query])
+        result = _sp.run(
+            ["claude", "-p", "--model", cfg.ai.model, "--system-prompt", context, query],
+            capture_output=True, text=True, timeout=cfg.ai.timeout,
+        )
+        response = result.stdout
+        if response:
+            console.print(response)
+        else:
+            stderr = (result.stderr or "").strip()
+            console.print("[red]Не удалось получить ответ.[/red]")
+            if stderr:
+                console.print(f"[dim]{stderr[:300]}[/dim]")
     else:
         with console.status("Генерация ответа", spinner="dots"):
             response = ai.call(system=context, user=query, max_tokens=8192)
@@ -2054,13 +2062,32 @@ def ask(ctx, query, section, chapter, model):
         else:
             console.print("[red]Не удалось получить ответ.[/red]")
 
-    # Update AGENTS.md index after session
-    if kctx.project_root:
+    # Save agent response to notes/agents/
+    if response and kctx.project_root:
+        from datetime import date as _date
+
+        slug = query[:40].strip().replace(" ", "_").replace("/", "-")
+        slug = "".join(c for c in slug if c.isalnum() or c in "_-")
+        today = _date.today().isoformat()
+        project_tag = f"{kctx.project_name}_" if kctx.project_name else ""
+        filename = f"Agent_{project_tag}{today}_{slug}.md"
+
+        agents_dir = kctx.project_root / "notes" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        save_path = agents_dir / filename
+
+        frontmatter = (
+            f"---\ntype: agent\ndate: {today}\n"
+            f"query: \"{query[:200]}\"\n---\n\n"
+        )
+        save_path.write_text(frontmatter + response, encoding="utf-8")
+        console.print(f"\n[green]Saved: {save_path}[/green]")
+
         idx = update_agents_index(kctx.project_root)
         if idx:
             console.print("[dim]Updated notes/AGENTS.md[/dim]")
 
-    console.print("\n[dim]Сессия агента завершена.[/dim]")
+    console.print("[dim]Сессия агента завершена.[/dim]")
 
 
 @main.group(invoke_without_command=True)


### PR DESCRIPTION
## Summary
- `klemma ask` now auto-saves agent responses to `notes/agents/Agent_{project}_{date}_{slug}.md`
- Both backends (claude CLI and litellm) capture and save output with YAML frontmatter
- Interactive claude path switched from `claude --system-prompt` (no capture) to `claude -p --system-prompt` (captured)
- Prints saved file path after each query

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 559 passed
- [x] Smoke: `klemma ask "test query"` → verify file created in `notes/agents/`
- [ ] Smoke: verify frontmatter includes `type: agent`, `date`, `query`

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)