### PR TITLE
feat: gaps suggest, search providers, acquire hardening

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -107,12 +107,19 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
             api_keys=cfg.ai._resolved_api_keys or None,
         )
 
+    # Search: create provider if configured (lazy init in `gaps suggest` otherwise)
+    search_provider = None
+    if cfg.search.backend:
+        from .search import create_search
+        search_provider = create_search(cfg.search.model_dump())
+
     dissertation_context = load_project_context(project_chain, cfg)
     available_tags = load_available_tags(klemma_home, cfg, project_chain=project_chain)
 
     return KlemmaContext(
         config=cfg, state=state, vault=vault, library=library,
         embeddings=emb_provider,
+        search=search_provider,
         project=project, project_name=project_root.name,
         klemma_home=klemma_home,
         dissertation_context=dissertation_context,
@@ -1301,8 +1308,21 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
 
     entry = library.entries.get(citekey)
     if not entry:
-        from .literature.models import ZoteroEntry
-        entry = ZoteroEntry(id=citekey, title=citekey)
+        from .literature.models import Author, ZoteroEntry
+        # Fall back to DB metadata from acquire (title, authors, year)
+        db_title = source.get("title", "") if source else ""
+        db_authors = source.get("authors", "") if source else ""
+        db_year = source.get("year") if source else None
+        db_abstract = source.get("abstract", "") if source else ""
+        issued = {"date-parts": [[db_year]]} if db_year else None
+        authors = [Author(literal=a.strip()) for a in db_authors.split(",") if a.strip()] if db_authors else []
+        entry = ZoteroEntry(
+            id=citekey,
+            title=db_title or citekey,
+            abstractNote=db_abstract,
+            author=authors,
+            issued=issued,
+        )
 
     if not quiet:
         console.print(f"[blue]Processing: {entry.authors_str} ({entry.year or '?'})[/blue] [dim]@{citekey}[/dim]")
@@ -1364,10 +1384,24 @@ def _process_single(citekey, cfg, state, vault, ai, pdf_extractor, library, quie
         else:
             console.print(" [dim](DB only)[/dim]")
 
-    # Auto-embed if provider available and entry has abstract
-    if embeddings and entry.abstract:
+    # Backfill abstract from S2 if missing (e.g. acquire hit rate limit)
+    abstract = entry.abstract or ""
+    if not abstract and entry.title:
         try:
-            vec = embeddings.embed(entry.title or citekey, entry.abstract)
+            from .literature.metadata import lookup_s2
+            hit = lookup_s2(entry.title)
+            if hit and hit.get("abstract"):
+                abstract = hit["abstract"]
+                state.update_source_info(citekey, abstract=abstract)
+                if not quiet:
+                    console.print("  [dim]abstract backfilled from S2[/dim]")
+        except Exception:
+            pass
+
+    # Auto-embed if provider available and entry has abstract
+    if embeddings and abstract:
+        try:
+            vec = embeddings.embed(entry.title or citekey, abstract)
             if vec:
                 state.save_embedding(citekey, vec, embeddings.model_name)
                 if not quiet:
@@ -1498,6 +1532,16 @@ def embed(ctx, citekeys, dry_run, backend, fragments):
             entry = entries.get(ck)
             title = entry.title if entry else ck
             abstract = entry.abstract if entry else ""
+            # Backfill abstract from S2 if missing
+            if not abstract and needs_abstract and title and title != ck:
+                try:
+                    from .literature.metadata import lookup_s2
+                    hit = lookup_s2(title)
+                    if hit and hit.get("abstract"):
+                        abstract = hit["abstract"]
+                        state.update_source_info(ck, abstract=abstract)
+                except Exception:
+                    pass
             if not abstract and needs_abstract:
                 no_abstract_count += 1
                 progress.advance(task)
@@ -1902,12 +1946,99 @@ def coverage(ctx):
     ctx.invoke(status, verbose=True)
 
 
-@main.command(hidden=True)
-@click.option("--min-sources", "-m", type=int, default=3)
+@main.group(invoke_without_command=True)
 @click.pass_context
-def gaps(ctx, min_sources):
-    """[alias] → status --verbose"""
-    ctx.invoke(status, verbose=True)
+def gaps(ctx):
+    """Reference gaps and acquisition suggestions."""
+    if ctx.invoked_subcommand is None:
+        # Backward compat: bare `klemma gaps` = status --verbose
+        ctx.invoke(status, verbose=True)
+
+
+main.add_command(gaps)
+
+
+@gaps.command()
+@click.option("--limit", "-n", type=int, default=10, help="Number of suggestions")
+@click.option("--section", "-s", default=None, help="Filter by section (e.g. 1.3)")
+@click.pass_context
+def suggest(ctx, limit, section):
+    """Suggest papers to fill reference gaps."""
+    from .search import ChainSearchProvider, CrossRefSearchProvider, S2SearchProvider, create_search
+    from .skills.suggester import suggest_acquisitions
+
+    kctx = _get_context(ctx)
+
+    # Fetch more gaps than needed (some won't resolve)
+    gaps_list = kctx.state.get_reference_gaps(section=section, limit=limit * 3)
+
+    if not gaps_list:
+        console.print("[yellow]No open reference gaps found.[/yellow]")
+        return
+
+    # Initialize search: configured provider, or default S2 → CrossRef chain
+    search = kctx.search
+    if search is None:
+        search_cfg = kctx.config.search
+        if search_cfg.backend:
+            search = create_search(search_cfg.model_dump())
+        else:
+            search = ChainSearchProvider([
+                S2SearchProvider(),
+                CrossRefSearchProvider(),
+            ])
+
+    console.print(f"\n[bold]Resolving top gaps via {search.backend_name}...[/bold]\n")
+
+    candidates = suggest_acquisitions(gaps_list, search, limit=limit)
+
+    if not candidates:
+        console.print("[yellow]No gaps could be resolved.[/yellow]")
+        return
+
+    total_open = len(gaps_list)
+    table = Table(
+        title=f"Gap Suggestions ({len(candidates)} of {total_open} open gaps)",
+        show_lines=True,
+    )
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Score", justify="right", width=6)
+    table.add_column("Authors", width=20)
+    table.add_column("Year", width=5)
+    table.add_column("Title", width=35)
+    table.add_column("Sections", width=12)
+
+    for i, c in enumerate(candidates, 1):
+        year_str = str(c.ref_year) if c.ref_year else "—"
+        sections_str = ", ".join(c.sections) if c.sections else "—"
+        title_display = c.ref_title[:60] + "..." if len(c.ref_title) > 60 else c.ref_title
+
+        table.add_row(
+            str(i),
+            f"{c.score:.1f}",
+            c.ref_authors[:25] if c.ref_authors else "—",
+            year_str,
+            title_display,
+            sections_str,
+        )
+
+    console.print(table)
+
+    # Print acquire commands below the table
+    console.print()
+    for i, c in enumerate(candidates, 1):
+        if c.acquire_cmd:
+            console.print(f"  [dim]{i}.[/dim] [green]→ {c.acquire_cmd}[/green]")
+        elif c.doi:
+            console.print(
+                f"  [dim]{i}.[/dim] [yellow]⚠ No open-access PDF found"
+                f" (DOI: {c.doi})[/yellow]"
+            )
+        else:
+            console.print(
+                f"  [dim]{i}.[/dim] [dim]⚠ Not found in search API[/dim]"
+            )
+    console.print()
 
 
 @main.group(invoke_without_command=True)
@@ -2854,13 +2985,15 @@ def prune(ctx, chapter, verdict, clear_key):
 @click.option("--volume", help="Volume")
 @click.option("--issue", help="Issue")
 @click.option("--section", "-s", multiple=True, help="Dissertation section(s) to assign")
+@click.option("--pdf", "pdf_url", help="Direct PDF URL (bypass DOI resolution, e.g. for WAF-protected publishers)")
 @click.option("--batch", "batch_path", type=click.Path(exists=True), help="JSON file with papers list")
 @click.option("--no-process", is_flag=True, help="Skip fragment extraction after adding")
 @click.pass_context
-def acquire(ctx, url, title, authors, year, journal, volume, issue, section, batch_path, no_process):
+def acquire(ctx, url, title, authors, year, journal, volume, issue, section, pdf_url, batch_path, no_process):
     """Download PDF, add to Zotero, register in klemma.
 
     Single paper: klemma acquire <pdf_url> --title "..." --authors "..." --year 2022 --section 1.2
+    With DOI + direct PDF: klemma acquire <doi_url> --pdf <direct_pdf_url> --section 1.3
     Batch: klemma acquire --batch papers.json
     """
     from .skills.acquirer import PaperMetadata, acquire_paper_local, load_batch
@@ -2881,6 +3014,7 @@ def acquire(ctx, url, title, authors, year, journal, volume, issue, section, bat
             journal=journal or "",
             volume=volume or "",
             issue=issue or "",
+            pdf_override=pdf_url or "",
             sections=list(section),
         )]
     else:
@@ -2897,7 +3031,7 @@ def acquire(ctx, url, title, authors, year, journal, volume, issue, section, bat
             meta, storage_path=cfg.zotero.storage_path, state=state,
         )
 
-        if result.status == "ok":
+        if result.status in ("ok", "ok_no_pdf"):
             console.print(f"  [green]@{result.citekey}[/green]")
             if meta.title:
                 auto = " [dim](auto-extracted)[/dim]" if not title else ""
@@ -2908,10 +3042,14 @@ def acquire(ctx, url, title, authors, year, journal, volume, issue, section, bat
                 console.print(f"  Year: {meta.year}")
             if result.zotero_added:
                 console.print("  [blue]Added to Zotero (BBT citekey)[/blue]")
+            if result.status == "ok_no_pdf":
+                console.print("  [yellow]No open-access PDF found (metadata-only)[/yellow]")
+                if result.zotero_added:
+                    console.print("  [dim]Tip: use Zotero → Right-click → Find Available PDF[/dim]")
             if meta.sections:
                 console.print(f"  [dim]sections: {', '.join(meta.sections)}[/dim]")
 
-            if not no_process:
+            if not no_process and result.status == "ok":
                 try:
                     ai = _init_ai(cfg)
                 except Exception as e:

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _SHIPPED_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
 
 # Config keys inherited from parent project (shared resources)
-_INHERITED_KEYS = {"obsidian", "zotero", "ai", "embeddings"}
+_INHERITED_KEYS = {"obsidian", "zotero", "ai", "embeddings", "search"}
 
 # Claude model shorthands → litellm model IDs (for bare-name detection)
 _CLAUDE_SHORTHANDS: dict[str, str] = {
@@ -47,6 +47,7 @@ def _get_known_fields() -> dict[str, set[str]]:
     _KNOWN_FIELDS["zotero"] = set(ZoteroConfig.model_fields.keys())
     _KNOWN_FIELDS["obsidian"] = set(ObsidianConfig.model_fields.keys())
     _KNOWN_FIELDS["embeddings"] = set(EmbeddingsConfig.model_fields.keys())
+    _KNOWN_FIELDS["search"] = set(SearchConfig.model_fields.keys())
     _KNOWN_FIELDS["state"] = set(StateConfig.model_fields.keys())
     _KNOWN_FIELDS["instance"] = set(InstanceConfig.model_fields.keys())
     _KNOWN_FIELDS["project"] = set(ProjectConfig.model_fields.keys())
@@ -78,7 +79,7 @@ def _warn_config_issues(raw: dict, source: str) -> None:
     # --- 1. Misplaced keys: known sub-section fields placed at root ---
     # Map: child field → list of sections it belongs to
     child_fields: dict[str, list[str]] = {}
-    for section in ("ai", "zotero", "obsidian", "embeddings", "state",
+    for section in ("ai", "zotero", "obsidian", "embeddings", "search", "state",
                     "instance", "project", "dissertation", "planning",
                     "reading", "processing", "tags", "export"):
         for field in fields.get(section, set()):
@@ -344,6 +345,11 @@ class EmbeddingsConfig(BaseModel):
     throttle: float = 3.1  # seconds between S2 API requests
 
 
+class SearchConfig(BaseModel):
+    backend: str = ""  # "s2" | "" (disabled; gaps suggest defaults to s2 on-demand)
+    throttle: float = 3.1  # seconds between API requests
+
+
 class StateConfig(BaseModel):
     db_path: str = "./data/klemma.db"
     inherit_db: bool = True  # inherit parent project's DB (read-only)
@@ -520,6 +526,7 @@ class KlemmaConfig(BaseModel):
     obsidian: ObsidianConfig = Field(default_factory=ObsidianConfig)
     ai: AIConfig = Field(default_factory=AIConfig)
     embeddings: EmbeddingsConfig = Field(default_factory=EmbeddingsConfig)
+    search: SearchConfig = Field(default_factory=SearchConfig)
     state: StateConfig = Field(default_factory=StateConfig)
     dissertation: DissertationConfig = Field(default_factory=DissertationConfig)
     planning: PlanningConfig = Field(default_factory=PlanningConfig)

--- a/src/klemma/context.py
+++ b/src/klemma/context.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .config import KlemmaConfig, ProjectConfig
     from .embeddings import EmbeddingProvider
     from .library_provider import LibraryProvider
+    from .search import SearchProvider
     from .state import StateManager
     from .vault import VaultAdapter
 
@@ -28,6 +29,7 @@ class KlemmaContext:
     vault: VaultAdapter
     ai: Optional[AIProvider] = None
     embeddings: Optional[EmbeddingProvider] = None
+    search: Optional[SearchProvider] = None
     library: Optional[LibraryProvider] = None
     project: Optional[ProjectConfig] = None
     project_name: str = "default"

--- a/src/klemma/search.py
+++ b/src/klemma/search.py
@@ -1,0 +1,265 @@
+"""Provider-agnostic paper search — resolve reference gaps to acquisition targets.
+
+Root-level provider (alongside embeddings.py) to avoid cross-package
+dependency between literature/ and evaluation/.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchResult:
+    """Resolved paper metadata from an external search API."""
+
+    title: str
+    authors: str = ""
+    year: int | None = None
+    abstract: str = ""
+    doi: str = ""
+    pdf_url: str = ""
+    source_api: str = ""  # "s2", "arxiv", "crossref", "unpaywall"
+
+
+@runtime_checkable
+class SearchProvider(Protocol):
+    """Protocol for paper search backends."""
+
+    backend_name: str
+
+    def resolve(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> SearchResult | None:
+        """Look up paper metadata by title/authors/year."""
+        ...
+
+    def resolve_pdf_url(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> str | None:
+        """Resolve an open-access PDF URL for a paper."""
+        ...
+
+
+class S2SearchProvider:
+    """Semantic Scholar search — wraps literature.metadata.lookup_s2().
+
+    Best for CS/ML papers. Rate-limited (~1 req/3s), returns abstract.
+    """
+
+    backend_name = "s2"
+
+    def __init__(self, throttle: float = 3.1) -> None:
+        self._throttle = throttle
+
+    def resolve(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> SearchResult | None:
+        from .literature.metadata import lookup_s2
+
+        hit = lookup_s2(title)
+        if not hit:
+            return None
+
+        return SearchResult(
+            title=hit.get("title", title),
+            authors=hit.get("authors", authors),
+            year=hit.get("year") or year,
+            abstract=hit.get("abstract", ""),
+            doi=hit.get("doi", ""),
+            source_api="s2",
+        )
+
+    def resolve_pdf_url(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> str | None:
+        from .evaluation.resolvers import resolve_pdf_url as _resolve
+
+        result = _resolve(title, authors, year)
+        return result.pdf_url if result and result.pdf_url else None
+
+
+class CrossRefSearchProvider:
+    """CrossRef search — free, no auth, generous rate limits.
+
+    Broader coverage than S2 (especially non-CS). No abstract.
+    Wraps evaluation.resolvers for both metadata and PDF resolution.
+    """
+
+    backend_name = "crossref"
+
+    def resolve(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> SearchResult | None:
+        from urllib.parse import quote_plus
+
+        import requests
+
+        from .evaluation.resolvers import _titles_match
+
+        query = title
+        url = (
+            f"https://api.crossref.org/works"
+            f"?query.bibliographic={quote_plus(query)}&rows=3"
+        )
+        try:
+            resp = requests.get(
+                url, timeout=10,
+                headers={"User-Agent": "klemma/0.4 (mailto:klemma@example.com)"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning("CrossRef lookup failed for '%s': %s", title[:60], e)
+            return None
+
+        for item in data.get("message", {}).get("items", []):
+            item_title = " ".join(item.get("title", []))
+            if not _titles_match(title, item_title):
+                continue
+
+            # Extract authors
+            cr_authors = ", ".join(
+                f"{a.get('family', '')} {a.get('given', '')}".strip()
+                for a in item.get("author", [])
+            ) or authors
+
+            # Extract year from published-print or issued
+            cr_year = year
+            for date_field in ("published-print", "issued", "published-online"):
+                parts = item.get(date_field, {}).get("date-parts", [[]])
+                if parts and parts[0] and parts[0][0]:
+                    cr_year = int(parts[0][0])
+                    break
+
+            return SearchResult(
+                title=item_title,
+                authors=cr_authors,
+                year=cr_year,
+                doi=item.get("DOI", ""),
+                source_api="crossref",
+            )
+
+        return None
+
+    def resolve_pdf_url(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> str | None:
+        from .evaluation.resolvers import resolve_pdf_url as _resolve
+
+        result = _resolve(title, authors, year)
+        return result.pdf_url if result and result.pdf_url else None
+
+
+class ChainSearchProvider:
+    """Try multiple search providers in sequence — first hit wins.
+
+    Default chain: S2 → CrossRef. If S2 rate-limits (429) or fails,
+    CrossRef picks up the slack.
+    """
+
+    def __init__(self, providers: list) -> None:
+        self._providers = providers
+        names = [p.backend_name for p in providers]
+        self.backend_name = "+".join(names)
+
+    def resolve(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> SearchResult | None:
+        for provider in self._providers:
+            try:
+                result = provider.resolve(title, authors, year)
+                if result:
+                    return result
+            except Exception:
+                logger.debug(
+                    "%s failed for '%s', trying next",
+                    provider.backend_name, title[:60],
+                    exc_info=True,
+                )
+        return None
+
+    def resolve_pdf_url(
+        self,
+        title: str,
+        authors: str = "",
+        year: int | None = None,
+    ) -> str | None:
+        for provider in self._providers:
+            try:
+                url = provider.resolve_pdf_url(title, authors, year)
+                if url:
+                    return url
+            except Exception:
+                logger.debug(
+                    "%s pdf resolve failed for '%s', trying next",
+                    provider.backend_name, title[:60],
+                    exc_info=True,
+                )
+        return None
+
+
+def create_search(
+    config: dict,
+    api_keys: dict | None = None,
+) -> SearchProvider | None:
+    """Create a SearchProvider from config dict.
+
+    Config keys:
+        backend: "s2" | "crossref" | "auto" | "" (default: "" = disabled)
+        throttle: seconds between S2 API requests (default: 3.1)
+
+    "auto" (and the on-demand default in `gaps suggest`) creates a
+    ChainSearchProvider: S2 → CrossRef, so rate-limited S2 calls
+    fall through to CrossRef automatically.
+
+    Returns None if backend is empty or unknown.
+    """
+    if not config:
+        return None
+
+    backend = config.get("backend", "")
+    if not backend:
+        return None
+
+    throttle = config.get("throttle", 3.1)
+
+    if backend == "s2":
+        return S2SearchProvider(throttle=throttle)
+
+    if backend == "crossref":
+        return CrossRefSearchProvider()
+
+    if backend == "auto":
+        return ChainSearchProvider([
+            S2SearchProvider(throttle=throttle),
+            CrossRefSearchProvider(),
+        ])
+
+    logger.warning("Unknown search backend: %s", backend)
+    return None

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -32,6 +32,7 @@ class PaperMetadata:
     issue: str = ""
     pages: str = ""
     doi: str = ""
+    pdf_override: str = ""  # direct PDF URL (bypass DOI resolution)
     sections: list[str] = field(default_factory=list)
 
 
@@ -84,6 +85,16 @@ def download_pdf(
             headers={"User-Agent": _USER_AGENT},
         )
         resp.raise_for_status()
+
+        # Detect WAF/anti-bot challenges (202 with text/html = JS challenge page)
+        if resp.status_code == 202:
+            ct = resp.headers.get("content-type", "")
+            if "html" in ct.lower():
+                logger.warning(
+                    "Publisher uses anti-bot protection (WAF); "
+                    "download manually or use Zotero → Find Available PDF"
+                )
+                return None
 
         content_length = resp.headers.get("content-length")
         if content_length and int(content_length) > max_bytes:
@@ -196,16 +207,296 @@ def _extract_doi(url: str) -> str:
 
 
 def _resolve_doi_to_pdf(doi: str) -> Optional[str]:
-    """Try to find a downloadable PDF URL for a DOI via Unpaywall."""
+    """Try to find a downloadable PDF URL for a DOI.
+
+    Resolution chain:
+    1. Unpaywall (open-access database)
+    2. Follow DOI redirect → apply publisher URL patterns (.xml→.pdf, etc.)
+    """
+    # 1. Unpaywall
     try:
         from ..evaluation.resolvers import resolve_unpaywall
         pdf_url = resolve_unpaywall(doi)
         if pdf_url:
-            logger.info("Resolved DOI %s → %s", doi, pdf_url)
+            logger.info("Resolved DOI %s → %s (Unpaywall)", doi, pdf_url)
             return pdf_url
     except Exception as e:
-        logger.debug("DOI resolution failed: %s", e)
+        logger.debug("Unpaywall resolution failed: %s", e)
+
+    # 2. Follow DOI redirect → publisher URL patterns
+    pdf_url = _resolve_publisher_pdf(doi)
+    if pdf_url:
+        logger.info("Resolved DOI %s → %s (publisher pattern)", doi, pdf_url)
+        return pdf_url
+
     return None
+
+
+# Publisher URL patterns: (suffix_to_match, replacement)
+# Applied to the final URL after following the DOI redirect.
+_PUBLISHER_PATTERNS: list[tuple[str, str]] = [
+    # Atypon/Silverchair publishers (AMS, AIP, etc.): /doi/DOI → /doi/pdf/DOI
+    ("/doi/10.", "/doi/pdf/10."),
+    # AMS journals: .xml → .pdf
+    (".xml", ".pdf"),
+    # Many publishers: /abstract → /pdf, /full → /pdf
+    ("/abstract", "/pdf"),
+    ("/full", "/pdf"),
+    # Springer/Nature: .html → .pdf
+    (".html", ".pdf"),
+]
+
+
+def _resolve_publisher_pdf(doi: str) -> Optional[str]:
+    """Follow DOI redirect, then try publisher URL patterns or page scrape.
+
+    Strategy:
+    1. Follow DOI redirect to get the landing page URL
+    2. Try URL suffix patterns (.xml→.pdf, /abstract→/pdf, etc.)
+    3. Scrape landing page for PDF download links
+    """
+    doi_url = f"https://doi.org/{doi}"
+    try:
+        # Use GET with stream=True — some publishers don't redirect on HEAD
+        resp = requests.get(
+            doi_url, allow_redirects=True, timeout=15, stream=True,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        final_url = resp.url
+        # Read content only if we need it for scraping (step 3)
+        page_content = None
+    except Exception as e:
+        logger.debug("DOI redirect failed: %s", e)
+        return None
+
+    # Step 2: Try URL suffix patterns
+    # Trust pattern-derived .pdf URLs without verification — many publishers
+    # (AMS, Springer) return 202/403 for programmatic HEAD/GET but serve
+    # the PDF fine in practice (anti-bot measures).
+    for suffix, replacement in _PUBLISHER_PATTERNS:
+        if suffix in final_url:
+            candidate = final_url.replace(suffix, replacement, 1)
+            logger.info("Publisher pattern %s→%s: %s", suffix, replacement, candidate)
+            resp.close()
+            return candidate
+
+    # Step 3: Scrape landing page for PDF links
+    try:
+        page_content = resp.text
+        resp.close()
+    except Exception:
+        resp.close()
+        return None
+
+    pdf_url = _scrape_pdf_link(page_content, final_url)
+    if pdf_url and _check_pdf_url(pdf_url):
+        return pdf_url
+
+    return None
+
+
+def _scrape_pdf_link(html: str, page_url: str) -> Optional[str]:
+    """Extract the most likely full-text PDF link from a publisher landing page."""
+    import re as _re
+    from urllib.parse import urljoin
+
+    # Find all href="...*.pdf..." links
+    pdf_hrefs = _re.findall(r'href="([^"]*\.pdf[^"]*)"', html)
+    if not pdf_hrefs:
+        return None
+
+    # Prefer links that look like the main article PDF (not supplements/tables)
+    # Filter out supplement/table PDFs (common suffixes: -t01, -supplement, -si)
+    main_pdfs = [
+        h for h in pdf_hrefs
+        if not _re.search(r'-(t\d+|supplement|si|supp)\b', h, _re.IGNORECASE)
+    ]
+    candidates = main_pdfs or pdf_hrefs
+
+    # Deduplicate preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for href in candidates:
+        full = urljoin(page_url, href)
+        if full not in seen:
+            seen.add(full)
+            unique.append(full)
+
+    return unique[0] if unique else None
+
+
+def _check_pdf_url(url: str) -> bool:
+    """Verify a URL points to a PDF via GET with streaming (more reliable than HEAD)."""
+    try:
+        resp = requests.get(
+            url, allow_redirects=True, timeout=10, stream=True,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        if resp.status_code not in (200, 206):
+            resp.close()
+            return False
+        ct = resp.headers.get("content-type", "")
+        if "pdf" in ct.lower():
+            resp.close()
+            return True
+        # Some servers lie about content-type — check magic bytes
+        chunk = resp.raw.read(5)
+        resp.close()
+        return chunk == b"%PDF-"
+    except Exception:
+        return False
+
+
+def _try_zotero(
+    meta: PaperMetadata,
+    resolved: dict,
+    pdf_path: Optional[Path],
+) -> Optional[str]:
+    """Try to add paper to Zotero, return BBT citekey or None."""
+    try:
+        from ..literature.zotero_api import create_zotero_item, get_bbt_citekey, is_zotero_running
+        if is_zotero_running():
+            ok = create_zotero_item(
+                meta.title, meta.authors, meta.year, meta.doi,
+                resolved.get("abstract", ""), pdf_path,
+            )
+            if ok:
+                return get_bbt_citekey(meta.title)
+    except Exception as e:
+        logger.warning("Zotero integration failed: %s", e)
+    return None
+
+
+def _enrich_metadata(meta: PaperMetadata) -> dict:
+    """Fill missing metadata from CrossRef (by DOI) or S2 (by title).
+
+    CrossRef is tried first when we have a DOI (common for DOI-only acquires).
+    S2 is tried when we have a title but no DOI.
+    Mutates meta in-place, returns resolved dict for abstract etc.
+    """
+    resolved: dict = {}
+
+    # 1. CrossRef by DOI — best for DOI-only acquires (no title needed)
+    if meta.doi and (not meta.title or not meta.authors):
+        try:
+            cr = _lookup_crossref_by_doi(meta.doi)
+            if cr:
+                resolved = cr
+                if not meta.title and cr.get("title"):
+                    meta.title = cr["title"]
+                if not meta.authors and cr.get("authors"):
+                    meta.authors = cr["authors"]
+                if meta.year is None and cr.get("year"):
+                    meta.year = cr["year"]
+        except Exception as e:
+            logger.debug("CrossRef DOI lookup failed: %s", e)
+
+    # 2. S2 by title — fills abstract (CrossRef doesn't have it)
+    if meta.title:
+        try:
+            from ..literature.metadata import lookup_s2
+            hit = lookup_s2(meta.title)
+            if hit:
+                if not resolved:
+                    resolved = hit
+                if not meta.title and hit.get("title"):
+                    meta.title = hit["title"]
+                if not meta.authors and hit.get("authors"):
+                    meta.authors = hit["authors"]
+                if meta.year is None and hit.get("year"):
+                    meta.year = hit["year"]
+                if not meta.doi and hit.get("doi"):
+                    meta.doi = hit["doi"]
+                # S2 has abstracts, CrossRef usually doesn't
+                if hit.get("abstract") and not resolved.get("abstract"):
+                    resolved["abstract"] = hit["abstract"]
+        except Exception as e:
+            logger.debug("S2 metadata lookup failed: %s", e)
+
+    return resolved
+
+
+def _lookup_crossref_by_doi(doi: str) -> Optional[dict]:
+    """Look up paper metadata on CrossRef by DOI (direct, no search needed)."""
+    url = f"https://api.crossref.org/works/{doi}"
+    try:
+        resp = requests.get(
+            url, timeout=10,
+            headers={"User-Agent": "klemma/0.4 (mailto:klemma@example.com)"},
+        )
+        resp.raise_for_status()
+        item = resp.json().get("message", {})
+    except Exception as e:
+        logger.debug("CrossRef works/%s failed: %s", doi, e)
+        return None
+
+    title = " ".join(item.get("title", []))
+    if not title:
+        return None
+
+    authors = ", ".join(
+        f"{a.get('family', '')} {a.get('given', '')}".strip()
+        for a in item.get("author", [])
+    )
+
+    year = None
+    for date_field in ("published-print", "issued", "published-online"):
+        parts = item.get(date_field, {}).get("date-parts", [[]])
+        if parts and parts[0] and parts[0][0]:
+            year = int(parts[0][0])
+            break
+
+    return {
+        "title": title,
+        "authors": authors,
+        "year": year,
+        "doi": doi,
+        "abstract": "",  # CrossRef rarely has abstracts
+    }
+
+
+def _acquire_metadata_only(
+    meta: PaperMetadata,
+    storage_path: str,
+    state=None,
+) -> AcquireResult:
+    """Acquire paper without a PDF — DOI-only registration.
+
+    Creates Zotero item (which can later "Find Available PDF"),
+    registers in klemma DB with metadata from S2/CrossRef.
+    """
+    logger.info("Metadata-only acquire for DOI %s (no PDF available)", meta.doi)
+
+    # Enrich metadata from CrossRef (by DOI) / S2 (by title)
+    resolved = _enrich_metadata(meta)
+
+    # Add to Zotero (without PDF — Zotero can find it via "Find Available PDF")
+    zotero_citekey = _try_zotero(meta, resolved, pdf_path=None)
+
+    # Generate citekey
+    citekey = zotero_citekey or _generate_citekey(meta)
+
+    # Register in klemma DB
+    if state:
+        state.register_sources([citekey])
+        if meta.sections:
+            chapters = list({int(s.split(".")[0]) for s in meta.sections if "." in s})
+            state.set_source_sections(citekey, meta.sections, chapters)
+        state.update_source_info(
+            citekey,
+            title=meta.title or resolved.get("title", ""),
+            authors=meta.authors or resolved.get("authors", ""),
+            year=meta.year or resolved.get("year"),
+            abstract=resolved.get("abstract", ""),
+            doi=meta.doi or resolved.get("doi", ""),
+        )
+
+    return AcquireResult(
+        citekey=citekey,
+        pdf_path="",
+        status="ok_no_pdf",
+        zotero_added=zotero_citekey is not None,
+    )
 
 
 def acquire_paper_local(
@@ -214,34 +505,41 @@ def acquire_paper_local(
     state=None,
 ) -> AcquireResult:
     """Local acquire: download PDF → auto-extract metadata → generate citekey → store → register in DB."""
-    # 0. Handle local file:// URLs directly
+    # 0a. Extract DOI from URL before any URL rewriting
+    doi_from_url = _extract_doi(meta.url)
+    if doi_from_url and not meta.doi:
+        meta.doi = doi_from_url
+
+    # 0b. Resolve effective download URL
+    # Priority: --pdf override > arXiv resolve > DOI resolve > original URL
+    arxiv_pdf = _resolve_arxiv_pdf_url(meta.url)
+    if meta.pdf_override:
+        meta.url = meta.pdf_override
+    elif arxiv_pdf:
+        meta.url = arxiv_pdf
+    elif doi_from_url:
+        pdf_url = _resolve_doi_to_pdf(doi_from_url)
+        if pdf_url:
+            meta.url = pdf_url
+        else:
+            logger.warning("Could not resolve DOI %s to a PDF URL", doi_from_url)
+
+    # 0c. Handle local file:// URLs directly
     parsed_url = urlparse(meta.url)
     if parsed_url.scheme == "file":
-        local_file = Path(parsed_url.path)
+        from urllib.parse import unquote
+        local_file = Path(unquote(parsed_url.path))
         if not local_file.is_file():
             logger.error("Local file not found: %s", local_file)
             return AcquireResult(status="download_failed")
         pdf_path = local_file
     else:
-        # 0a. If URL is an arXiv abstract page, resolve to PDF URL
-        arxiv_pdf = _resolve_arxiv_pdf_url(meta.url)
-        if arxiv_pdf:
-            meta.url = arxiv_pdf
-
-        # 0b. If URL is a DOI link, extract DOI and resolve to actual PDF URL
-        doi_from_url = _extract_doi(meta.url)
-        if doi_from_url:
-            if not meta.doi:
-                meta.doi = doi_from_url
-            pdf_url = _resolve_doi_to_pdf(doi_from_url)
-            if pdf_url:
-                meta.url = pdf_url
-            else:
-                logger.warning("Could not resolve DOI %s to a PDF URL", doi_from_url)
-
         # 1. Download PDF
         pdf_path = download_pdf(meta.url)
         if not pdf_path:
+            # No PDF available — but if we have a DOI, do metadata-only acquire
+            if meta.doi:
+                return _acquire_metadata_only(meta, storage_path, state)
             return AcquireResult(status="download_failed")
 
     is_local_file = parsed_url.scheme == "file"
@@ -270,19 +568,28 @@ def acquire_paper_local(
         logger.warning("Metadata extraction failed, continuing: %s", e)
         resolved = {}
 
-    # 2a. Add to Zotero if running
-    zotero_citekey = None
-    try:
-        from ..literature.zotero_api import create_zotero_item, get_bbt_citekey, is_zotero_running
-        if is_zotero_running():
-            ok = create_zotero_item(
-                meta.title, meta.authors, meta.year, meta.doi,
-                resolved.get("abstract", ""), pdf_path,
-            )
-            if ok:
-                zotero_citekey = get_bbt_citekey(meta.title)
-    except Exception as e:
-        logger.warning("Zotero integration failed: %s", e)
+    # 2a. CrossRef fallback — when S2 is unavailable (429) and key fields missing
+    if meta.doi and (not meta.authors or meta.year is None):
+        try:
+            cr = _lookup_crossref_by_doi(meta.doi)
+            if cr:
+                # CrossRef title is authoritative — prefer over PDF-extracted
+                if cr.get("title"):
+                    meta.title = cr["title"]
+                    resolved["title"] = cr["title"]
+                if not meta.authors and cr.get("authors"):
+                    meta.authors = cr["authors"]
+                if meta.year is None and cr.get("year"):
+                    meta.year = cr["year"]
+                if not resolved.get("authors") and cr.get("authors"):
+                    resolved["authors"] = cr["authors"]
+                if not resolved.get("year") and cr.get("year"):
+                    resolved["year"] = cr["year"]
+        except Exception as e:
+            logger.debug("CrossRef fallback failed: %s", e)
+
+    # 2b. Add to Zotero if running
+    zotero_citekey = _try_zotero(meta, resolved, pdf_path)
 
     # 3. Generate citekey — prefer BBT, fallback to local
     citekey = zotero_citekey or _generate_citekey(meta)

--- a/src/klemma/skills/suggester.py
+++ b/src/klemma/skills/suggester.py
@@ -1,0 +1,147 @@
+"""Suggest papers to acquire for filling reference gaps.
+
+Pure skill — no file I/O, no CLI. Resolves top-scored gaps
+via a SearchProvider and builds acquisition command strings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from ..search import SearchProvider, SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SuggestCandidate:
+    """A reference gap enriched with search results and acquisition info."""
+
+    ref_authors: str
+    ref_year: int | None
+    ref_title: str
+    score: float
+    sections: list[str]
+    search_result: SearchResult | None = None
+    pdf_url: str = ""
+    doi: str = ""
+    acquire_cmd: str = ""
+
+
+def suggest_acquisitions(
+    gaps: list[dict],
+    search: SearchProvider,
+    limit: int = 10,
+) -> list[SuggestCandidate]:
+    """Resolve top gaps via search provider.
+
+    For each gap (sorted by score desc, limited):
+    1. Call search.resolve(title, authors, year) for metadata
+    2. If found, call search.resolve_pdf_url() for open-access PDF
+    3. Build acquire_cmd string for CLI usage
+
+    Returns list of SuggestCandidate, longest first.
+    """
+    sorted_gaps = sorted(gaps, key=lambda g: g.get("score", 0), reverse=True)
+
+    candidates: list[SuggestCandidate] = []
+    for gap in sorted_gaps:
+        if len(candidates) >= limit:
+            break
+
+        title = gap.get("ref_title", "")
+        authors = gap.get("ref_authors", "")
+        year = gap.get("ref_year")
+        score = gap.get("score", 0)
+
+        # Parse sections — DB stores JSON arrays, GROUP_CONCAT joins them
+        sections_raw = gap.get("dissertation_sections", "")
+        sections = _parse_sections(sections_raw)
+
+        candidate = SuggestCandidate(
+            ref_authors=authors,
+            ref_year=year,
+            ref_title=title,
+            score=score,
+            sections=sections,
+        )
+
+        # Resolve metadata via search
+        try:
+            result = search.resolve(title, authors, year)
+            if result:
+                candidate.search_result = result
+                candidate.doi = result.doi
+                # Try to get PDF URL
+                pdf_url = search.resolve_pdf_url(
+                    result.title, result.authors, result.year,
+                )
+                if pdf_url:
+                    candidate.pdf_url = pdf_url
+                elif result.doi:
+                    candidate.doi = result.doi
+        except Exception:
+            logger.warning("Search failed for '%s'", title[:60], exc_info=True)
+
+        # Build acquire command
+        if candidate.pdf_url:
+            section_flags = " ".join(f"-s {s}" for s in candidate.sections)
+            candidate.acquire_cmd = f"klemma acquire {candidate.pdf_url}"
+            if section_flags:
+                candidate.acquire_cmd += f" {section_flags}"
+        elif candidate.doi:
+            section_flags = " ".join(f"-s {s}" for s in candidate.sections)
+            candidate.acquire_cmd = f"klemma acquire https://doi.org/{candidate.doi}"
+            if section_flags:
+                candidate.acquire_cmd += f" {section_flags}"
+
+        candidates.append(candidate)
+
+    return candidates
+
+
+def _parse_sections(raw: str) -> list[str]:
+    """Parse sections from DB dissertation_sections field.
+
+    The DB stores JSON arrays per row (e.g. '["1.3", "2.3"]').
+    GROUP_CONCAT joins multiple rows: '["1.3", "2.3"],["1.4"]'.
+    We need to extract the unique flat list: ["1.3", "2.3", "1.4"].
+    """
+    if not raw:
+        return []
+
+    # Wrap in array brackets if GROUP_CONCAT joined multiple JSON arrays
+    # e.g. '["1.3"],["2.3"]' → '[["1.3"],["2.3"]]'
+    normalized = raw.strip()
+    try:
+        parsed = json.loads(normalized)
+        if isinstance(parsed, list):
+            # Could be flat ["1.3", "2.3"] or nested [["1.3"], ["2.3"]]
+            result: list[str] = []
+            for item in parsed:
+                if isinstance(item, list):
+                    result.extend(str(s) for s in item)
+                else:
+                    result.append(str(item))
+            return list(dict.fromkeys(result))  # dedup preserving order
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # GROUP_CONCAT of multiple JSON arrays: '["1.3","2.3"],["1.4"]'
+    try:
+        parsed = json.loads(f"[{normalized}]")
+        if isinstance(parsed, list):
+            result = []
+            for item in parsed:
+                if isinstance(item, list):
+                    result.extend(str(s) for s in item)
+                else:
+                    result.append(str(item))
+            return list(dict.fromkeys(result))
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Last resort: plain comma-separated
+    return [s.strip().strip('"') for s in raw.split(",") if s.strip().strip('"')]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,248 @@
+"""Tests for search.py — SearchProvider protocol, S2 backend, factory."""
+
+from unittest.mock import MagicMock, patch
+
+from klemma.search import (
+    ChainSearchProvider,
+    CrossRefSearchProvider,
+    S2SearchProvider,
+    SearchProvider,
+    SearchResult,
+    create_search,
+)
+
+
+class TestSearchResult:
+    def test_defaults(self):
+        r = SearchResult(title="Test Paper")
+        assert r.title == "Test Paper"
+        assert r.authors == ""
+        assert r.year is None
+        assert r.abstract == ""
+        assert r.doi == ""
+        assert r.pdf_url == ""
+        assert r.source_api == ""
+
+    def test_full(self):
+        r = SearchResult(
+            title="Paper",
+            authors="Smith, Jones",
+            year=2023,
+            abstract="Abstract text",
+            doi="10.1234/test",
+            pdf_url="https://example.com/paper.pdf",
+            source_api="s2",
+        )
+        assert r.year == 2023
+        assert r.doi == "10.1234/test"
+
+
+class TestS2SearchProvider:
+    def test_protocol_conformance(self):
+        provider = S2SearchProvider()
+        assert isinstance(provider, SearchProvider)
+        assert provider.backend_name == "s2"
+
+    @patch("klemma.literature.metadata.lookup_s2")
+    def test_resolve_found(self, mock_lookup):
+        mock_lookup.return_value = {
+            "title": "Found Paper",
+            "authors": "Doe, J.",
+            "year": 2022,
+            "abstract": "An abstract",
+            "doi": "10.5555/found",
+        }
+        provider = S2SearchProvider()
+        result = provider.resolve("Found Paper")
+        assert result is not None
+        assert result.title == "Found Paper"
+        assert result.authors == "Doe, J."
+        assert result.year == 2022
+        assert result.doi == "10.5555/found"
+        assert result.source_api == "s2"
+        mock_lookup.assert_called_once_with("Found Paper")
+
+    @patch("klemma.literature.metadata.lookup_s2")
+    def test_resolve_not_found(self, mock_lookup):
+        mock_lookup.return_value = None
+        provider = S2SearchProvider()
+        result = provider.resolve("Unknown Paper")
+        assert result is None
+
+    @patch("klemma.evaluation.resolvers.resolve_pdf_url")
+    def test_resolve_pdf_url_found(self, mock_resolve):
+        mock_result = MagicMock()
+        mock_result.pdf_url = "https://arxiv.org/pdf/2106.12345"
+        mock_resolve.return_value = mock_result
+
+        provider = S2SearchProvider()
+        url = provider.resolve_pdf_url("Test Paper", "Smith", 2021)
+        assert url == "https://arxiv.org/pdf/2106.12345"
+
+    @patch("klemma.evaluation.resolvers.resolve_pdf_url")
+    def test_resolve_pdf_url_not_found(self, mock_resolve):
+        mock_result = MagicMock()
+        mock_result.pdf_url = ""
+        mock_resolve.return_value = mock_result
+
+        provider = S2SearchProvider()
+        url = provider.resolve_pdf_url("Test Paper")
+        assert url is None
+
+
+class TestCreateSearch:
+    def test_s2_backend(self):
+        provider = create_search({"backend": "s2", "throttle": 5.0})
+        assert provider is not None
+        assert isinstance(provider, S2SearchProvider)
+        assert provider.backend_name == "s2"
+
+    def test_empty_backend_returns_none(self):
+        assert create_search({"backend": ""}) is None
+
+    def test_no_backend_returns_none(self):
+        assert create_search({}) is None
+
+    def test_empty_config_returns_none(self):
+        assert create_search(None) is None
+
+    def test_unknown_backend_returns_none(self):
+        assert create_search({"backend": "unknown"}) is None
+
+    def test_crossref_backend(self):
+        provider = create_search({"backend": "crossref"})
+        assert provider is not None
+        assert isinstance(provider, CrossRefSearchProvider)
+        assert provider.backend_name == "crossref"
+
+    def test_auto_backend_creates_chain(self):
+        provider = create_search({"backend": "auto"})
+        assert provider is not None
+        assert isinstance(provider, ChainSearchProvider)
+        assert "s2" in provider.backend_name
+        assert "crossref" in provider.backend_name
+
+
+class TestCrossRefSearchProvider:
+    def test_protocol_conformance(self):
+        provider = CrossRefSearchProvider()
+        assert isinstance(provider, SearchProvider)
+        assert provider.backend_name == "crossref"
+
+    @patch("requests.get")
+    def test_resolve_found(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "message": {
+                    "items": [{
+                        "title": ["Arctic Sea Ice Predictions"],
+                        "DOI": "10.1234/arctic",
+                        "author": [
+                            {"family": "Smith", "given": "J."},
+                            {"family": "Jones", "given": "K."},
+                        ],
+                        "published-print": {"date-parts": [[2021]]},
+                    }]
+                }
+            },
+        )
+        provider = CrossRefSearchProvider()
+        result = provider.resolve("Arctic Sea Ice Predictions")
+        assert result is not None
+        assert result.doi == "10.1234/arctic"
+        assert result.year == 2021
+        assert result.source_api == "crossref"
+        assert "Smith" in result.authors
+
+    @patch("requests.get")
+    def test_resolve_no_match(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"message": {"items": []}},
+        )
+        provider = CrossRefSearchProvider()
+        assert provider.resolve("Nonexistent Paper XYZ") is None
+
+    @patch("requests.get")
+    def test_resolve_api_error(self, mock_get):
+        mock_get.side_effect = Exception("Connection timeout")
+        provider = CrossRefSearchProvider()
+        assert provider.resolve("Some Paper") is None
+
+
+class TestChainSearchProvider:
+    def test_first_provider_wins(self):
+        p1 = MagicMock()
+        p1.backend_name = "first"
+        p1.resolve.return_value = SearchResult(title="Found", source_api="first")
+
+        p2 = MagicMock()
+        p2.backend_name = "second"
+
+        chain = ChainSearchProvider([p1, p2])
+        result = chain.resolve("Test")
+        assert result is not None
+        assert result.source_api == "first"
+        p2.resolve.assert_not_called()
+
+    def test_fallback_on_first_failure(self):
+        p1 = MagicMock()
+        p1.backend_name = "first"
+        p1.resolve.side_effect = Exception("429 rate limit")
+
+        p2 = MagicMock()
+        p2.backend_name = "second"
+        p2.resolve.return_value = SearchResult(title="Found", source_api="second")
+
+        chain = ChainSearchProvider([p1, p2])
+        result = chain.resolve("Test")
+        assert result is not None
+        assert result.source_api == "second"
+
+    def test_fallback_on_first_returns_none(self):
+        p1 = MagicMock()
+        p1.backend_name = "first"
+        p1.resolve.return_value = None
+
+        p2 = MagicMock()
+        p2.backend_name = "second"
+        p2.resolve.return_value = SearchResult(title="Found", source_api="second")
+
+        chain = ChainSearchProvider([p1, p2])
+        result = chain.resolve("Test")
+        assert result is not None
+        assert result.source_api == "second"
+
+    def test_all_fail_returns_none(self):
+        p1 = MagicMock()
+        p1.backend_name = "first"
+        p1.resolve.return_value = None
+
+        p2 = MagicMock()
+        p2.backend_name = "second"
+        p2.resolve.return_value = None
+
+        chain = ChainSearchProvider([p1, p2])
+        assert chain.resolve("Test") is None
+
+    def test_backend_name_joined(self):
+        p1 = MagicMock()
+        p1.backend_name = "s2"
+        p2 = MagicMock()
+        p2.backend_name = "crossref"
+        chain = ChainSearchProvider([p1, p2])
+        assert chain.backend_name == "s2+crossref"
+
+    def test_pdf_url_fallback(self):
+        p1 = MagicMock()
+        p1.backend_name = "first"
+        p1.resolve_pdf_url.return_value = None
+
+        p2 = MagicMock()
+        p2.backend_name = "second"
+        p2.resolve_pdf_url.return_value = "https://example.com/paper.pdf"
+
+        chain = ChainSearchProvider([p1, p2])
+        url = chain.resolve_pdf_url("Test")
+        assert url == "https://example.com/paper.pdf"

--- a/tests/test_suggester.py
+++ b/tests/test_suggester.py
@@ -1,0 +1,148 @@
+"""Tests for skills/suggester.py — suggest_acquisitions."""
+
+from unittest.mock import MagicMock
+
+from klemma.search import SearchResult
+from klemma.skills.suggester import _parse_sections, suggest_acquisitions
+
+
+def _make_gap(title="Paper A", authors="Smith", year=2022, score=5.0, sections='["1.2", "2.3"]'):
+    return {
+        "ref_title": title,
+        "ref_authors": authors,
+        "ref_year": year,
+        "score": score,
+        "dissertation_sections": sections,
+    }
+
+
+def _mock_search(resolve_return=None, pdf_url_return=None):
+    search = MagicMock()
+    search.backend_name = "mock"
+    search.resolve.return_value = resolve_return
+    search.resolve_pdf_url.return_value = pdf_url_return
+    return search
+
+
+class TestSuggestAcquisitions:
+    def test_empty_gaps(self):
+        search = _mock_search()
+        result = suggest_acquisitions([], search, limit=5)
+        assert result == []
+
+    def test_basic_resolution(self):
+        gaps = [_make_gap(score=8.0)]
+        sr = SearchResult(
+            title="Paper A", authors="Smith", year=2022,
+            doi="10.1234/a", source_api="s2",
+        )
+        search = _mock_search(
+            resolve_return=sr,
+            pdf_url_return="https://arxiv.org/pdf/2022.00001",
+        )
+
+        candidates = suggest_acquisitions(gaps, search, limit=5)
+
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.ref_title == "Paper A"
+        assert c.score == 8.0
+        assert c.pdf_url == "https://arxiv.org/pdf/2022.00001"
+        assert "klemma acquire" in c.acquire_cmd
+        assert "https://arxiv.org/pdf/2022.00001" in c.acquire_cmd
+        assert "-s 1.2" in c.acquire_cmd
+        assert "-s 2.3" in c.acquire_cmd
+
+    def test_search_returns_none(self):
+        """When search finds nothing, candidate still created without pdf/doi."""
+        gaps = [_make_gap()]
+        search = _mock_search(resolve_return=None)
+
+        candidates = suggest_acquisitions(gaps, search)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.search_result is None
+        assert c.pdf_url == ""
+        assert c.acquire_cmd == ""
+
+    def test_doi_only_no_pdf(self):
+        """When DOI is found but no open-access PDF, acquire_cmd uses DOI URL."""
+        gaps = [_make_gap()]
+        sr = SearchResult(
+            title="Paper A", authors="Smith", year=2022,
+            doi="10.1234/a", source_api="s2",
+        )
+        search = _mock_search(resolve_return=sr, pdf_url_return=None)
+
+        candidates = suggest_acquisitions(gaps, search)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.doi == "10.1234/a"
+        assert "doi.org/10.1234/a" in c.acquire_cmd
+
+    def test_limit_respected(self):
+        gaps = [_make_gap(title=f"Paper {i}", score=10 - i) for i in range(10)]
+        search = _mock_search(resolve_return=None)
+
+        candidates = suggest_acquisitions(gaps, search, limit=3)
+        assert len(candidates) == 3
+
+    def test_sorted_by_score(self):
+        gaps = [
+            _make_gap(title="Low", score=1.0),
+            _make_gap(title="High", score=9.0),
+            _make_gap(title="Mid", score=5.0),
+        ]
+        search = _mock_search(resolve_return=None)
+
+        candidates = suggest_acquisitions(gaps, search, limit=3)
+        assert candidates[0].ref_title == "High"
+        assert candidates[1].ref_title == "Mid"
+        assert candidates[2].ref_title == "Low"
+
+    def test_search_error_handled(self):
+        """Search exceptions are caught, candidate still added."""
+        gaps = [_make_gap()]
+        search = _mock_search()
+        search.resolve.side_effect = Exception("API timeout")
+
+        candidates = suggest_acquisitions(gaps, search)
+        assert len(candidates) == 1
+        assert candidates[0].search_result is None
+
+    def test_json_sections_parsed(self):
+        """JSON-encoded sections from DB are parsed correctly."""
+        gaps = [_make_gap(sections='["1.3", "2.3"]')]
+        sr = SearchResult(title="Paper A", doi="10.1234/a", source_api="s2")
+        search = _mock_search(resolve_return=sr, pdf_url_return=None)
+
+        candidates = suggest_acquisitions(gaps, search)
+        c = candidates[0]
+        assert c.sections == ["1.3", "2.3"]
+        assert "-s 1.3" in c.acquire_cmd
+        assert "-s 2.3" in c.acquire_cmd
+
+    def test_group_concat_sections(self):
+        """GROUP_CONCAT of multiple JSON arrays parsed correctly."""
+        gaps = [_make_gap(sections='["1.3", "2.3"],["1.4"]')]
+        search = _mock_search(resolve_return=None)
+
+        candidates = suggest_acquisitions(gaps, search)
+        assert candidates[0].sections == ["1.3", "2.3", "1.4"]
+
+
+class TestParseSections:
+    def test_empty(self):
+        assert _parse_sections("") == []
+
+    def test_single_json_array(self):
+        assert _parse_sections('["1.3", "2.3"]') == ["1.3", "2.3"]
+
+    def test_group_concat_arrays(self):
+        assert _parse_sections('["1.3", "2.3"],["1.4"]') == ["1.3", "2.3", "1.4"]
+
+    def test_deduplicates(self):
+        assert _parse_sections('["1.3"],["1.3", "2.3"]') == ["1.3", "2.3"]
+
+    def test_plain_csv_fallback(self):
+        assert _parse_sections("1.3, 2.3") == ["1.3", "2.3"]


### PR DESCRIPTION
## Summary

- **`klemma gaps suggest`** — new command that resolves reference gaps via S2 → CrossRef search chain and outputs Rich table with `klemma acquire` commands
- **Search layer** — `SearchProvider` protocol with S2, CrossRef, and Chain backends; `create_search()` factory
- **Acquire hardening** — `--pdf` flag for direct PDF URLs (WAF bypass), `file://` with percent-decoding, CrossRef metadata fallback when S2 is 429, metadata-only Zotero path, abstract backfill in process/embed

Part of #84

## Changes

| File | Action | What |
|------|--------|------|
| `src/klemma/search.py` | NEW | SearchProvider protocol, S2/CrossRef/Chain backends, factory |
| `src/klemma/skills/suggester.py` | NEW | SuggestCandidate, suggest_acquisitions, _parse_sections |
| `src/klemma/config.py` | MOD | SearchConfig model, search in KlemmaConfig + _INHERITED_KEYS |
| `src/klemma/context.py` | MOD | search: Optional[SearchProvider] field |
| `src/klemma/cli.py` | MOD | gaps group + suggest subcommand, --pdf flag, metadata fallbacks, abstract backfill |
| `src/klemma/skills/acquirer.py` | MOD | --pdf/file:// support, WAF detection, CrossRef fallback, metadata-only path, publisher URL patterns |
| `tests/test_search.py` | NEW | 24 tests for search providers |
| `tests/test_suggester.py` | NEW | 14 tests for suggester |

## Test plan

- [x] `ruff check src/ tests/` — all passed
- [x] `python -m pytest tests/ -q` — 741 passed (2 pre-existing failures)
- [x] Manual: `klemma gaps suggest --limit 5` — Rich table with acquire commands
- [x] Manual: `klemma gaps` bare — backward compat (= status --verbose)
- [x] Manual: `klemma acquire <doi> --pdf <direct_url>` — downloads from direct URL
- [x] Manual: `klemma acquire <doi> --pdf file:///path/with%20spaces/paper.pdf` — local file
- [x] Manual: WAF-protected publisher (AMS) → clear warning + metadata-only path
- [x] Manual: S2 rate-limited → CrossRef fallback fills authors/year/title

## Release Note

### Problem
`klemma status` shows reference gaps but provides no way to act on them. Acquiring papers from DOI URLs fails silently when publishers use WAF protection or S2 is rate-limited, leaving metadata incomplete.

### Academic Foundation
The gap→acquire loop implements the iterative literature review methodology where gap analysis drives targeted acquisition. The multi-provider search chain (S2 → CrossRef) follows the principle of cascading metadata resolution common in digital library systems.

### Implementation
New `search.py` module with `SearchProvider` protocol and three backends (S2, CrossRef, Chain). `gaps suggest` command resolves top gaps and generates ready-to-run `klemma acquire` commands. Acquire pipeline hardened with `--pdf` override for WAF-protected publishers, CrossRef DOI→metadata fallback, metadata-only Zotero registration, and abstract backfill in process/embed.

### Results
38 new tests, 1310 lines added. Full acquire pipeline works for WAF-protected publishers (AMS, Springer) via `--pdf` flag. CrossRef fallback ensures complete metadata even under S2 rate limits (429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)