### PR TITLE
feat: duplicate source detection by metadata

### DIFF
--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -11,7 +11,7 @@ Click CLI entry point. Defines 17 commands + hidden aliases.
 - `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
-- Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `suggest`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`
+- Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `library duplicates`, `suggest`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`
 - Hidden aliases: `gaps suggest` → `suggest`, `coverage` → `status --verbose`
 - Deprecation warnings: bare `klemma gaps` → use `klemma status --verbose`; `klemma library -s` → use `klemma research -s`
 - `init --outline` generates an outline after project setup (requires AI backend)

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -3098,6 +3098,55 @@ def prune(ctx, chapter, verdict, clear_key):
     console.print(f"\n[dim]Total: {summary['drop']} drop, {summary['maybe']} maybe[/dim]")
 
 
+@library.command()
+@click.pass_context
+def duplicates(ctx):
+    """Detect duplicate sources by metadata (DOI, author+year+title, title prefix)."""
+    from .skills.duplicate_checker import find_duplicates
+
+    kctx = _get_context(ctx)
+    sources = kctx.state.get_all_sources_metadata()
+
+    if not sources:
+        console.print("[dim]No sources in library.[/dim]")
+        return
+
+    pairs = find_duplicates(sources)
+
+    if not pairs:
+        console.print(f"[green]No duplicates found among {len(sources)} sources.[/green]")
+        return
+
+    table = Table(
+        title=f"Potential Duplicates ({len(pairs)} pairs)",
+        show_edge=False, pad_edge=False,
+    )
+    table.add_column("#", width=4, style="dim")
+    table.add_column("Source A", max_width=30)
+    table.add_column("Source B", max_width=30)
+    table.add_column("Strategy", width=18)
+    table.add_column("Conf", width=5, justify="right")
+    table.add_column("Detail", max_width=50)
+
+    for i, pair in enumerate(pairs, 1):
+        conf_style = "red" if pair.confidence >= 0.9 else "yellow"
+        table.add_row(
+            str(i),
+            f"@{pair.citekey_a}",
+            f"@{pair.citekey_b}",
+            pair.strategy,
+            f"[{conf_style}]{pair.confidence:.1f}[/{conf_style}]",
+            pair.detail,
+        )
+
+    console.print(table)
+    console.print(
+        f"\n[yellow]{len(pairs)} potential duplicate pair(s) found "
+        f"among {len(sources)} sources.[/yellow]"
+    )
+    console.print("[dim]Review and manually remove duplicates from Zotero.[/dim]")
+
+
 # --- Acquire: download + add to Zotero + register ---
 
 @main.command()

--- a/src/klemma/repositories/CLAUDE.md
+++ b/src/klemma/repositories/CLAUDE.md
@@ -32,6 +32,7 @@ Base class providing shared `_conn` factory.
 Source lifecycle, sections, Zotero key management, vault sync.
 - `register_sources()`, `mark_completed()`, `get_source()`, `get_stats()`, `update_source_info()` (persist title/authors/year/abstract/doi)
 - `get_all_sources()` — includes `year` column for recency filtering
+- `get_all_sources_metadata()` — full metadata (title, authors, year, doi) for dedup checks
 - `set_source_sections()` — replaces old `_set_sections_inline`
 - `get_by_section(section, section_type?)` — filter by numeric section or semantic type (#67)
 - `get_existing_source_ids()` — replaces old direct `_conn()` usage in cli.py

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -254,12 +254,13 @@ class SourceRepository(BaseRepository):
             return [dict(row) for row in cur.fetchall()]
 
     def get_all_sources_metadata(self) -> list[dict]:
-        """Get all sources with full metadata for dedup checks."""
+        """Get completed sources with full metadata for dedup checks."""
         with self._conn() as conn:
             cur = conn.execute(
-                """SELECT id, title, authors, year, doi, status
-                   FROM sources
+                """SELECT id, title, authors, year, doi
+                   FROM sources WHERE status=?
                    ORDER BY id""",
+                (ProcessingStatus.COMPLETED,),
             )
             return [dict(row) for row in cur.fetchall()]
 

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -253,6 +253,16 @@ class SourceRepository(BaseRepository):
             )
             return [dict(row) for row in cur.fetchall()]
 
+    def get_all_sources_metadata(self) -> list[dict]:
+        """Get all sources with full metadata for dedup checks."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT id, title, authors, year, doi, status
+                   FROM sources
+                   ORDER BY id""",
+            )
+            return [dict(row) for row in cur.fetchall()]
+
     def get_by_chapter(self, chapter: int) -> list[dict]:
         with self._conn() as conn:
             cur = conn.execute(

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -83,6 +83,12 @@ Local-only paper acquisition pipeline: download → auto-extract metadata → Zo
 - `load_batch()` — parse JSON batch file
 - Dataclasses: `PaperMetadata`, `AcquireResult` (with `zotero_added` bool)
 
+### duplicate_checker.py (120 lines)
+Duplicate source detection by metadata. Pure skill — receives source list, returns duplicate pairs.
+- `DuplicatePair` — dataclass: citekey_a, citekey_b, strategy, confidence, detail
+- `find_duplicates(sources)` — runs 3 strategies, deduplicates pairs, returns sorted by confidence
+- Strategies: DOI match (1.0), author+year+title prefix (0.9), title prefix 50 chars (0.7)
+
 ### suggester.py (162 lines)
 Suggest papers to acquire for filling reference gaps. Pure skill — no file I/O, no CLI.
 - `SuggestCandidate` — dataclass: ref_title, ref_authors, ref_year, score, sections, search_result, pdf_url, doi, acquire_cmd

--- a/src/klemma/skills/duplicate_checker.py
+++ b/src/klemma/skills/duplicate_checker.py
@@ -1,0 +1,135 @@
+"""Duplicate source detection by metadata."""
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DuplicatePair:
+    """A pair of sources suspected to be duplicates."""
+
+    citekey_a: str
+    citekey_b: str
+    strategy: str
+    confidence: float  # 0.0-1.0
+    detail: str = ""
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip, collapse whitespace."""
+    return " ".join(text.lower().split())
+
+
+def _find_doi_duplicates(sources: list[dict]) -> list[DuplicatePair]:
+    """Find sources sharing the same DOI."""
+    doi_map: dict[str, list[str]] = {}
+    for s in sources:
+        doi = (s.get("doi") or "").strip().lower()
+        if doi:
+            doi_map.setdefault(doi, []).append(s["id"])
+
+    pairs = []
+    for doi, ids in doi_map.items():
+        if len(ids) > 1:
+            for i in range(len(ids)):
+                for j in range(i + 1, len(ids)):
+                    pairs.append(DuplicatePair(
+                        citekey_a=ids[i],
+                        citekey_b=ids[j],
+                        strategy="doi",
+                        confidence=1.0,
+                        detail=f"DOI: {doi}",
+                    ))
+    return pairs
+
+
+def _find_author_year_title_duplicates(sources: list[dict]) -> list[DuplicatePair]:
+    """Find sources with same first author surname + year + similar title prefix."""
+    def _first_author_surname(authors: str) -> str:
+        if not authors:
+            return ""
+        first = authors.split(",")[0].split(" and ")[0].strip()
+        parts = first.split()
+        return parts[-1].lower() if parts else ""
+
+    key_map: dict[tuple, list[str]] = {}
+    for s in sources:
+        surname = _first_author_surname(s.get("authors") or "")
+        year = s.get("year")
+        title = _normalize(s.get("title") or "")[:50]
+        if surname and year and title:
+            key = (surname, year, title)
+            key_map.setdefault(key, []).append(s["id"])
+
+    pairs = []
+    for (surname, year, title), ids in key_map.items():
+        if len(ids) > 1:
+            for i in range(len(ids)):
+                for j in range(i + 1, len(ids)):
+                    pairs.append(DuplicatePair(
+                        citekey_a=ids[i],
+                        citekey_b=ids[j],
+                        strategy="author+year+title",
+                        confidence=0.9,
+                        detail=f"{surname} ({year}): {title}...",
+                    ))
+    return pairs
+
+
+def _find_title_prefix_duplicates(sources: list[dict]) -> list[DuplicatePair]:
+    """Find sources with identical title prefix (first 50 chars, normalized)."""
+    prefix_map: dict[str, list[str]] = {}
+    for s in sources:
+        title = _normalize(s.get("title") or "")
+        prefix = title[:50]
+        if len(prefix) >= 15:  # skip very short titles
+            prefix_map.setdefault(prefix, []).append(s["id"])
+
+    pairs = []
+    for prefix, ids in prefix_map.items():
+        if len(ids) > 1:
+            for i in range(len(ids)):
+                for j in range(i + 1, len(ids)):
+                    pairs.append(DuplicatePair(
+                        citekey_a=ids[i],
+                        citekey_b=ids[j],
+                        strategy="title_prefix",
+                        confidence=0.7,
+                        detail=f"Title: {prefix}...",
+                    ))
+    return pairs
+
+
+def find_duplicates(sources: list[dict]) -> list[DuplicatePair]:
+    """Find duplicate sources using all metadata strategies.
+
+    Pure skill: receives source list, returns duplicate pairs.
+    Sources must have keys: id, title, authors, year, doi.
+
+    Strategies (in confidence order):
+    1. DOI match (confidence=1.0)
+    2. Author surname + year + title prefix (confidence=0.9)
+    3. Title prefix 50 chars (confidence=0.7)
+    """
+    if len(sources) < 2:
+        return []
+
+    all_pairs: list[DuplicatePair] = []
+    all_pairs.extend(_find_doi_duplicates(sources))
+    all_pairs.extend(_find_author_year_title_duplicates(sources))
+    all_pairs.extend(_find_title_prefix_duplicates(sources))
+
+    # Deduplicate: same pair may match multiple strategies — keep highest confidence
+    seen: dict[tuple[str, str], DuplicatePair] = {}
+    for pair in all_pairs:
+        key = (min(pair.citekey_a, pair.citekey_b), max(pair.citekey_a, pair.citekey_b))
+        existing = seen.get(key)
+        if existing is None or pair.confidence > existing.confidence:
+            seen[key] = pair
+
+    result = sorted(seen.values(), key=lambda p: (-p.confidence, p.citekey_a))
+    if result:
+        logger.info("Found %d duplicate pair(s)", len(result))
+    return result

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -439,6 +439,13 @@ class StateManager:
         parent = self.parent_state.sources.get_all_sources()
         return self._merge_by_id(child, parent, key="id")
 
+    def get_all_sources_metadata(self) -> list[dict]:
+        child = self.sources.get_all_sources_metadata()
+        if not self.parent_state:
+            return child
+        parent = self.parent_state.sources.get_all_sources_metadata()
+        return self._merge_by_id(child, parent, key="id")
+
     def get_by_chapter(self, chapter: int) -> list[dict]:
         child = self.sources.get_by_chapter(chapter)
         if not self.parent_state:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tests
 
-## Current test suite (775 tests)
+## Current test suite (798 tests)
 - `test_errors.py` (33 lines) — `KlemmaAIError` hierarchy, `retryable` classification, cause chaining
 - `test_ai.py` (170 lines) — `extract_json()`, `AIProviderBase`, `AICallResult` dataclass, `call_with_meta()` base + Claude, `create_ai()` factory
 - `test_ai_litellm.py` (265 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry, `call_with_meta()` with structured error mapping + token extraction
@@ -34,6 +34,7 @@
 - `test_cli_restructuring.py` (~55 lines) — 5 tests: suggest top-level (visible in help, help accessible), gaps suggest backward compat (help, hidden), bare gaps deprecation, library recommend deprecation
 - `test_context_loader.py` (~50 lines) — `load_research_report()`: notes/research/ path, legacy fallback, missing, empty, preference
 - `test_drafter.py` (~190 lines) — `DraftResult` defaults, `_extract_citations` regex, `_filter_hallucinated_citations` (valid/invalid/empty/dedup), `generate_draft` pipeline (with/without research, filtering, empty response), `section_draft.md` template rendering
+- `test_duplicate_checker.py` (~170 lines) — 23 tests: `_normalize`, DOI dedup (same/different/empty/3-way), author+year+title (match/different year/author/missing/and-separator), title prefix (match/short skipped/case insensitive), `find_duplicates` (empty/single/none/dedup across strategies/sorted/dataclass/None fields)
 - `test_prompts.py` (~280 lines) — 25 tests: all 12 prompt templates render without Jinja2 errors, coverage check (all shipped templates have test contexts), reconstruct.md ablation variants (default/max_recs/fewshot/combined), prompt hash determinism + uniqueness, AblationParams defaults + to_snapshot + with_fewshot factory
 - `test_notes_subdirs.py` (~190 lines) — 10 tests: `notes/` subdirectory layout (#34) — researcher save/load (new path, legacy fallback, preference), librarian save to `notes/library/`, agent scanner finds `notes/{research,library,agents}/`, backward compat for flat reports, `update_agents_index` (generation, no-dir, empty-dir, reverse sort)
 - `test_task_model_routing.py` (~166 lines) — 13 tests: `resolve_task_model()` routing (no classes, not in classes, claude returns class, class_model_map priority, litellm with/without map, openai with map), model_override forwarding (ClaudeClient subprocess args, LiteLLMClient completion kwargs), AIConfig task_classes/class_model_map parsing

--- a/tests/test_duplicate_checker.py
+++ b/tests/test_duplicate_checker.py
@@ -1,0 +1,187 @@
+"""Tests for duplicate source detection (duplicate_checker.py)."""
+
+from klemma.skills.duplicate_checker import (
+    DuplicatePair,
+    _find_author_year_title_duplicates,
+    _find_doi_duplicates,
+    _find_title_prefix_duplicates,
+    _normalize,
+    find_duplicates,
+)
+
+
+def _src(citekey, title="", authors="", year=None, doi=""):
+    return {"id": citekey, "title": title, "authors": authors, "year": year, "doi": doi}
+
+
+class TestNormalize:
+    def test_lowercase_and_strip(self):
+        assert _normalize("  Hello  World  ") == "hello world"
+
+    def test_collapses_whitespace(self):
+        assert _normalize("a   b\tc") == "a b c"
+
+    def test_empty(self):
+        assert _normalize("") == ""
+
+
+class TestDoiDuplicates:
+    def test_same_doi(self):
+        sources = [
+            _src("a", doi="10.1234/abc"),
+            _src("b", doi="10.1234/ABC"),  # case-insensitive
+        ]
+        pairs = _find_doi_duplicates(sources)
+        assert len(pairs) == 1
+        assert pairs[0].confidence == 1.0
+        assert pairs[0].strategy == "doi"
+
+    def test_no_doi(self):
+        sources = [_src("a"), _src("b")]
+        assert _find_doi_duplicates(sources) == []
+
+    def test_different_dois(self):
+        sources = [
+            _src("a", doi="10.1234/abc"),
+            _src("b", doi="10.1234/def"),
+        ]
+        assert _find_doi_duplicates(sources) == []
+
+    def test_empty_doi_ignored(self):
+        sources = [
+            _src("a", doi=""),
+            _src("b", doi=""),
+        ]
+        assert _find_doi_duplicates(sources) == []
+
+    def test_three_way_duplicate(self):
+        sources = [
+            _src("a", doi="10.1/x"),
+            _src("b", doi="10.1/x"),
+            _src("c", doi="10.1/x"),
+        ]
+        pairs = _find_doi_duplicates(sources)
+        assert len(pairs) == 3  # a-b, a-c, b-c
+
+
+class TestAuthorYearTitleDuplicates:
+    def test_same_author_year_title(self):
+        sources = [
+            _src("smith2020a", title="Attention mechanisms in neural network architectures for NLP", authors="Smith, John", year=2020),
+            _src("smith2020b", title="Attention mechanisms in neural network architectures for NLP: extended", authors="Smith, J.", year=2020),
+        ]
+        pairs = _find_author_year_title_duplicates(sources)
+        assert len(pairs) == 1
+        assert pairs[0].confidence == 0.9
+
+    def test_different_year(self):
+        sources = [
+            _src("a", title="Same Title Here For Testing", authors="Smith, John", year=2020),
+            _src("b", title="Same Title Here For Testing", authors="Smith, John", year=2021),
+        ]
+        assert _find_author_year_title_duplicates(sources) == []
+
+    def test_different_author(self):
+        sources = [
+            _src("a", title="Same Title Here For Testing", authors="Smith, John", year=2020),
+            _src("b", title="Same Title Here For Testing", authors="Jones, Bob", year=2020),
+        ]
+        assert _find_author_year_title_duplicates(sources) == []
+
+    def test_missing_fields(self):
+        sources = [
+            _src("a", title="", authors="Smith", year=2020),
+            _src("b", title="", authors="Smith", year=2020),
+        ]
+        assert _find_author_year_title_duplicates(sources) == []
+
+    def test_and_separator(self):
+        sources = [
+            _src("a", title="Some Long Title For Matching Purpose", authors="Smith, J. and Jones, B.", year=2020),
+            _src("b", title="Some Long Title For Matching Purpose", authors="Smith, John", year=2020),
+        ]
+        pairs = _find_author_year_title_duplicates(sources)
+        assert len(pairs) == 1
+
+
+class TestTitlePrefixDuplicates:
+    def test_same_prefix(self):
+        sources = [
+            _src("a", title="A comprehensive survey of deep learning approaches in natural language processing"),
+            _src("b", title="A comprehensive survey of deep learning approaches in NLP: extended version"),
+        ]
+        pairs = _find_title_prefix_duplicates(sources)
+        assert len(pairs) == 1
+        assert pairs[0].confidence == 0.7
+
+    def test_short_title_skipped(self):
+        sources = [
+            _src("a", title="Short Title"),
+            _src("b", title="Short Title"),
+        ]
+        assert _find_title_prefix_duplicates(sources) == []
+
+    def test_case_insensitive(self):
+        sources = [
+            _src("a", title="The ROLE of embeddings in modern NLP systems and applications"),
+            _src("b", title="the role of Embeddings in Modern NLP Systems and applications"),
+        ]
+        pairs = _find_title_prefix_duplicates(sources)
+        assert len(pairs) == 1
+
+
+class TestFindDuplicates:
+    def test_empty(self):
+        assert find_duplicates([]) == []
+
+    def test_single_source(self):
+        assert find_duplicates([_src("a")]) == []
+
+    def test_no_duplicates(self):
+        sources = [
+            _src("a", title="Paper A on topic one research", authors="Smith", year=2020, doi="10.1/a"),
+            _src("b", title="Paper B on topic two research", authors="Jones", year=2021, doi="10.1/b"),
+        ]
+        assert find_duplicates(sources) == []
+
+    def test_dedup_across_strategies(self):
+        """Same pair found by DOI and title — keep highest confidence."""
+        sources = [
+            _src("a", title="Attention is all you need for transformers", authors="Vaswani", year=2017, doi="10.1/att"),
+            _src("b", title="Attention is all you need for transformers", authors="Vaswani", year=2017, doi="10.1/att"),
+        ]
+        pairs = find_duplicates(sources)
+        # Should be 1 pair, not 3 (deduped)
+        assert len(pairs) == 1
+        assert pairs[0].confidence == 1.0  # DOI wins
+
+    def test_sorted_by_confidence(self):
+        sources = [
+            _src("a", title="A long paper title about deep learning methods", authors="Smith", year=2020),
+            _src("b", title="A long paper title about deep learning methods", authors="Smith", year=2020),
+            _src("c", title="Another very interesting research paper title", doi="10.1/x"),
+            _src("d", title="Completely different paper from another", doi="10.1/x"),
+        ]
+        pairs = find_duplicates(sources)
+        assert len(pairs) == 2
+        assert pairs[0].confidence >= pairs[1].confidence
+
+    def test_returns_dataclass(self):
+        sources = [
+            _src("a", doi="10.1/same"),
+            _src("b", doi="10.1/same"),
+        ]
+        pairs = find_duplicates(sources)
+        assert len(pairs) == 1
+        assert isinstance(pairs[0], DuplicatePair)
+        assert pairs[0].citekey_a in ("a", "b")
+        assert pairs[0].citekey_b in ("a", "b")
+
+    def test_none_fields_handled(self):
+        """Sources with None for title/authors/doi don't crash."""
+        sources = [
+            {"id": "a", "title": None, "authors": None, "year": None, "doi": None},
+            {"id": "b", "title": None, "authors": None, "year": None, "doi": None},
+        ]
+        pairs = find_duplicates(sources)
+        assert pairs == []


### PR DESCRIPTION
## Summary

- New `klemma library duplicates` command — detects duplicate sources using 3 metadata strategies
- Pure skill in `duplicate_checker.py` — receives source list, returns `DuplicatePair` list
- 23 new tests covering all strategies and edge cases
- Rich table output with confidence scores

Part of #87

## Strategies

| Strategy | Confidence | Description |
|----------|-----------|-------------|
| DOI match | 1.0 | Same DOI, different citekeys |
| Author+Year+Title | 0.9 | Same first author surname + year + 50-char title prefix |
| Title prefix | 0.7 | Identical first 50 chars of normalized title |

Embedding-based detection (cosine > 0.95) and interactive merge (`--resolve`) deferred to follow-up per PM/CTO review.

## Release Note

### Problem
Users with 200+ sources from Zotero often have duplicates: same paper imported with different citekeys, scanned from different sources, or re-added after Zotero sync issues. No way to detect this — duplicates pollute coverage stats, inflate fragment counts, and waste extraction API calls. Prerequisite for three-tier library (#82) where shared corpus requires content-addressable dedup.

### Academic Foundation
Content-addressable deduplication is standard practice in digital library systems (Arms 2000, Bainbridge et al. 2003). DOI as primary identifier follows CrossRef best practices. Author-key matching (surname + year) is the fallback strategy used by BibTeX duplicate checkers including the `check-bib-dupes-and-usage.py` script from the bolkhovsky/phd LaTeX template.

### Implementation
- `skills/duplicate_checker.py` (120 lines) — pure skill with 3 strategies: `_find_doi_duplicates`, `_find_author_year_title_duplicates`, `_find_title_prefix_duplicates`. Cross-strategy dedup keeps highest confidence pair.
- `repositories/sources.py` — new `get_all_sources_metadata()` returning title/authors/year/doi
- `cli.py` — `library duplicates` subcommand with rich table (confidence color-coded)
- `DuplicatePair` dataclass consistent with existing result patterns (DraftResult, SuggestCandidate)

### Results
23 new tests, 798 total (was 775). Lint clean. No new dependencies. Skill is vault/Zotero-independent (SaaS-ready per ADR-009 checklist).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] 23 new tests in `test_duplicate_checker.py` — all pass
- [x] Full suite — 798 passed
- [ ] Manual: `klemma library duplicates` on real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)