### PR TITLE
fix: filter ghost sources without metadata from draft prompts

### DIFF
--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -1,9 +1,12 @@
 """Source management repository — CRUD, status, sections, Zotero keys, vault sync."""
 
+import logging
 from datetime import date, datetime
 from typing import Optional
 
 from .base import BaseRepository
+
+logger = logging.getLogger(__name__)
 
 # Subquery for filtering out sources marked for pruning
 PRUNE_DROP_SUBQUERY = (
@@ -97,6 +100,18 @@ class SourceRepository(BaseRepository):
                    ON CONFLICT(date) DO UPDATE SET count = count + 1""",
                 (today,),
             )
+
+            # Warn if source completed without metadata (#114)
+            row = conn.execute(
+                "SELECT title, authors FROM sources WHERE id = ?",
+                (source_id,),
+            ).fetchone()
+            if row and (not row[0]) and (not row[1]):
+                logger.warning(
+                    "Source %s marked completed without title/authors — "
+                    "will be excluded from draft prompts",
+                    source_id,
+                )
 
     def update_source_metadata(
         self,
@@ -252,7 +267,8 @@ class SourceRepository(BaseRepository):
             cur = conn.execute(
                 """SELECT id, note_path, quality_score, primary_chapter,
                           primary_section, relevance_nr1, relevance_nr2,
-                          citation_priority, fragment_count, year
+                          citation_priority, fragment_count, year,
+                          title, authors
                    FROM sources WHERE status=?
                    ORDER BY primary_chapter, citation_priority DESC, quality_score DESC""",
                 (ProcessingStatus.COMPLETED,),
@@ -275,7 +291,7 @@ class SourceRepository(BaseRepository):
             cur = conn.execute(
                 f"""SELECT DISTINCT s.id, s.note_path, s.quality_score, s.primary_section,
                           s.relevance_nr1, s.relevance_nr2, s.citation_priority,
-                          s.fragment_count
+                          s.fragment_count, s.title, s.authors
                    FROM sources s
                    LEFT JOIN source_sections ss ON s.id = ss.source_id
                    WHERE s.status=? AND (s.primary_chapter=? OR ss.chapter=?)
@@ -294,7 +310,8 @@ class SourceRepository(BaseRepository):
                 cur = conn.execute(
                     f"""SELECT DISTINCT s.id, s.note_path, s.quality_score,
                               s.primary_chapter, s.relevance_nr1, s.relevance_nr2,
-                              s.citation_priority, s.fragment_count
+                              s.citation_priority, s.fragment_count,
+                              s.title, s.authors
                        FROM sources s
                        JOIN source_sections ss ON s.id = ss.source_id
                        WHERE s.status=? AND ss.section_type=?
@@ -306,7 +323,8 @@ class SourceRepository(BaseRepository):
                 cur = conn.execute(
                     f"""SELECT DISTINCT s.id, s.note_path, s.quality_score,
                               s.primary_chapter, s.relevance_nr1, s.relevance_nr2,
-                              s.citation_priority, s.fragment_count
+                              s.citation_priority, s.fragment_count,
+                              s.title, s.authors
                        FROM sources s
                        LEFT JOIN source_sections ss ON s.id = ss.source_id
                        WHERE s.status=? AND (s.primary_section LIKE ? OR ss.section LIKE ?)

--- a/src/klemma/skills/context_loader.py
+++ b/src/klemma/skills/context_loader.py
@@ -124,6 +124,9 @@ def load_section_sources(
 
         sources = sources[:max_sources]
 
+    # Filter out ghost sources with no metadata (#114)
+    sources = [s for s in sources if s.get("title") and s.get("authors")]
+
     enriched = []
     for src in sources:
         citekey = src["id"]

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -206,7 +206,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 10  # bump this when adding new migrations
+        target = 11  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -424,6 +424,23 @@ class StateManager:
                 skipped_at TEXT DEFAULT (datetime('now')),
                 PRIMARY KEY (source_id, from_section, to_section)
             )""")
+
+        if version < 11:
+            import logging
+            _log = logging.getLogger("klemma.state")
+
+            # 11: Mark ghost sources (no title AND no authors) as incomplete
+            cur = conn.execute(
+                """UPDATE sources SET status = 'incomplete'
+                   WHERE (title IS NULL OR title = '')
+                     AND (authors IS NULL OR authors = '')
+                     AND status != 'incomplete'"""
+            )
+            if cur.rowcount:
+                _log.info(
+                    "v11 migration: marked %d ghost sources as incomplete",
+                    cur.rowcount,
+                )
 
         conn.execute(f"PRAGMA user_version = {target}")
 

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 10
+        assert version == 11
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 10
+        assert version == 11
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_context_loader.py
+++ b/tests/test_context_loader.py
@@ -1,7 +1,8 @@
 """Tests for context_loader shared helpers."""
 
+from unittest.mock import MagicMock
 
-from klemma.skills.context_loader import load_research_report
+from klemma.skills.context_loader import load_research_report, load_section_sources
 
 
 class TestLoadResearchReport:
@@ -49,3 +50,86 @@ class TestLoadResearchReport:
         result = load_research_report("1.2", tmp_path)
 
         assert result == "new path"
+
+
+class TestLoadSectionSourcesMetadataGate:
+    """Ghost sources without title/authors are excluded (#114)."""
+
+    def _make_state(self, sources):
+        state = MagicMock()
+        state.get_by_section.return_value = sources
+        state.get_by_chapter.return_value = []
+        state.get_all_sources.return_value = sources
+        return state
+
+    def _make_vault(self):
+        vault = MagicMock()
+        vault.read_note.return_value = None
+        return vault
+
+    def test_ghost_source_excluded(self):
+        """Source with no title and no authors is filtered out."""
+        sources = [
+            {"id": "ghostKey", "title": None, "authors": None,
+             "quality_score": 4, "citation_priority": "medium"},
+        ]
+        state = self._make_state(sources)
+        vault = self._make_vault()
+
+        result = load_section_sources("1.1", 1, state, vault)
+
+        assert len(result) == 0
+
+    def test_source_with_metadata_included(self):
+        """Source with title and authors passes the filter."""
+        sources = [
+            {"id": "smith2024Ice", "title": "Ice Dynamics",
+             "authors": "Smith, J.", "quality_score": 4,
+             "citation_priority": "high"},
+        ]
+        state = self._make_state(sources)
+        vault = self._make_vault()
+
+        result = load_section_sources("1.1", 1, state, vault)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "smith2024Ice"
+
+    def test_mixed_sources_only_valid_pass(self):
+        """Only sources with metadata survive the filter."""
+        sources = [
+            {"id": "goodKey", "title": "A Paper", "authors": "Author, A.",
+             "quality_score": 3, "citation_priority": "medium"},
+            {"id": "ghostKey", "title": "", "authors": "",
+             "quality_score": 4, "citation_priority": "high"},
+            {"id": "anotherGood", "title": "Another", "authors": "B.",
+             "quality_score": 2, "citation_priority": "low"},
+        ]
+        state = self._make_state(sources)
+        vault = self._make_vault()
+
+        result = load_section_sources("1.1", 1, state, vault)
+
+        ids = [r["id"] for r in result]
+        assert "goodKey" in ids
+        assert "anotherGood" in ids
+        assert "ghostKey" not in ids
+
+    def test_ghost_excluded_with_citekey_filter(self):
+        """Ghost sources also excluded when using citekey_filter (RAG path)."""
+        sources = [
+            {"id": "ghostRAG", "title": None, "authors": None,
+             "quality_score": 4, "citation_priority": "medium"},
+            {"id": "realRAG", "title": "Real Paper", "authors": "Auth",
+             "quality_score": 3, "citation_priority": "medium"},
+        ]
+        state = self._make_state(sources)
+        vault = self._make_vault()
+
+        result = load_section_sources(
+            "1.1", 1, state, vault,
+            citekey_filter={"ghostRAG", "realRAG"},
+        )
+
+        assert len(result) == 1
+        assert result[0]["id"] == "realRAG"

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 10
+    assert version == 11
     conn.close()
 
 


### PR DESCRIPTION
## Summary

Fixes #114. Sources with no title/authors (32 ghost entries in titds-2025 DB) were passing through `load_section_sources()` into draft prompts, causing the LLM to cite them based on citekey name alone (e.g. `@RemoteSensingFree` → cited as a remote sensing paper).

- Filter sources missing title or authors in `context_loader.load_section_sources()`
- Add `title`/`authors` columns to `get_by_section`, `get_by_chapter`, `get_all_sources` queries
- DB migration v11: mark ghost sources as `status='incomplete'`
- Warning in `mark_completed` when source has no metadata
- 4 new tests for the metadata gate

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `python -m pytest tests/ -q` — 880 passed
- [x] Ghost source excluded from `load_section_sources()` result
- [x] Source with title+authors included normally
- [x] Mixed sources: only valid pass through
- [x] Ghost excluded via RAG citekey_filter path too

🤖 Generated with [Claude Code](https://claude.com/claude-code)