### PR TITLE
feat: source_role classification — author publications vs external

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1867,6 +1867,19 @@ def status(ctx, verbose, chapter):
                         f"  [green]x{ref['cite_count']}[/green]  @{ref['target_citekey']}"
                     )
 
+    # --- Author publications (ГОСТ Р 7.0.11-2011) ---
+    author_counts = state.get_author_publication_counts()
+    if author_counts:
+        from .source_role import ROLE_LABELS, format_gost_phrase
+        console.print()
+        console.print("[bold]Публикации автора[/bold]")
+        for role, cnt in sorted(author_counts.items()):
+            label = ROLE_LABELS.get(role, role)
+            console.print(f"  {label}: [green]{cnt}[/green]")
+        gost = format_gost_phrase(author_counts)
+        if gost:
+            console.print(f"\n  [dim italic]{gost}[/dim italic]")
+
     # --- Recommended actions ---
     _emb = state.get_embedding_stats()
     _prune = state.get_prune_summary()
@@ -1895,6 +1908,37 @@ def coverage(ctx):
 def gaps(ctx, min_sources):
     """[alias] → status --verbose"""
     ctx.invoke(status, verbose=True)
+
+
+@main.group(invoke_without_command=True)
+@click.pass_context
+def source(ctx):
+    """Manage individual sources."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+main.add_command(source)
+
+
+@source.command()
+@click.argument("citekey")
+@click.argument("role", type=click.Choice([
+    "external", "author_vak", "author_scopus", "author_wos",
+    "author_conf", "author_patent", "author_program", "author_other",
+]))
+@click.pass_context
+def role(ctx, citekey, role):
+    """Assign a source_role to a source (e.g. author_vak, author_conf)."""
+    kctx = _get_context(ctx)
+    src = kctx.state.get_source(citekey)
+    if not src:
+        console.print(f"[red]Source '{citekey}' not found.[/red]")
+        raise SystemExit(1)
+    kctx.state.set_source_role(citekey, role)
+    from .source_role import ROLE_LABELS
+    label = ROLE_LABELS.get(role, role)
+    console.print(f"[green]@{citekey}[/green] → {label}")
 
 
 @main.command()

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -446,3 +446,21 @@ class SourceRepository(BaseRepository):
             "new_registered": new_registered,
             "unchanged": unchanged,
         }
+
+    def set_source_role(self, source_id: str, role: str):
+        """Set the source_role for a source."""
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE sources SET source_role = ? WHERE id = ?",
+                (role, source_id),
+            )
+
+    def get_author_publication_counts(self) -> dict[str, int]:
+        """Count sources by author role (excluding 'external')."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT source_role, COUNT(*) as cnt FROM sources "
+                "WHERE source_role != 'external' AND source_role IS NOT NULL "
+                "GROUP BY source_role"
+            )
+            return {row["source_role"]: row["cnt"] for row in cur.fetchall()}

--- a/src/klemma/source_role.py
+++ b/src/klemma/source_role.py
@@ -1,0 +1,69 @@
+"""Source role classification — author publications vs external sources (ГОСТ Р 7.0.11-2011)."""
+
+from enum import Enum
+
+
+class SourceRole(str, Enum):
+    """Classification of a source's role in the dissertation bibliography."""
+
+    EXTERNAL = "external"
+    AUTHOR_VAK = "author_vak"
+    AUTHOR_SCOPUS = "author_scopus"
+    AUTHOR_WOS = "author_wos"
+    AUTHOR_CONF = "author_conf"
+    AUTHOR_PATENT = "author_patent"
+    AUTHOR_PROGRAM = "author_program"
+    AUTHOR_OTHER = "author_other"
+
+    @classmethod
+    def author_roles(cls) -> list["SourceRole"]:
+        """All roles that represent author's own publications."""
+        return [r for r in cls if r != cls.EXTERNAL]
+
+    @classmethod
+    def values(cls) -> list[str]:
+        return [r.value for r in cls]
+
+
+# Human-readable labels for status display
+ROLE_LABELS: dict[str, str] = {
+    "author_vak": "ВАК",
+    "author_scopus": "Scopus",
+    "author_wos": "Web of Science",
+    "author_conf": "Конференции",
+    "author_patent": "Патенты",
+    "author_program": "Свидетельства о программах для ЭВМ",
+    "author_other": "Прочие",
+}
+
+
+def format_gost_phrase(counts: dict[str, int]) -> str:
+    """Generate ГОСТ Р 7.0.11-2011 publication summary phrase.
+
+    Example: 'Основные результаты изложены в 12 печатных изданиях,
+    3 из которых в журналах ВАК, 2 — в Scopus, 1 — в тезисах докладов'
+    """
+    total = sum(counts.values())
+    if total == 0:
+        return ""
+
+    parts = []
+    if counts.get("author_vak", 0):
+        parts.append(f"{counts['author_vak']} из которых в журналах ВАК")
+    if counts.get("author_scopus", 0):
+        parts.append(f"{counts['author_scopus']} — в Scopus")
+    if counts.get("author_wos", 0):
+        parts.append(f"{counts['author_wos']} — в Web of Science")
+    if counts.get("author_conf", 0):
+        parts.append(f"{counts['author_conf']} — в тезисах докладов")
+    if counts.get("author_patent", 0):
+        parts.append(f"{counts['author_patent']} — патентов")
+    if counts.get("author_program", 0):
+        parts.append(f"{counts['author_program']} — свидетельств о программах для ЭВМ")
+    if counts.get("author_other", 0):
+        parts.append(f"{counts['author_other']} — прочих публикаций")
+
+    phrase = f"Основные результаты изложены в {total} печатных изданиях"
+    if parts:
+        phrase += ", " + ", ".join(parts)
+    return phrase + "."

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -206,7 +206,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 7  # bump this when adding new migrations
+        target = 8  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -343,6 +343,15 @@ class StateManager:
                 "ON section_type_map(section_type)"
             )
 
+        if version < 8:
+            existing_src = {
+                row[1] for row in conn.execute("PRAGMA table_info(sources)")
+            }
+            if "source_role" not in existing_src:
+                conn.execute(
+                    "ALTER TABLE sources ADD COLUMN source_role TEXT DEFAULT 'external'"
+                )
+
         conn.execute(f"PRAGMA user_version = {target}")
 
     # ── Source delegation ─────────────────────────────────────────────────
@@ -394,6 +403,12 @@ class StateManager:
     def update_source_info(self, source_id: str, title: str = "", authors: str = "",
                            year: Optional[int] = None, abstract: str = "", doi: str = ""):
         return self.sources.update_source_info(source_id, title, authors, year, abstract, doi)
+
+    def set_source_role(self, source_id: str, role: str):
+        return self.sources.set_source_role(source_id, role)
+
+    def get_author_publication_counts(self) -> dict[str, int]:
+        return self.sources.get_author_publication_counts()
 
     def get_existing_source_ids(self) -> set[str]:
         return self.sources.get_existing_source_ids()

--- a/tests/test_section_types.py
+++ b/tests/test_section_types.py
@@ -191,7 +191,7 @@ class TestMigrationV7:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 7
+        assert version >= 7
 
     def test_section_type_columns_exist(self, state):
         import sqlite3

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -1,0 +1,90 @@
+"""Tests for source_role classification (#85)."""
+
+import sqlite3
+
+from klemma.source_role import SourceRole, format_gost_phrase
+from klemma.state import StateManager
+
+
+def _make_db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    sm = StateManager(db_path)
+    return sm
+
+
+def test_source_role_enum_values():
+    """SourceRole has 8 values."""
+    assert len(SourceRole) == 8
+    assert SourceRole.EXTERNAL.value == "external"
+    assert SourceRole.AUTHOR_VAK.value == "author_vak"
+
+
+def test_source_role_author_roles():
+    """author_roles() excludes external."""
+    roles = SourceRole.author_roles()
+    assert SourceRole.EXTERNAL not in roles
+    assert len(roles) == 7
+
+
+def test_migration_v8_adds_source_role(tmp_path):
+    """DB migration v8 adds source_role column with default 'external'."""
+    _make_db(tmp_path)
+    db_path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db_path)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
+    assert "source_role" in cols
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    assert version == 8
+    conn.close()
+
+
+def test_set_source_role(tmp_path):
+    """set_source_role updates the column."""
+    sm = _make_db(tmp_path)
+    sm.register_sources(["@testkey"])
+    sm.set_source_role("@testkey", "author_vak")
+    src = sm.get_source("@testkey")
+    assert src["source_role"] == "author_vak"
+
+
+def test_set_source_role_default_external(tmp_path):
+    """New sources default to 'external'."""
+    sm = _make_db(tmp_path)
+    sm.register_sources(["@newkey"])
+    src = sm.get_source("@newkey")
+    assert src["source_role"] == "external"
+
+
+def test_get_author_publication_counts(tmp_path):
+    """get_author_publication_counts groups by role, excludes external."""
+    sm = _make_db(tmp_path)
+    sm.register_sources(["@a", "@b", "@c", "@d"])
+    sm.set_source_role("@a", "author_vak")
+    sm.set_source_role("@b", "author_vak")
+    sm.set_source_role("@c", "author_conf")
+    # @d stays external — should not appear
+    counts = sm.get_author_publication_counts()
+    assert counts == {"author_vak": 2, "author_conf": 1}
+
+
+def test_format_gost_phrase_full():
+    """ГОСТ phrase includes all role counts."""
+    counts = {"author_vak": 3, "author_scopus": 2, "author_conf": 1}
+    phrase = format_gost_phrase(counts)
+    assert "6 печатных изданиях" in phrase
+    assert "3 из которых в журналах ВАК" in phrase
+    assert "2 — в Scopus" in phrase
+    assert "1 — в тезисах докладов" in phrase
+    assert phrase.endswith(".")
+
+
+def test_format_gost_phrase_empty():
+    """Empty counts → empty string."""
+    assert format_gost_phrase({}) == ""
+
+
+def test_format_gost_phrase_single_role():
+    """Single role still formats correctly."""
+    phrase = format_gost_phrase({"author_vak": 5})
+    assert "5 печатных изданиях" in phrase
+    assert "5 из которых в журналах ВАК" in phrase


### PR DESCRIPTION
## Summary

- `SourceRole` enum with 8 values: `external` (default) + 7 author categories (ВАК, Scopus, WoS, conferences, patents, programs, other)
- DB migration v7→v8: `source_role` column on `sources` table
- `klemma source role <citekey> <role>` — assign role to a source
- `klemma status` — new "Публикации автора" section with per-role counts + ГОСТ Р 7.0.11-2011 phrase generation
- `format_gost_phrase()` — generates standard bibliographic summary ("Основные результаты изложены в N печатных изданиях...")

Part of #85

## Test plan

- [x] `ruff check` passes
- [x] 9 new tests in `test_source_role.py` — all pass
- [x] Full suite — no new failures
- [ ] Manual: `klemma source role @key author_vak` → updates role
- [ ] Manual: `klemma status` → shows author section when author sources exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)