### PR TITLE
fix: reassign improvements, context isolation, mutation pattern

### DIFF
--- a/docs/adr/ADR-011-mutation-command-pattern.md
+++ b/docs/adr/ADR-011-mutation-command-pattern.md
@@ -1,0 +1,111 @@
+# ADR-011: Mutation Command Pattern
+
+**Status**: Accepted
+**Date**: 2026-03-07
+**Context**: Inconsistent confirmation UIs across mutation commands
+
+## Problem
+
+Klemma CLI has several commands that mutate state (DB, vault files, external services). Each implemented its own confirmation UI:
+
+| Command | Mutation | Confirmation style |
+|---------|----------|--------------------|
+| `prune --apply` | Delete sources from DB | Per-item y/n/q with details |
+| `reassign --apply` | Add sections to vault frontmatter | Per-item y/n/q with details |
+| `acquire` | Download PDF + register source | Batch confirm |
+| `process` | Extract fragments, overwrite existing | No confirmation |
+| `library prune` | AI generates drop/keep verdicts | No confirmation (suggest-only) |
+
+No shared code, inconsistent default choices, different detail levels.
+
+## Decision
+
+All mutation commands follow a two-phase **suggest → apply** pattern with a shared `interactive_review()` helper.
+
+### Command Categories
+
+| Category | Flags | Behavior |
+|----------|-------|----------|
+| **Read-only** | (none) | Default. Show suggestions/status. No mutation. |
+| **Suggest + apply** | `--apply` | Show suggestions, then per-item interactive confirmation. |
+| **Batch apply** | `--apply --yes` | Auto-accept all items. For scripts and CI. |
+| **Dry run** | `--dry-run` | Preview what would happen without API calls or mutations. |
+
+### Shared Helper: `cli_confirm.py`
+
+```python
+from klemma.cli_confirm import ReviewItem, interactive_review
+
+items = [ReviewItem(
+    key="chevallier2013",
+    header="@chevallierSeasonalForecastsPanArctic2013",
+    details=[
+        ("Fragment", "Seasonal forecasts of Pan-Arctic sea ice..."),
+        ("Current", "3.2 — Разработка методики (sim=0.412)"),
+        ("Suggested", "1.4 — Анализ предметной области (sim=0.687)"),
+    ],
+    action_label="Add section 1.4 to vault frontmatter",
+    data={"citekey": "chevallier2013", "section": "1.4"},
+)]
+
+result = interactive_review(
+    items,
+    console=console,
+    title="Review reassignment suggestions",
+    default_choice="y",
+    yes=auto_yes_flag,
+)
+
+# result.accepted — list of ReviewItem the user said "y" to
+# result.skipped — count of "n" responses
+# result.quit_early — True if user pressed "q"
+```
+
+### Per-Item Display Format
+
+```
+── [1/20] @chevallierSeasonalForecastsPanArctic2013 ──
+  Fragment: Seasonal forecasts of Pan-Arctic sea ice...
+  Current: 3.2 — Разработка методики (sim=0.412)
+  Suggested: 1.4 — Анализ предметной области (sim=0.687)
+  Action: Add section 1.4 to vault frontmatter
+  Accept? [y/n/q] (y):
+```
+
+Every item shows:
+1. **What** — the entity being changed (source, fragment, gap)
+2. **Why** — context for the suggestion (scores, reasons, descriptions)
+3. **Action** — exactly what will happen if accepted
+4. **Prompt** — `y`/`n`/`q` with configurable default
+
+### Rules for New Mutation Commands
+
+1. Default mode is always **read-only** (suggest/display)
+2. `--apply` enables mutations with per-item confirmation
+3. `--yes` / `-y` skips prompts (requires `--apply`)
+4. Use `ReviewItem` + `interactive_review()` from `cli_confirm.py`
+5. After all items, print summary: `N accepted, M skipped, K applied`
+6. Mutations are visible: print what changed after each accepted item
+
+### Migration Plan
+
+| Command | Current | Target | Priority |
+|---------|---------|--------|----------|
+| `reassign --apply` | Custom loop | `interactive_review()` | Now |
+| `prune --apply` | Custom loop | `interactive_review()` | Next |
+| `acquire` (batch) | `click.confirm()` | Keep as-is (batch, not per-item) | Low |
+| `process` | No confirmation | Add `--yes` for overwrite | Low |
+
+## Consequences
+
+- **Consistent UX** across all mutation commands
+- **Shared code** reduces per-command boilerplate (~30 lines → ~10 lines)
+- **Testable** — `ReviewItem` is a dataclass, `interactive_review` is a pure function with injected console
+- **`--yes` flag** enables scripting and CI pipelines
+- All mutations remain **opt-in** — read-only by default
+
+## Alternatives Considered
+
+- **Batch confirmation** (single "apply all?" prompt): Rejected. Per-item review is essential for academic work where wrong assignments have real consequences.
+- **TUI checkbox list**: Over-engineering for CLI. Textual/curses adds complexity for marginal UX gain.
+- **Config-based auto-apply**: Dangerous. Mutations should require explicit intent.

--- a/prompts/annotate.md
+++ b/prompts/annotate.md
@@ -1,4 +1,4 @@
-Analyze a scientific paper and create a structured annotation for a {{ project_type }}.
+Analyze a scientific paper and create a structured annotation for a {{ project_type }}. Respond entirely in {{ language }}.
 
 ## Paper Metadata
 - **Title**: {{ title }}
@@ -101,4 +101,4 @@ Create a JSON annotation with the following structure:
    - **in_library**: false if the reference is not in our library. citekey = null
    - Priority: prefer references NOT in our library — these are gaps
 
-Respond with ONLY valid JSON. No markdown formatting, no explanations. Respond in {{ language }}.
+Respond with ONLY valid JSON in {{ language }}. No markdown formatting, no explanations.

--- a/prompts/librarian.md
+++ b/prompts/librarian.md
@@ -1,4 +1,4 @@
-You are a library analyst for a {{ project_type }}. You analyze the state of sources and provide strategic recommendations.
+You are a library analyst for a {{ project_type }}. You analyze the state of sources and provide strategic recommendations. Respond entirely in {{ language }}.
 
 ## Project Context
 
@@ -142,4 +142,4 @@ Chapter {{ ch }}: {{ chapters[ch] | default("?") }} sources
 }
 ```
 
-Respond with ONLY valid JSON. The report_text field should be a brief summary (NOT the full report — structured data is already in other JSON fields). Respond in {{ language }}.
+Respond with ONLY valid JSON in {{ language }}. The report_text field should be a brief summary (NOT the full report — structured data is already in other JSON fields).

--- a/prompts/librarian_prune.md
+++ b/prompts/librarian_prune.md
@@ -35,4 +35,4 @@ Analyze the list and suggest candidates for removal.
 }
 ```
 
-Respond with ONLY valid JSON. Include only real citekeys from the list above. Respond in {{ language }}.
+Respond entirely in {{ language }}. Respond with ONLY valid JSON. Include only real citekeys from the list above.

--- a/prompts/morning.md
+++ b/prompts/morning.md
@@ -1,4 +1,4 @@
-You are an academic writing assistant for a {{ project_type }}. Philosophy: one focus per day, concrete action, tied to strategy.
+You are an academic writing assistant for a {{ project_type }}. Philosophy: one focus per day, concrete action, tied to strategy. Respond entirely in {{ language }}.
 
 ## Project Context
 
@@ -104,4 +104,4 @@ Generate a morning briefing in JSON format:
 6. **Strategy suggestions** — only when real problems exist
 7. **Identify current session** from the chapter plan based on coverage and gaps
 
-Respond with ONLY valid JSON. Respond in {{ language }}.
+Respond with ONLY valid JSON in {{ language }}.

--- a/prompts/outline.md
+++ b/prompts/outline.md
@@ -87,6 +87,6 @@ Return a JSON object:
 3. **Scientific results** — identify concrete contributions. For papers: 2-3 results. For dissertations: 3-5
 4. **outline_text** — full markdown with `#`/`##`/`###` headings, brief description of each section (1-2 sentences), and estimated word count or page target if available
 5. **Preserve existing assignments** — if sources are already assigned to sections in the database, respect that structure
-6. **Language** — respond in the same language as the project materials
+6. **Language** — respond in {{ language }}. All output (titles, descriptions, outline_text) MUST be in {{ language }}, regardless of the language of source materials
 
 Respond with ONLY valid JSON. Respond in {{ language }}.

--- a/prompts/outline_incremental.md
+++ b/prompts/outline_incremental.md
@@ -112,6 +112,6 @@ Return a JSON object:
 3. **Scientific results** — update if feedback requires, otherwise preserve from previous
 4. **outline_text** — full markdown with `#`/`##`/`###` headings, brief description of each section
 5. **update_summary** — required, summarize what changed vs previous outline
-6. **Language** — respond in the same language as the project materials
+6. **Language** — respond in {{ language }}. All output (titles, descriptions, outline_text) MUST be in {{ language }}, regardless of the language of source materials
 
 Respond with ONLY valid JSON. Respond in {{ language }}.

--- a/prompts/research.md
+++ b/prompts/research.md
@@ -1,4 +1,4 @@
-You are a research analyst for a {{ project_type }}. Your task is to prepare a structured briefing before writing a section.
+You are a research analyst for a {{ project_type }}. Your task is to prepare a structured briefing before writing a section. Respond entirely in {{ language }}, regardless of the language of source materials below.
 
 ## Project Context
 
@@ -137,4 +137,4 @@ Analyze the readiness of section {{ target_section }} for writing and generate a
 8. **Source priority** — prefer quality >= 4, citation_priority = high, relevance >= 4
 9. **fragment_distribution** — distribution of available fragments by type (from provided data)
 
-Respond with ONLY valid JSON. Respond in {{ language }}.
+Respond with ONLY valid JSON in {{ language }}.

--- a/prompts/research_incremental.md
+++ b/prompts/research_incremental.md
@@ -1,4 +1,4 @@
-You are a research analyst for a {{ project_type }}. This is a REPEAT analysis of a section — update the previous briefing based on new data.
+You are a research analyst for a {{ project_type }}. This is a REPEAT analysis of a section — update the previous briefing based on new data. Respond entirely in {{ language }}, regardless of the language of source materials below.
 
 ## Project Context
 
@@ -140,4 +140,4 @@ Return updated JSON in the same format:
 }
 ```
 
-Respond with ONLY valid JSON. Respond in {{ language }}.
+Respond with ONLY valid JSON in {{ language }}.

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -59,7 +59,7 @@ Semantic section vocabulary — cross-project labels for dissertation/paper sect
 - `infer_section_type(chapter_name)` — keyword matching → `SectionType | None`
 - `resolve_section_identifier(input, config?)` — parse CLI input: numeric `"2.3"` → `(section, None)`, semantic `"methodology"` → `(section?, SectionType)`
 
-### state.py (~870 lines)
+### state.py (~965 lines)
 SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v10), auto-migrates via `_migrate_schema()`. All 70+ public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
 
 **DB inheritance (#55):** `set_parent(db_path)` attaches a read-only parent `StateManager`. Nine read methods merge parent data: `get_all_sources`, `get_by_chapter`, `get_by_section`, `get_fragments`, `get_coverage_stats`, `retrieve_similar_fragments`, `get_fragment_embeddings`, `get_all_embeddings`, `get_reference_gaps`. Child wins on key collision. Writes go only to child DB. Controlled by `StateConfig.inherit_db` (default `True`).

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -60,7 +60,7 @@ Semantic section vocabulary — cross-project labels for dissertation/paper sect
 - `resolve_section_identifier(input, config?)` — parse CLI input: numeric `"2.3"` → `(section, None)`, semantic `"methodology"` → `(section?, SectionType)`
 
 ### state.py (~870 lines)
-SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v9), auto-migrates via `_migrate_schema()`. All 70+ public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
+SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v10), auto-migrates via `_migrate_schema()`. All 70+ public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
 
 **DB inheritance (#55):** `set_parent(db_path)` attaches a read-only parent `StateManager`. Nine read methods merge parent data: `get_all_sources`, `get_by_chapter`, `get_by_section`, `get_fragments`, `get_coverage_stats`, `retrieve_similar_fragments`, `get_fragment_embeddings`, `get_all_embeddings`, `get_reference_gaps`. Child wins on key collision. Writes go only to child DB. Controlled by `StateConfig.inherit_db` (default `True`).
 
@@ -69,7 +69,7 @@ SQLite state manager — **facade** over 8 domain repositories in `repositories/
 Tables:
 - `sources` — Zotero entries (citekey, title, authors, year, abstract, doi, status, chapter, quality, pdf_path, `embedding` BLOB float32, `embedding_model` TEXT)
 - `source_sections` — junction table: source_id × section × `section_type` (multi-section support)
-- `fragments` — extracted citation fragments (text, type, chapter, section, `section_type`, relevance, page, `citation_intent`: background/method/result_comparison, `embedding` BLOB float32, `embedding_model` TEXT)
+- `fragments` — extracted citation fragments (text, type, chapter, section, `section_type`, relevance, page, `citation_intent`: background/method/result_comparison, `embedding` BLOB float32, `embedding_model` TEXT, `UNIQUE(source_id, fragment_text)`)
 - `reference_gaps` — missing references from bibliographies (status: open/resolved, score, `citation_intent`, `section_type`, intent-weighted scoring)
 - `section_type_map` — lookup table: numeric section → semantic type + chapter (populated from config)
 - `citation_links` — citation graph: source_id → target (title_hash MD5 for dedup, citation_intent, in_library flag)
@@ -78,6 +78,7 @@ Tables:
 - `prune_verdicts` — librarian audit results (drop/maybe with reason)
 - `benchmark_runs` — benchmark run history (run_id, timestamp, metrics JSON, paper_citekey, git_commit, klemma_version, config_snapshot, duration)
 - `section_embeddings` — section centroid embeddings (section × embedding_model composite PK, BLOB float32, source_count, updated_at)
+- `reassign_skips` — persisted skip decisions for `reassign` command (PK: source_id, from_section, to_section; `--fresh` clears)
 
 Key methods: `register_sources()`, `update_source_info()`, `get_by_section(section, section_type?)` (JOIN on `source_sections`), `get_coverage_stats()` (includes `section_types` dict), `get_gap_summary()`, `save_plan()`, `save_citation_links()`, `get_citation_graph()`, `save_embedding()`, `get_embeddings()`, `save_section_embedding()`, `get_section_embedding()`, `get_all_section_embeddings()`, `get_section_embedding_stats()`, `save_prune_verdicts()`, `get_prune_verdicts()`, `save_benchmark_run()`, `get_benchmark_runs()`, `compare_benchmark_runs()`, `sync_section_types(config)`.
 

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -364,6 +364,12 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
     if auto_register_mode == "none":
         vault_data = [vd for vd in vault_data if vd["citekey"] in existing]
 
+    # Filter out vault notes that match old (renamed-from) citekeys —
+    # prevents sync_source_sections from re-creating the old source row.
+    renamed_from = {old_ck for old_ck, _ in renames}
+    if renamed_from:
+        vault_data = [vd for vd in vault_data if vd["citekey"] not in renamed_from]
+
     result = state.sync_source_sections(vault_data, new_entries)
 
     # Backfill metadata (title/authors/year/abstract/doi) from library for sources missing it

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -763,7 +763,12 @@ def init(ctx, project_type, global_only, no_input, non_interactive, force, outli
             embeddings_backend=_emb,
         )
 
-    result = init_project(project_dir, project_type=project_type, values=values)
+    # Detect parent project before init — affects config defaults (ADR-012)
+    pre_chain = discover_project_chain(project_dir.parent)
+    _has_parent = len(pre_chain) > 0
+
+    result = init_project(project_dir, project_type=project_type, values=values,
+                          has_parent=_has_parent)
 
     # Overwrite KLEMMA.md with rich plan content if plan was provided
     effective_plan = plan_data or (values.plan_data if values else None)

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -3506,15 +3506,17 @@ def reassign(ctx, threshold, limit, apply, fresh):
 
     # Load full fragment texts for detailed display
     frag_texts: dict[int, str] = {}
-    all_frag_ids: set[int] = set()
+    all_frag_ids: list[int] = []
     for s in suggestions:
-        all_frag_ids.update(s.get("frag_ids", [s["frag_id"]]))
+        all_frag_ids.extend(s.get("frag_ids", [s["frag_id"]]))
     if all_frag_ids:
-        frags = state.get_fragments(limit=len(all_frag_ids) + 10)
-        frag_texts = {
-            f["id"]: f.get("fragment_text", "")
-            for f in frags if f["id"] in all_frag_ids
-        }
+        with state._conn() as conn:
+            placeholders = ",".join("?" * len(all_frag_ids))
+            cur = conn.execute(
+                f"SELECT id, fragment_text FROM fragments WHERE id IN ({placeholders})",
+                all_frag_ids,
+            )
+            frag_texts = {row["id"]: row["fragment_text"] for row in cur.fetchall()}
 
     # Build ReviewItems
     review_items = []

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -2486,12 +2486,32 @@ def research(ctx, section, no_save, force, model):
     chapter = parse_chapter_from_section(section)
 
     # Auto-process unextracted sources
-    with console.status(f"Auto-processing unextracted sources for section {section}", spinner="arc"):
+    from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn
+
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("[dim]{task.fields[status]}[/dim]"),
+        console=console,
+        transient=True,
+    )
+    task_id = progress.add_task(
+        f"Extracting fragments for section {section}",
+        total=None,
+        status="scanning sources...",
+    )
+
+    def _on_extract_progress(ck: str, status: str, i: int, n: int) -> None:
+        progress.update(task_id, total=n, completed=i, status=f"@{ck}: {status}")
+
+    with progress:
         extract_result = pre_extract_sources(
             section, chapter, cfg, state, vault, ai,
             force=force,
             library=kctx.library,
-            on_progress=lambda ck, st, i, n: None,  # suppress inside spinner
+            on_progress=_on_extract_progress,
             dissertation_context=kctx.dissertation_context,
             available_tags=kctx.available_tags,
             klemma_home=kctx.klemma_home,

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -3248,8 +3248,12 @@ def duplicates(ctx):
               help="Minimum cosine similarity for suggestion (default: 0.5)")
 @click.option("--limit", "-n", type=int, default=20,
               help="Max suggestions to show (default: 20)")
+@click.option("--apply", is_flag=True, default=False,
+              help="Apply suggestions: add sections to vault frontmatter")
+@click.option("--fresh", is_flag=True, default=False,
+              help="Clear saved skip decisions and show all suggestions")
 @click.pass_context
-def reassign(ctx, threshold, limit):
+def reassign(ctx, threshold, limit, apply, fresh):
     """Suggest fragment-to-section reassignments based on embedding similarity."""
     from .embeddings import cosine_similarity
 
@@ -3339,13 +3343,43 @@ def reassign(ctx, threshold, limit):
                     "preview": (meta.get("text_preview") or "")[:80],
                 })
 
-    # Deduplicate: keep best score per (source, suggested section)
-    seen: dict[tuple[str, str], dict] = {}
+    # Group by (citekey, current, suggested) — collect all fragment IDs per group
+    groups: dict[tuple[str, str, str], dict] = {}
     for s in raw_suggestions:
-        key = (s["citekey"], s["suggested"])
-        if key not in seen or s["score"] > seen[key]["score"]:
-            seen[key] = s
-    suggestions = list(seen.values())
+        key = (s["citekey"], s["current"], s["suggested"])
+        if key not in groups:
+            groups[key] = {**s, "frag_ids": [s["frag_id"]]}
+        else:
+            groups[key]["frag_ids"].append(s["frag_id"])
+            if s["score"] > groups[key]["score"]:
+                # Keep best-scoring fragment's metadata as representative
+                best_frag_ids = groups[key]["frag_ids"]
+                groups[key].update(s)
+                groups[key]["frag_ids"] = best_frag_ids
+
+    # Filter out previously skipped suggestions
+    if fresh:
+        cleared = state.clear_reassign_skips()
+        if cleared:
+            console.print(f"[dim]Cleared {cleared} saved skip(s).[/dim]")
+        skips: set[tuple[str, str, str]] = set()
+    else:
+        skips = state.get_reassign_skips()
+
+    suggestions = []
+    skipped_by_memory = 0
+    for key, group in groups.items():
+        source_id, from_sec, to_sec = key
+        if (source_id, from_sec, to_sec) in skips:
+            skipped_by_memory += 1
+            continue
+        suggestions.append(group)
+
+    if skipped_by_memory:
+        console.print(
+            f"[dim]Filtered {skipped_by_memory} previously skipped suggestion(s). "
+            f"Use --fresh to reset.[/dim]"
+        )
 
     if not suggestions:
         console.print(
@@ -3366,9 +3400,11 @@ def reassign(ctx, threshold, limit):
         sug_name = _section_label(sug_sec)
         delta = s["delta"]
         runner_up = s.get("runner_up")
+        frag_count = len(s.get("frag_ids", [1]))
 
         console.print(f"[bold]── [{i}/{len(suggestions)}] @{s['citekey']} ──[/bold]")
-        console.print(f"  [dim]Fragment:[/dim] {s['preview']}")
+        count_label = f" ({frag_count} fragments)" if frag_count > 1 else ""
+        console.print(f"  [dim]Fragment:[/dim] {s['preview']}{count_label}")
         console.print(
             f"  [dim]Current:[/dim]   {cur_sec}"
             + (f" ({cur_name})" if cur_name else "")
@@ -3391,10 +3427,185 @@ def reassign(ctx, threshold, limit):
             )
         console.print()
 
+    if not apply:
+        console.print(
+            f"[dim]{total} suggestions total (showing top {len(suggestions)}). "
+            f"Use --apply to reassign fragments interactively.[/dim]"
+        )
+        return
+
+    # --- Apply: per-item interactive confirmation (ADR-011) ---
+    from .cli_confirm import ReviewItem, interactive_review
+
+    vault = kctx.vault
+    notes_folder = kctx.config.obsidian.notes_folder
+
+    # Build section description: type + sample source titles
+    section_type_labels: dict[str, str] = {}
+    if project:
+        type_map = project.section_type_map or {}
+        for sec_id, sec_type in type_map.items():
+            section_type_labels[sec_id] = sec_type
+        # Infer subsection types from parent: 1.4.1 → type of "1"
+        for ch_num in (project.chapters or {}):
+            if str(ch_num) in type_map:
+                section_type_labels[str(ch_num)] = type_map[str(ch_num)]
+
+    # Sample source titles per section (top 3 by relevance)
+    section_samples: dict[str, list[str]] = {}
+    try:
+        with state._conn() as conn:
+            cur = conn.execute(
+                """SELECT ss.section, s.title
+                   FROM source_sections ss
+                   JOIN sources s ON ss.source_id = s.id
+                   WHERE s.title IS NOT NULL AND s.title != ''
+                   ORDER BY ss.section"""
+            )
+            for row in cur.fetchall():
+                sec = row["section"]
+                section_samples.setdefault(sec, [])
+                if len(section_samples[sec]) < 3:
+                    title = row["title"]
+                    if title and len(title) > 60:
+                        title = title[:57] + "..."
+                    if title:
+                        section_samples[sec].append(title)
+    except Exception:
+        pass
+
+    def _describe_section(sec_id: str) -> str:
+        parts = []
+        # Section type (inherit from parent chapter if not explicitly mapped)
+        st = section_type_labels.get(sec_id)
+        if not st:
+            ch = sec_id.split(".")[0]
+            st = section_type_labels.get(ch)
+        if st:
+            parts.append(f"[{st}]")
+        # Chapter name (short — just the chapter number)
+        ch_num = sec_id.split(".")[0]
+        ch_name = chapter_names.get(ch_num)
+        if ch_name and sec_id != ch_num:
+            # Truncate long chapter names for subsections
+            short = ch_name[:50] + "..." if len(ch_name) > 50 else ch_name
+            parts.append(f"Гл. {ch_num}: {short}")
+        elif ch_name:
+            parts.append(ch_name)
+        # Sample sources in this section
+        samples = section_samples.get(sec_id, [])
+        if samples:
+            parts.append(f"({len(samples)}+ sources: {samples[0]})")
+        return " | ".join(parts) if parts else sec_id
+
+    # Load full fragment texts for detailed display
+    frag_texts: dict[int, str] = {}
+    all_frag_ids: set[int] = set()
+    for s in suggestions:
+        all_frag_ids.update(s.get("frag_ids", [s["frag_id"]]))
+    if all_frag_ids:
+        frags = state.get_fragments(limit=len(all_frag_ids) + 10)
+        frag_texts = {
+            f["id"]: f.get("fragment_text", "")
+            for f in frags if f["id"] in all_frag_ids
+        }
+
+    # Build ReviewItems
+    review_items = []
+    for s in suggestions:
+        frag_ids_list = s.get("frag_ids", [s["frag_id"]])
+        frag_text = frag_texts.get(s["frag_id"], s["preview"])
+        display_text = frag_text[:200] + ("..." if len(frag_text) > 200 else "")
+        cur_sec = s["current"]
+        sug_sec = s["suggested"]
+        cur_desc = _describe_section(cur_sec) if cur_sec != "(none)" else "unassigned"
+        sug_desc = _describe_section(sug_sec)
+        score_style = "green" if s["score"] >= 0.7 else "yellow"
+        frag_count = len(frag_ids_list)
+        count_note = f" ({frag_count} fragments)" if frag_count > 1 else ""
+
+        review_items.append(ReviewItem(
+            key=f"{s['citekey']}:{cur_sec}:{sug_sec}",
+            header=f"@{s['citekey']}{count_note}",
+            details=[
+                ("Fragment", display_text),
+                ("Current", f"{cur_sec} — {cur_desc}  (sim={s['current_score']:.3f})"),
+                ("Suggested", f"[{score_style}]{sug_sec}[/{score_style}] — "
+                              f"{sug_desc}  (sim={s['score']:.3f}, +{s['delta']:.3f})"),
+            ],
+            action_label=(
+                f"Move {frag_count} fragment(s) from {cur_sec} → {sug_sec}"
+            ),
+            data={
+                "citekey": s["citekey"],
+                "frag_ids": frag_ids_list,
+                "section": sug_sec,
+                "from_section": cur_sec,
+            },
+        ))
+
+    result = interactive_review(
+        review_items,
+        console=console,
+        title="Review reassignment suggestions",
+    )
+
+    # Save skip decisions for items not accepted
+    new_skips: list[tuple[str, str, str]] = []
+    accepted_keys = {item.key for item in result.accepted}
+    for item in review_items:
+        if item.key not in accepted_keys:
+            new_skips.append((
+                item.data["citekey"],
+                item.data["from_section"],
+                item.data["section"],
+            ))
+    if new_skips:
+        state.save_reassign_skips_batch(new_skips)
+
+    if not result.accepted:
+        console.print(f"[dim]No changes applied ({result.skipped} skipped).[/dim]")
+        return
+
+    # 1. Update fragment sections in DB — move ALL fragments per group
+    moved = 0
+    for item in result.accepted:
+        for frag_id in item.data["frag_ids"]:
+            ok = state.update_fragment_section(frag_id, item.data["section"])
+            if ok:
+                moved += 1
+
+    # 2. Also add new sections to vault frontmatter (if source not already associated)
+    vault_updates = 0
+    additions: dict[str, set[str]] = {}
+    for item in result.accepted:
+        additions.setdefault(item.data["citekey"], set()).add(item.data["section"])
+
+    for citekey, new_sections in additions.items():
+        note_name = f"@{citekey}"
+        props = vault.get_properties(note_name)
+        if not props:
+            continue
+
+        current = set(str(s) for s in props.get("sections", []))
+        merged = current | new_sections
+        if merged == current:
+            continue
+
+        ok = vault.update_frontmatter_sections(
+            note_name, list(merged), folder=notes_folder,
+        )
+        if ok:
+            added = sorted(merged - current)
+            vault_updates += 1
+            console.print(
+                f"  [dim]Vault @{citekey}: added sections {', '.join(added)}[/dim]"
+            )
+
     console.print(
-        f"[dim]{total} suggestions total (showing top {len(suggestions)}). "
-        f"Edit vault frontmatter 'sections:' to reassign, "
-        f"then run any command to sync.[/dim]"
+        f"\n[green]{moved} fragment(s) reassigned in DB, "
+        f"{result.skipped} skipped.[/green]"
+        + (f" [dim]{vault_updates} vault note(s) updated.[/dim]" if vault_updates else "")
     )
 
 

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -3515,7 +3515,6 @@ def reassign(ctx, threshold, limit, apply, fresh):
     for s in suggestions:
         frag_ids_list = s.get("frag_ids", [s["frag_id"]])
         frag_text = frag_texts.get(s["frag_id"], s["preview"])
-        display_text = frag_text[:200] + ("..." if len(frag_text) > 200 else "")
         cur_sec = s["current"]
         sug_sec = s["suggested"]
         cur_desc = _describe_section(cur_sec) if cur_sec != "(none)" else "unassigned"
@@ -3528,7 +3527,7 @@ def reassign(ctx, threshold, limit, apply, fresh):
             key=f"{s['citekey']}:{cur_sec}:{sug_sec}",
             header=f"@{s['citekey']}{count_note}",
             details=[
-                ("Fragment", display_text),
+                ("Fragment", frag_text),
                 ("Current", f"{cur_sec} — {cur_desc}  (sim={s['current_score']:.3f})"),
                 ("Suggested", f"[{score_style}]{sug_sec}[/{score_style}] — "
                               f"{sug_desc}  (sim={s['score']:.3f}, +{s['delta']:.3f})"),

--- a/src/klemma/cli_confirm.py
+++ b/src/klemma/cli_confirm.py
@@ -1,0 +1,113 @@
+"""Shared interactive confirmation UI for mutation commands (ADR-011).
+
+Pattern: suggest → review → apply. All mutation commands with --apply
+use this module for consistent per-item confirmation UX.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+import click
+from rich.console import Console
+
+
+@dataclass
+class ReviewItem:
+    """One item to present for user confirmation.
+
+    Attributes:
+        key: Unique identifier (e.g. citekey, fragment ID).
+        header: Bold first line (e.g. "@citekey" or "paper title").
+        details: Lines of context shown before the prompt.
+            Each entry is (label, value) — rendered as "  label: value".
+        action_label: What accepting means (e.g. "Add section 1.4", "Delete").
+        data: Arbitrary payload passed through to the apply callback.
+    """
+    key: str
+    header: str
+    details: list[tuple[str, str]] = field(default_factory=list)
+    action_label: str = ""
+    data: dict = field(default_factory=dict)
+
+
+@dataclass
+class ReviewResult:
+    """Outcome of an interactive review session."""
+    accepted: list[ReviewItem] = field(default_factory=list)
+    skipped: int = 0
+    quit_early: bool = False
+
+
+def interactive_review(
+    items: list[ReviewItem],
+    *,
+    console: Console,
+    title: str = "Review items",
+    default_choice: str = "y",
+    yes: bool = False,
+    on_accept: Optional[Callable[[ReviewItem], Optional[str]]] = None,
+) -> ReviewResult:
+    """Run a per-item y/n/q interactive review loop.
+
+    Args:
+        items: Items to review.
+        console: Rich console for output.
+        title: Header printed before the loop.
+        default_choice: Default for the prompt ("y" or "n").
+        yes: Skip prompts, auto-accept all (for --yes flag).
+        on_accept: Optional callback called immediately when item is accepted.
+            Returns an optional status message to display (e.g. "[red]Deleted[/red]").
+
+    Returns:
+        ReviewResult with accepted items, skip count, and quit flag.
+    """
+    if not items:
+        console.print("[dim]No items to review.[/dim]")
+        return ReviewResult()
+
+    console.print(f"\n[bold]{title} ({len(items)} items)[/bold]")
+    console.print("[dim]y = accept, n = skip, q = quit[/dim]\n")
+
+    result = ReviewResult()
+
+    for i, item in enumerate(items, 1):
+        # Header
+        console.print(f"[bold]── [{i}/{len(items)}] {item.header} ──[/bold]")
+
+        # Detail lines
+        for label, value in item.details:
+            if label:
+                console.print(f"  [dim]{label}:[/dim] {value}")
+            else:
+                console.print(f"  {value}")
+
+        # Action description
+        if item.action_label:
+            console.print(f"  [bold]Action:[/bold] {item.action_label}")
+
+        if yes:
+            choice = "y"
+        else:
+            choice = click.prompt(
+                "  Accept?",
+                type=click.Choice(["y", "n", "q"]),
+                default=default_choice,
+            )
+
+        if choice == "q":
+            console.print("[dim]Stopped.[/dim]")
+            result.quit_early = True
+            break
+        elif choice == "y":
+            result.accepted.append(item)
+            if on_accept:
+                msg = on_accept(item)
+                if msg:
+                    console.print(f"  {msg}")
+        else:
+            result.skipped += 1
+            console.print("  [dim]Skipped[/dim]")
+
+        console.print()
+
+    return result

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -807,31 +807,32 @@ def resolve_effective_config(
 
 
 def load_project_context(project_chain: list[Path], config: Optional[KlemmaConfig] = None) -> str:
-    """Load and aggregate KLEMMA.md files from project chain.
+    """Load project context from KLEMMA.md.
 
-    project_chain is child-first. Result: parent context first, then child.
+    For nested projects (chain > 1), returns ONLY the child's context.
+    Child projects are independent — they reuse parent's library via
+    inherit_db, not parent's dissertation context (ADR-012).
+
+    For solo projects (chain == 1), returns that project's context.
     Falls back to .klemma/context.md (legacy) and then config fields.
     """
-    contexts: list[str] = []
+    # Child project = first in chain (child-first order)
+    target_root = project_chain[0] if project_chain else None
 
-    for root in reversed(project_chain):  # parent first
+    if target_root:
         # Try KLEMMA.md first
-        klemma_md = root / "KLEMMA.md"
+        klemma_md = target_root / "KLEMMA.md"
         if klemma_md.exists():
             text = klemma_md.read_text(encoding="utf-8").strip()
             if text:
-                contexts.append(text)
-                continue
+                return text
 
         # Legacy fallback: .klemma/context.md
-        context_md = root / ".klemma" / "context.md"
+        context_md = target_root / ".klemma" / "context.md"
         if context_md.exists():
             text = context_md.read_text(encoding="utf-8").strip()
             if text:
-                contexts.append(text)
-
-    if contexts:
-        return "\n\n---\n\n".join(contexts)
+                return text
 
     # Final fallback: build from config fields
     if config:

--- a/src/klemma/repositories/CLAUDE.md
+++ b/src/klemma/repositories/CLAUDE.md
@@ -40,9 +40,10 @@ Source lifecycle, sections, Zotero key management, vault sync.
 - `sync_source_sections()` — vault frontmatter bidirectional sync
 - `rename_source()`, `delete_source()` — cascade operations
 
-### fragments.py (~250 lines)
-Fragment CRUD, citation intent coverage, and fragment-level embeddings.
-- `save_fragments()`, `get_fragments(section_type?)`, `get_fragment_stats()`
+### fragments.py (~330 lines)
+Fragment CRUD, citation intent coverage, fragment-level embeddings, and reassign skip persistence.
+- `save_fragments()` — `INSERT OR IGNORE` (UNIQUE constraint on source_id+fragment_text prevents duplicates)
+- `get_fragments(section_type?)`, `get_fragment_stats()`
 - `get_intent_coverage()` — section x intent matrix
 - `get_embedded_fragment_metadata(model?)` — id, source_id, section, chapter, text_preview for fragments with embeddings
 - `save_fragment_embedding()` — store vector BLOB (struct.pack float32)
@@ -50,6 +51,9 @@ Fragment CRUD, citation intent coverage, and fragment-level embeddings.
 - `get_fragment_embedding_stats()` — coverage stats (total, embedded, by model)
 - `get_unembedded_fragments()` — fragments missing embeddings
 - `retrieve_similar_fragments(query_embedding, top_k, model?)` — top-K cosine retrieval
+- `save_reassign_skip()`, `save_reassign_skips_batch()` — persist skip decisions for `reassign`
+- `get_reassign_skips()` — return `{(source_id, from, to)}` set
+- `clear_reassign_skips()` — remove all skips (used by `--fresh`)
 
 ### embeddings_store.py (~180 lines)
 Vector BLOB storage with model versioning.

--- a/src/klemma/repositories/fragments.py
+++ b/src/klemma/repositories/fragments.py
@@ -11,9 +11,10 @@ class FragmentRepository(BaseRepository):
     def save_fragments(self, source_id: str, fragments: list[dict]) -> int:
         """Save extracted fragments and update source fragment count."""
         with self._conn() as conn:
+            inserted = 0
             for f in fragments:
-                conn.execute(
-                    """INSERT INTO fragments
+                cur = conn.execute(
+                    """INSERT OR IGNORE INTO fragments
                        (source_id, fragment_text, fragment_type, chapter, section,
                         relevance_score, usage_hint, page_number, citation_intent)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
@@ -29,11 +30,12 @@ class FragmentRepository(BaseRepository):
                         f.get("citation_intent"),
                     ),
                 )
+                inserted += cur.rowcount
             conn.execute(
                 "UPDATE sources SET fragment_count=? WHERE id=?",
-                (len(fragments), source_id),
+                (inserted, source_id),
             )
-            return len(fragments)
+            return inserted
 
     def get_fragments(
         self,
@@ -103,6 +105,15 @@ class FragmentRepository(BaseRepository):
             for row in cur.fetchall():
                 stats["by_section"][row["section"]] = row["cnt"]
             return stats
+
+    def update_fragment_section(self, fragment_id: int, section: str) -> bool:
+        """Update the section assignment for a single fragment. Returns True if modified."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE fragments SET section=? WHERE id=?",
+                (section, fragment_id),
+            )
+            return cur.rowcount > 0
 
     def delete_fragments(self, source_id: str) -> int:
         """Delete all fragments for a source. Returns number of deleted rows."""
@@ -230,6 +241,49 @@ class FragmentRepository(BaseRepository):
                 (limit,),
             )
             return [dict(row) for row in cur.fetchall()]
+
+    # ── Reassign skips ─────────────────────────────────────────────────
+
+    def save_reassign_skip(
+        self, source_id: str, from_section: str, to_section: str,
+    ) -> None:
+        """Record that the user skipped a reassign suggestion."""
+        with self._conn() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO reassign_skips "
+                "(source_id, from_section, to_section) VALUES (?, ?, ?)",
+                (source_id, from_section, to_section),
+            )
+
+    def save_reassign_skips_batch(
+        self, skips: list[tuple[str, str, str]],
+    ) -> int:
+        """Batch-save skip decisions. Each tuple: (source_id, from, to)."""
+        with self._conn() as conn:
+            for source_id, from_sec, to_sec in skips:
+                conn.execute(
+                    "INSERT OR REPLACE INTO reassign_skips "
+                    "(source_id, from_section, to_section) VALUES (?, ?, ?)",
+                    (source_id, from_sec, to_sec),
+                )
+            return len(skips)
+
+    def get_reassign_skips(self) -> set[tuple[str, str, str]]:
+        """Return all skip decisions as {(source_id, from_section, to_section)}."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "SELECT source_id, from_section, to_section FROM reassign_skips"
+            )
+            return {
+                (row["source_id"], row["from_section"], row["to_section"])
+                for row in cur.fetchall()
+            }
+
+    def clear_reassign_skips(self) -> int:
+        """Remove all skip decisions. Returns count removed."""
+        with self._conn() as conn:
+            cur = conn.execute("DELETE FROM reassign_skips")
+            return cur.rowcount
 
     def retrieve_similar_fragments(
         self,

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -41,8 +41,13 @@ class InitValues:
             self.keywords = []
 
 
-def _build_project_config(values: InitValues) -> dict:
-    """Build config dict from wizard values."""
+def _build_project_config(values: InitValues, *, has_parent: bool = False) -> dict:
+    """Build config dict from wizard values.
+
+    When has_parent=True, skip ai/embeddings defaults — child projects
+    inherit these from parent via config cascade (ADR-012).
+    Only write language override and explicitly provided values.
+    """
     cfg: dict = {}
 
     # Zotero (only if paths provided)
@@ -63,20 +68,30 @@ def _build_project_config(values: InitValues) -> dict:
             obsidian["tags_folder"] = values.tags_folder
         cfg["obsidian"] = obsidian
 
-    # AI — backend-aware model naming
-    ai_cfg: dict = {"language": values.language}
-    if values.backend:
-        ai_cfg["backend"] = values.backend
-    if values.ai_model:
-        ai_cfg["model"] = values.ai_model
-    elif values.backend == "claude":
-        ai_cfg["model"] = "sonnet"
-    elif values.backend == "litellm":
-        ai_cfg["model"] = "anthropic/claude-sonnet-4-6"
+    # AI — skip backend/model defaults for child projects (inherited from parent)
+    if has_parent:
+        ai_cfg: dict = {"language": values.language}
+        # Only write backend/model if explicitly provided by user
+        if values.backend:
+            ai_cfg["backend"] = values.backend
+        if values.ai_model:
+            ai_cfg["model"] = values.ai_model
+        cfg["ai"] = ai_cfg
     else:
-        # No backend chosen — use shorthand, klemmarc will define backend
-        ai_cfg["model"] = "sonnet"
-    cfg["ai"] = ai_cfg
+        # Root project — write full AI config
+        ai_cfg = {"language": values.language}
+        if values.backend:
+            ai_cfg["backend"] = values.backend
+        if values.ai_model:
+            ai_cfg["model"] = values.ai_model
+        elif values.backend == "claude":
+            ai_cfg["model"] = "sonnet"
+        elif values.backend == "litellm":
+            ai_cfg["model"] = "anthropic/claude-sonnet-4-6"
+        else:
+            # No backend chosen — use shorthand, klemmarc will define backend
+            ai_cfg["model"] = "sonnet"
+        cfg["ai"] = ai_cfg
 
     # Project
     project: dict = {"type": values.project_type}
@@ -269,11 +284,16 @@ def init_project(
     project_dir: Path,
     project_type: str = "dissertation",
     values: Optional[InitValues] = None,
+    *,
+    has_parent: bool = False,
 ) -> dict:
     """Create .klemma/ project in project_dir + KLEMMA.md.
 
     If values is provided (interactive mode), writes config from discovered/prompted
     values. Otherwise falls back to example template (--no-input / legacy).
+
+    When has_parent=True, child project config skips ai/embeddings defaults —
+    these are inherited from parent via config cascade (ADR-012).
 
     Returns dict with keys: created (list of file names), skipped (list).
     """
@@ -291,7 +311,7 @@ def init_project(
     else:
         if values:
             values.project_type = project_type
-            cfg = _build_project_config(values)
+            cfg = _build_project_config(values, has_parent=has_parent)
             text = yaml.dump(cfg, default_flow_style=False, allow_unicode=True, sort_keys=False)
             config_target.write_text(text, encoding="utf-8")
         else:

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -206,7 +206,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 9  # bump this when adding new migrations
+        target = 10  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -360,6 +360,69 @@ class StateManager:
                 source_count INTEGER DEFAULT 0,
                 updated_at TEXT,
                 PRIMARY KEY (section, embedding_model)
+            )""")
+
+        if version < 10:
+            import logging
+            _log = logging.getLogger("klemma.state")
+
+            # 10a. Dedup fragments: keep lowest id per (source_id, fragment_text)
+            cur = conn.execute(
+                """DELETE FROM fragments WHERE id NOT IN (
+                    SELECT MIN(id) FROM fragments
+                    GROUP BY source_id, fragment_text
+                )"""
+            )
+            if cur.rowcount:
+                _log.info("v10 migration: removed %d duplicate fragments", cur.rowcount)
+
+            # 10b. Rebuild fragments table with UNIQUE(source_id, fragment_text)
+            conn.executescript("""
+                CREATE TABLE fragments_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id TEXT NOT NULL REFERENCES sources(id),
+                    fragment_text TEXT NOT NULL,
+                    fragment_type TEXT,
+                    chapter INTEGER,
+                    section TEXT,
+                    relevance_score INTEGER,
+                    usage_hint TEXT,
+                    page_number INTEGER,
+                    extracted_at TEXT DEFAULT (datetime('now')),
+                    used_in_draft BOOLEAN DEFAULT 0,
+                    citation_intent TEXT,
+                    embedding BLOB,
+                    embedding_model TEXT,
+                    section_type TEXT,
+                    UNIQUE(source_id, fragment_text)
+                );
+
+                INSERT OR IGNORE INTO fragments_new
+                    (id, source_id, fragment_text, fragment_type, chapter, section,
+                     relevance_score, usage_hint, page_number, extracted_at,
+                     used_in_draft, citation_intent, embedding, embedding_model,
+                     section_type)
+                SELECT id, source_id, fragment_text, fragment_type, chapter, section,
+                       relevance_score, usage_hint, page_number, extracted_at,
+                       used_in_draft, citation_intent, embedding, embedding_model,
+                       section_type
+                FROM fragments;
+
+                DROP TABLE fragments;
+                ALTER TABLE fragments_new RENAME TO fragments;
+
+                CREATE INDEX IF NOT EXISTS idx_fragments_source ON fragments(source_id);
+                CREATE INDEX IF NOT EXISTS idx_fragments_section ON fragments(section);
+                CREATE INDEX IF NOT EXISTS idx_fragments_type ON fragments(fragment_type);
+            """)
+
+            # 10c. Create reassign_skips table
+            conn.execute("""CREATE TABLE IF NOT EXISTS reassign_skips (
+                source_id TEXT NOT NULL,
+                from_section TEXT NOT NULL,
+                to_section TEXT NOT NULL,
+                skipped_at TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (source_id, from_section, to_section)
             )""")
 
         conn.execute(f"PRAGMA user_version = {target}")
@@ -521,11 +584,26 @@ class StateManager:
     def get_embedded_fragment_metadata(self, model: Optional[str] = None) -> list[dict]:
         return self.fragments.get_embedded_fragment_metadata(model)
 
+    def update_fragment_section(self, fragment_id: int, section: str) -> bool:
+        return self.fragments.update_fragment_section(fragment_id, section)
+
     def get_fragment_embedding_stats(self) -> dict:
         return self.fragments.get_fragment_embedding_stats()
 
     def get_unembedded_fragments(self, limit: int = 100000) -> list[dict]:
         return self.fragments.get_unembedded_fragments(limit)
+
+    def save_reassign_skip(self, source_id: str, from_section: str, to_section: str):
+        return self.fragments.save_reassign_skip(source_id, from_section, to_section)
+
+    def save_reassign_skips_batch(self, skips: list[tuple[str, str, str]]) -> int:
+        return self.fragments.save_reassign_skips_batch(skips)
+
+    def get_reassign_skips(self) -> set[tuple[str, str, str]]:
+        return self.fragments.get_reassign_skips()
+
+    def clear_reassign_skips(self) -> int:
+        return self.fragments.clear_reassign_skips()
 
     def retrieve_similar_fragments(
         self, query_embedding: list[float], top_k: int = 10, model: Optional[str] = None

--- a/src/klemma/vault.py
+++ b/src/klemma/vault.py
@@ -252,6 +252,42 @@ class VaultAdapter:
         d.mkdir(exist_ok=True)
         return d
 
+    def update_frontmatter_sections(
+        self, name: str, sections: list[str], folder: Optional[str] = None,
+    ) -> bool:
+        """Update the 'sections' list in a note's YAML frontmatter.
+
+        Rewrites the frontmatter block with the new sections list.
+        Returns True if the file was modified, False if not found.
+        """
+        import yaml
+
+        # Find the file
+        if folder:
+            target = self._resolve_folder(folder) / f"{name}.md"
+            if not target.exists():
+                return False
+        else:
+            found = list(self.vault_path.rglob(f"{name}.md"))
+            if not found:
+                return False
+            target = found[0]
+
+        text = target.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            return False
+        end = text.find("---", 3)
+        if end == -1:
+            return False
+
+        fm = yaml.safe_load(text[3:end]) or {}
+        fm["sections"] = sorted(sections, key=lambda s: [int(x) for x in s.split(".")])
+
+        new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        new_text = f"---\n{new_fm}---{text[end + 3:]}"
+        target.write_text(new_text, encoding="utf-8")
+        return True
+
     @staticmethod
     def _parse_frontmatter(text: str) -> dict:
         """Extract YAML frontmatter from markdown text."""

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 9
+        assert version == 10
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 9
+        assert version == 10
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_cli_confirm.py
+++ b/tests/test_cli_confirm.py
@@ -1,0 +1,88 @@
+"""Tests for shared interactive confirmation UI (ADR-011)."""
+
+from unittest.mock import patch
+
+from rich.console import Console
+
+from klemma.cli_confirm import ReviewItem, interactive_review
+
+
+def _items(n=3):
+    return [
+        ReviewItem(
+            key=f"item-{i}",
+            header=f"Item {i}",
+            details=[("Label", f"Detail {i}")],
+            action_label=f"Do thing {i}",
+            data={"index": i},
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+class TestInteractiveReview:
+
+    def test_accept_all_with_yes_flag(self):
+        items = _items(3)
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(items, console=console, yes=True)
+        assert len(result.accepted) == 3
+        assert result.skipped == 0
+        assert result.quit_early is False
+
+    @patch("klemma.cli_confirm.click.prompt", return_value="n")
+    def test_skip_all(self, mock_prompt):
+        items = _items(2)
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(items, console=console)
+        assert len(result.accepted) == 0
+        assert result.skipped == 2
+
+    @patch("klemma.cli_confirm.click.prompt", side_effect=["y", "n", "y"])
+    def test_mixed_choices(self, mock_prompt):
+        items = _items(3)
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(items, console=console)
+        assert len(result.accepted) == 2
+        assert result.skipped == 1
+        assert result.accepted[0].key == "item-1"
+        assert result.accepted[1].key == "item-3"
+
+    @patch("klemma.cli_confirm.click.prompt", side_effect=["y", "q"])
+    def test_quit_early(self, mock_prompt):
+        items = _items(5)
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(items, console=console)
+        assert len(result.accepted) == 1
+        assert result.quit_early is True
+
+    def test_empty_items(self):
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review([], console=console)
+        assert len(result.accepted) == 0
+        assert result.skipped == 0
+
+    def test_on_accept_callback(self):
+        called_with = []
+
+        def on_accept(item):
+            called_with.append(item.key)
+            return "[green]Done[/green]"
+
+        items = _items(2)
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(
+            items, console=console, yes=True, on_accept=on_accept,
+        )
+        assert called_with == ["item-1", "item-2"]
+        assert len(result.accepted) == 2
+
+    def test_data_preserved(self):
+        items = [ReviewItem(
+            key="test",
+            header="Test",
+            data={"citekey": "smith2023", "section": "1.4"},
+        )]
+        console = Console(file=open("/dev/null", "w"))
+        result = interactive_review(items, console=console, yes=True)
+        assert result.accepted[0].data == {"citekey": "smith2023", "section": "1.4"}

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -290,8 +290,8 @@ class TestLoadProjectContext:
         assert "My Dissertation" in result
         assert "ice forecasting" in result
 
-    def test_nested_parent_first(self, tmp_path):
-        """Parent context appears first, child second."""
+    def test_nested_child_only(self, tmp_path):
+        """Child project uses only its own context, not parent's (ADR-012)."""
         parent = tmp_path / "thesis"
         child = parent / "paper1"
         (parent / ".klemma").mkdir(parents=True)
@@ -302,11 +302,13 @@ class TestLoadProjectContext:
         from klemma.config import load_project_context
 
         result = load_project_context([child, parent])
-        # Parent should come first
-        assert result.index("Dissertation") < result.index("Paper 1")
-        assert "---" in result  # separator
+        # Child context only — parent excluded (ADR-012)
+        assert "Paper 1" in result
+        assert "Dissertation" not in result
+        assert "---" not in result  # no separator
 
-    def test_missing_klemma_md_skipped(self, tmp_path):
+    def test_missing_child_klemma_md_falls_back_to_config(self, tmp_path):
+        """When child has no KLEMMA.md, fall back to config fields, not parent."""
         parent = tmp_path / "thesis"
         child = parent / "paper1"
         (parent / ".klemma").mkdir(parents=True)
@@ -314,10 +316,16 @@ class TestLoadProjectContext:
         # Only parent has KLEMMA.md
         (parent / "KLEMMA.md").write_text("# Dissertation")
 
-        from klemma.config import load_project_context
+        from klemma.config import KlemmaConfig, load_project_context
 
-        result = load_project_context([child, parent])
-        assert "Dissertation" in result
+        cfg = KlemmaConfig.model_validate({
+            "obsidian": {"vault_path": "/v"},
+            "project": {"type": "paper", "title": "My Paper"},
+        })
+        result = load_project_context([child, parent], config=cfg)
+        # Should fall back to config, not use parent
+        assert "My Paper" in result
+        assert "Dissertation" not in result
 
     def test_legacy_context_md_fallback(self, tmp_path):
         (tmp_path / ".klemma").mkdir()
@@ -460,6 +468,43 @@ class TestInitProject:
         content = (tmp_path / ".gitignore").read_text()
         assert ".klemma/data/" in content
         assert "*.pyc" in content
+
+
+    def test_child_project_skips_ai_defaults(self, tmp_path):
+        """Child project config should not write backend/model defaults (ADR-012)."""
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(
+            title="My Paper",
+            description="A paper",
+            language="en",
+            project_type="paper",
+        )
+        init_project(tmp_path, project_type="paper", values=values, has_parent=True)
+        import yaml
+        cfg = yaml.safe_load((tmp_path / ".klemma" / "config.yaml").read_text())
+        ai = cfg.get("ai", {})
+        assert ai.get("language") == "en"
+        assert "backend" not in ai  # inherited from parent
+        assert "model" not in ai  # inherited from parent
+
+    def test_root_project_writes_ai_defaults(self, tmp_path):
+        """Root project config should write backend/model defaults."""
+        from klemma.setup import InitValues, init_project
+
+        values = InitValues(
+            title="My Dissertation",
+            description="A dissertation",
+            language="ru",
+            project_type="dissertation",
+            backend="litellm",
+        )
+        init_project(tmp_path, project_type="dissertation", values=values, has_parent=False)
+        import yaml
+        cfg = yaml.safe_load((tmp_path / ".klemma" / "config.yaml").read_text())
+        ai = cfg.get("ai", {})
+        assert ai.get("backend") == "litellm"
+        assert "model" in ai  # default model written
 
 
 class TestInitSystem:

--- a/tests/test_reassign_apply.py
+++ b/tests/test_reassign_apply.py
@@ -1,0 +1,164 @@
+"""Tests for reassign --apply: fragment reassignment + vault frontmatter updates."""
+
+import pytest
+import yaml
+
+from klemma.state import StateManager
+from klemma.vault import VaultAdapter
+
+
+def _make_note(sections=None, extra=None):
+    """Create a minimal vault note with YAML frontmatter."""
+    fm = {"citekey": "testKey2023", "title": "Test Paper"}
+    if sections is not None:
+        fm["sections"] = sections
+    if extra:
+        fm.update(extra)
+    body = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    return f"---\n{body}---\n\n> Some content here\n"
+
+
+class TestUpdateFrontmatterSections:
+    """Test VaultAdapter.update_frontmatter_sections()."""
+
+    def test_adds_new_sections(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text(_make_note(sections=["1.1", "2.3"]))
+
+        ok = vault.update_frontmatter_sections("@testKey2023", ["1.1", "2.3", "3.2"])
+        assert ok is True
+
+        props = vault.get_properties("@testKey2023")
+        assert set(props["sections"]) == {"1.1", "2.3", "3.2"}
+
+    def test_sorts_sections_numerically(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text(_make_note(sections=["3.2"]))
+
+        vault.update_frontmatter_sections("@testKey2023", ["3.2", "1.1", "2.3"])
+        props = vault.get_properties("@testKey2023")
+        assert props["sections"] == ["1.1", "2.3", "3.2"]
+
+    def test_preserves_other_frontmatter(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text(_make_note(
+            sections=["1.1"],
+            extra={"quality": 4, "chapter": 3, "tags": ["Sea Ice"]},
+        ))
+
+        vault.update_frontmatter_sections("@testKey2023", ["1.1", "2.3"])
+        props = vault.get_properties("@testKey2023")
+        assert props["quality"] == 4
+        assert props["chapter"] == 3
+        assert props["tags"] == ["Sea Ice"]
+        assert set(props["sections"]) == {"1.1", "2.3"}
+
+    def test_preserves_body_content(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text(_make_note(sections=["1.1"]))
+
+        vault.update_frontmatter_sections("@testKey2023", ["1.1", "2.3"])
+        text = note.read_text()
+        assert "> Some content here" in text
+
+    def test_returns_false_for_missing_note(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        ok = vault.update_frontmatter_sections("@nonexistent", ["1.1"])
+        assert ok is False
+
+    def test_returns_false_for_no_frontmatter(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text("No frontmatter here, just text.")
+
+        ok = vault.update_frontmatter_sections("@testKey2023", ["1.1"])
+        assert ok is False
+
+    def test_creates_sections_from_empty(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        note.write_text(_make_note(sections=None))
+
+        vault.update_frontmatter_sections("@testKey2023", ["2.1", "3.3"])
+        props = vault.get_properties("@testKey2023")
+        assert props["sections"] == ["2.1", "3.3"]
+
+    def test_folder_parameter(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        refs = tmp_path / "2 - Refs"
+        refs.mkdir()
+        note = refs / "@testKey2023.md"
+        note.write_text(_make_note(sections=["1.1"]))
+
+        ok = vault.update_frontmatter_sections(
+            "@testKey2023", ["1.1", "3.2"], folder="2 - Refs",
+        )
+        assert ok is True
+        props = vault.get_properties("@testKey2023")
+        assert "3.2" in props["sections"]
+
+    def test_unicode_preserved(self, tmp_path):
+        vault = VaultAdapter(str(tmp_path), use_cli=False)
+        note = tmp_path / "@testKey2023.md"
+        content = _make_note(
+            sections=["1.1"],
+            extra={"title": "Прогнозирование ледовой обстановки"},
+        )
+        note.write_text(content)
+
+        vault.update_frontmatter_sections("@testKey2023", ["1.1", "2.3"])
+        props = vault.get_properties("@testKey2023")
+        assert props["title"] == "Прогнозирование ледовой обстановки"
+        assert set(props["sections"]) == {"1.1", "2.3"}
+
+
+class TestUpdateFragmentSection:
+    """Test fragment-level section reassignment in DB."""
+
+    @pytest.fixture
+    def state(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        return StateManager(str(db_path))
+
+    def test_reassign_fragment_section(self, state):
+        state.register_sources(["src1"])
+        state.fragments.save_fragments("src1", [
+            {"text": "Fragment about ice prediction", "type": "key_idea",
+             "section": "1.4", "relevance": 5},
+        ])
+        # Verify original
+        frags = state.get_fragments(source_id="src1")
+        assert frags[0]["section"] == "1.4"
+
+        # Reassign
+        ok = state.update_fragment_section(frags[0]["id"], "3.3")
+        assert ok is True
+
+        # Verify updated
+        frags = state.get_fragments(source_id="src1")
+        assert frags[0]["section"] == "3.3"
+
+    def test_reassign_nonexistent_fragment(self, state):
+        ok = state.update_fragment_section(99999, "1.1")
+        assert ok is False
+
+    def test_reassign_preserves_other_fields(self, state):
+        state.register_sources(["src1"])
+        state.fragments.save_fragments("src1", [
+            {"text": "Important fragment", "type": "methodology",
+             "section": "2.1", "relevance": 4, "citation_intent": "method"},
+        ])
+        frags = state.get_fragments(source_id="src1")
+        frag_id = frags[0]["id"]
+
+        state.update_fragment_section(frag_id, "3.2")
+
+        frags = state.get_fragments(source_id="src1")
+        assert frags[0]["section"] == "3.2"
+        assert frags[0]["fragment_type"] == "methodology"
+        assert frags[0]["relevance_score"] == 4
+        assert frags[0]["citation_intent"] == "method"

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 9
+    assert version == 10
     conn.close()
 
 


### PR DESCRIPTION
## Summary

- **Reassign fixes**: stop rename loops from author+year collisions, show full fragment text in review, persist skip decisions so suggestions don't repeat
- **Context isolation (ADR-012, #108)**: child projects use only their own KLEMMA.md — parent dissertation context no longer leaks into AI prompts. Fixes wrong language and wrong structure in sub-project AI commands
- **Mutation pattern (ADR-011)**: shared `cli_confirm.py` with `ReviewItem`/`interactive_review()` for consistent `--apply` UX across all mutation commands
- **Prompt language**: all 8 prompt templates reinforced with `Respond entirely in {{ language }}` at the top
- **Init defaults**: `klemma init` in sub-project skips ai/embeddings defaults when parent exists

## Test plan

- [x] 841 tests passing, lint clean
- [x] `test_nested_child_only` — verifies parent context excluded for nested projects
- [x] `test_child_project_skips_ai_defaults` — verifies init doesn't write backend/model for child
- [x] 22 orphan resolution tests covering collision, suffix, self-match
- [x] 19 cli_confirm + reassign apply tests
- [ ] Manual: `klemma research -s 1` in TITDS sub-project outputs English briefing

Closes #108
Part of #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)