### PR TITLE
feat: Protocol interfaces + content hashing (ADR-014, PR A)

### DIFF
--- a/docs/adr/ADR-014-three-tier-library-split.md
+++ b/docs/adr/ADR-014-three-tier-library-split.md
@@ -1,0 +1,106 @@
+# ADR-014: Three-tier library split
+
+**Status**: Accepted
+**Date**: 2026-03-10
+**Epic**: #82
+**Supersedes**: ADR-005 (three-tier spec, previously unimplemented)
+
+## Context
+
+Klemma uses a monolithic SQLite database per project. When a user works on multiple projects (dissertation + papers) with overlapping PDFs, extraction and embedding are repeated for every project — wasting API costs (Claude ~$0.03/paper, OpenAI ~$0.001/paper) and wall-clock time (~30s/paper). The `inherit_db` mechanism (ADR-002) attempted to solve this by attaching a parent DB read-only, but it's fragile, creates merge complexity in 9 read methods, and doesn't scale to SaaS (no concept of shared corpus).
+
+Current state: 966 tests, cli.py ~5950 lines, state.py ~965 lines, 8 domain repositories, DB v11.
+
+## Decision
+
+Split the monolithic `klemma.db` into two databases:
+
+```
+~/.klemma/library.db              ← shared: papers, fragments, embeddings, citations
+project/.klemma/data/project.db   ← per-project: assignments, gaps, plans, benchmarks
+```
+
+### Key design choices
+
+**1. Protocol interfaces as the boundary**
+
+Three runtime-checkable Protocols: `PaperStore` (global corpus), `UserLibrary` (user's collection), `ProjectStore` (per-project data). Each has a local SQLite implementation (Phase 1) and will have a PostgreSQL implementation (SaaS, Phase 2). StateManager becomes a facade over these three stores.
+
+**2. Content-addressable fragment IDs**
+
+Fragment IDs use `content_hash` = SHA256(paper_id + fragment_text + page_number). This is deterministic, globally unique, and supports dedup: same PDF + same extraction = same fragment IDs. No UUIDs for immutable content.
+
+**3. No ATTACH DATABASE**
+
+Each Protocol implementation queries its own DB independently. The StateManager facade merges results in Python. This ensures the same code works with PostgreSQL (SaaS) — ATTACH is SQLite-specific.
+
+**4. Dual-write migration**
+
+During transition, `_process_single()` writes to BOTH monolithic DB and library.db. This validates the split without breaking existing flows. The monolithic write path is removed only after the project DB split is complete and `klemma migrate` has been run.
+
+**5. Deferred to SaaS sprint**
+
+- Privacy model (visibility levels, consent flows, `auto_share_published`)
+- `user_preferences` table
+- `user_tags` table
+- Multi-user `user_id` columns
+
+These add complexity without delivering value for CLI single-user mode.
+
+### What lives where
+
+| Data | Store | Rationale |
+|------|-------|-----------|
+| Paper metadata (title, authors, DOI, abstract) | PaperStore (library.db) | Same paper for everyone |
+| PDF hash (SHA256) | PaperStore | Content-addressable dedup |
+| Extracted fragments (text, type, page, intent) | PaperStore | Deterministic: same PDF + prompt = same fragments |
+| Paper + fragment embeddings | PaperStore | Deterministic: same text + model = same vector |
+| Citation graph | PaperStore | Objective bibliographic relationship |
+| Extraction versioning (prompt_hash, ai_model) | PaperStore | Enables re-extraction on prompt upgrade |
+| User's citekey mapping | UserLibrary (library.db) | Different users may use different BibTeX keys |
+| Source status (pending/completed/failed) | UserLibrary | User's processing progress |
+| Zotero integration (pdf_path, note_path) | UserLibrary | User's local Zotero instance |
+| Quality score | UserLibrary | Per-user assessment |
+| Chapter/section assignment | ProjectStore (project.db) | Same paper → different sections in different projects |
+| Fragment relevance score, usage_hint | ProjectStore | Per-project relevance |
+| Reference gaps | ProjectStore | Gaps depend on project's section structure |
+| Section type map | ProjectStore | Project-specific vocabulary |
+| Plans, reading queue, prune verdicts, benchmarks | ProjectStore | Per-project workflow |
+
+## Execution plan
+
+**4 independently shippable PRs, each maintaining backward compat:**
+
+| PR | Name | Depends on | Deliverable |
+|----|------|------------|-------------|
+| A | Protocol interfaces + hashing | — | Types, data classes, pdf_hash + content_hash. Zero behavior change. |
+| B | LocalPaperStore + library.db | A | Dedup on process/embed. Dual-write to library.db + monolithic. |
+| C | Project DB split + migration | B | LocalProjectStore, `klemma migrate`, remove `inherit_db`. |
+| D | cli.py split into command groups | — (parallel) | Reduce cli.py from ~5950 to <1000 lines. |
+
+PR D can proceed in parallel with A/B/C.
+
+## Consequences
+
+- **Removes** `inherit_db` / `set_parent()` / `_merge_by_id()` — the most fragile hack in the codebase
+- **Removes** 9 merge methods in StateManager that handle parent-child data merging
+- **Enables** SaaS: same Protocol interfaces, PostgreSQL+pgvector backend
+- **Enables** dedup: `klemma process` in project B instantly finds fragments from project A
+- **Requires** `klemma migrate` for existing users (with dry-run, backup, rollback)
+- **Changes** StateManager from facade-over-8-repos to facade-over-3-stores
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Migration corrupts data | HIGH | Backup before migration, dry-run mode, rollback |
+| Fragment ID collision during migration | MEDIUM | Content-hash is deterministic — same content = same hash |
+| Performance: Python-level merge vs SQL JOIN | LOW | Profile after PR B; optimize if >100ms |
+| cli.py changes across 18 commands | HIGH | PR D (cli.py split) reduces blast radius |
+
+## Alternatives considered
+
+1. **ATTACH DATABASE for cross-DB queries** — rejected: SQLite-specific, won't port to PostgreSQL
+2. **UUID fragment IDs** — rejected: content-addressable is better for immutable content
+3. **Big-bang rewrite in single PR** — rejected: too risky, 3000-5000 LOC change with no intermediate checkpoints
+4. **Keep inherit_db, add dedup layer on top** — rejected: adds complexity to already fragile mechanism

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -88,6 +88,25 @@ Tables:
 
 Key methods: `register_sources()`, `update_source_info()`, `get_by_section(section, section_type?)` (JOIN on `source_sections`), `get_coverage_stats()` (includes `section_types` dict), `get_gap_summary()`, `save_plan()`, `save_citation_links()`, `get_citation_graph()`, `save_embedding()`, `get_embeddings()`, `save_section_embedding()`, `get_section_embedding()`, `get_all_section_embeddings()`, `get_section_embedding_stats()`, `save_prune_verdicts()`, `get_prune_verdicts()`, `save_benchmark_run()`, `get_benchmark_runs()`, `compare_benchmark_runs()`, `sync_section_types(config)`.
 
+### hashing.py (25 lines)
+Content-addressable hashing utilities for the three-tier library (ADR-014). Pure stdlib, no internal dependencies.
+- `compute_pdf_hash(pdf_path)` — SHA256 of PDF bytes for content-addressable paper dedup
+- `compute_content_hash(paper_id, text, page)` — SHA256 fragment ID (deterministic: same PDF + extraction = same IDs)
+- `compute_prompt_hash(prompt_text)` — first 16 hex chars of SHA256 for extraction prompt versioning
+
+### protocols.py (100 lines)
+Protocol interfaces for the three-tier library split (ADR-014). Defines the boundary between tiers.
+- `PaperStore` — content-addressable paper storage (Global Corpus): find/register papers, save/get fragments and embeddings
+- `UserLibrary` — user's personal collection: citekey→paper_id mapping, source status
+- `ProjectStore` — per-project data: section assignments, coverage stats, reference gaps
+All three are `@runtime_checkable`. Skills do NOT import this module.
+
+### models.py (60 lines)
+Data classes for the three-tier storage layer (ADR-014). Distinct from `literature/models.py` (AI extraction output).
+- `PaperRecord` — global corpus paper (paper_id, pdf_hash, doi, title, authors, year, abstract)
+- `FragmentRecord` — stored fragment with content-addressable ID (fragment_id = content_hash)
+- `UserSource` — user's source entry mapping citekey → global paper_id
+
 ### errors.py (32 lines)
 Klemma error taxonomy for AI backends.
 - `KlemmaAIError` — base class with `retryable` flag and optional `cause` chaining

--- a/src/klemma/hashing.py
+++ b/src/klemma/hashing.py
@@ -1,0 +1,23 @@
+"""Content-addressable hashing utilities for the three-tier library (ADR-014)."""
+
+import hashlib
+from pathlib import Path
+
+
+def compute_pdf_hash(pdf_path: Path) -> str:
+    """SHA256 of PDF bytes — used for content-addressable paper dedup."""
+    return hashlib.sha256(pdf_path.read_bytes()).hexdigest()
+
+
+def compute_content_hash(paper_id: str, text: str, page: int | None) -> str:
+    """Content-addressable fragment ID: SHA256(paper_id + text + page).
+
+    Deterministic — same PDF + same extraction = same fragment IDs.
+    """
+    content = f"{paper_id}:{text}:{page or 0}"
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def compute_prompt_hash(prompt_text: str) -> str:
+    """Hash of extraction prompt for versioning (first 16 hex chars)."""
+    return hashlib.sha256(prompt_text.encode()).hexdigest()[:16]

--- a/src/klemma/models.py
+++ b/src/klemma/models.py
@@ -1,0 +1,58 @@
+"""Data classes for the three-tier library storage layer (ADR-014).
+
+These are storage-layer records — distinct from the Pydantic models in
+literature/models.py which represent AI extraction output. The naming
+convention is *Record/*Source to avoid collision with existing types:
+
+- PaperRecord   — global corpus paper (vs ZoteroEntry for Zotero data)
+- FragmentRecord — stored fragment (vs Fragment for extraction-time model)
+- UserSource    — user's citekey mapping to a global paper
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PaperRecord:
+    """A paper in the global corpus (library.db)."""
+
+    paper_id: str
+    pdf_hash: str | None = None
+    doi: str | None = None
+    title: str = ""
+    authors: str = ""
+    year: int | None = None
+    abstract: str = ""
+
+
+@dataclass
+class FragmentRecord:
+    """A stored fragment in the global corpus (library.db).
+
+    fragment_id is content-addressable: SHA256(paper_id + text + page).
+    See hashing.compute_content_hash().
+    """
+
+    fragment_id: str  # content_hash
+    paper_id: str
+    fragment_text: str
+    fragment_type: str = "key_idea"
+    page_number: int | None = None
+    citation_intent: str | None = None
+    content_hash: str = ""  # same as fragment_id, explicit for clarity
+
+
+@dataclass
+class UserSource:
+    """A user's source entry mapping citekey → global paper."""
+
+    citekey: str
+    paper_id: str
+    status: str = "pending"
+    pdf_path: str | None = None
+    note_path: str | None = None
+    quality_score: int | None = None
+    chapters: list[int] = field(default_factory=list)
+    sections: list[str] = field(default_factory=list)

--- a/src/klemma/protocols.py
+++ b/src/klemma/protocols.py
@@ -1,0 +1,110 @@
+"""Protocol interfaces for the three-tier library split (ADR-014).
+
+Defines the boundary between Global Corpus (PaperStore),
+User Library (UserLibrary), and Project data (ProjectStore).
+
+These Protocols are the seam between tiers — each has a local SQLite
+implementation (PR B/C) and will have a PostgreSQL implementation (SaaS).
+Skills do NOT import this module — they receive data via arguments.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .models import FragmentRecord, PaperRecord, UserSource
+
+
+@runtime_checkable
+class PaperStore(Protocol):
+    """Content-addressable paper storage (Global Corpus).
+
+    Stores papers, fragments, and embeddings that are shared across
+    all projects. Content is immutable and deduplicated by hash.
+    """
+
+    def find_paper(
+        self, *, pdf_hash: str | None = None, doi: str | None = None
+    ) -> PaperRecord | None: ...
+
+    def register_paper(
+        self,
+        *,
+        title: str,
+        authors: str,
+        year: int | None = None,
+        doi: str | None = None,
+        abstract: str = "",
+        pdf_hash: str,
+    ) -> str:
+        """Register a paper, return paper_id."""
+        ...
+
+    def get_fragments(self, paper_id: str) -> list[FragmentRecord]: ...
+
+    def save_fragments(
+        self,
+        paper_id: str,
+        fragments: list[FragmentRecord],
+        prompt_hash: str,
+        ai_model: str,
+    ) -> int:
+        """Save fragments for a paper. Returns count saved."""
+        ...
+
+    def get_paper_embedding(
+        self, paper_id: str, model: str
+    ) -> list[float] | None: ...
+
+    def save_paper_embedding(
+        self, paper_id: str, vector: list[float], model: str
+    ) -> None: ...
+
+    def get_fragment_embeddings(
+        self, paper_id: str, model: str
+    ) -> dict[str, list[float]]: ...
+
+    def save_fragment_embedding(
+        self, fragment_id: str, vector: list[float], model: str
+    ) -> None: ...
+
+
+@runtime_checkable
+class UserLibrary(Protocol):
+    """User's personal paper collection.
+
+    Maps user-specific citekeys to global paper_ids.
+    Stores per-user metadata: status, pdf_path, quality score.
+    """
+
+    def add_source(
+        self, paper_id: str, citekey: str, **metadata: object
+    ) -> None: ...
+
+    def get_source_by_citekey(self, citekey: str) -> UserSource | None: ...
+
+    def resolve_paper_id(self, citekey: str) -> str | None: ...
+
+    def get_existing_citekeys(self) -> set[str]: ...
+
+
+@runtime_checkable
+class ProjectStore(Protocol):
+    """Per-project data: section assignments, gaps, plans, benchmarks.
+
+    Each project has its own DB. Same paper may appear in multiple
+    projects with different section assignments and relevance scores.
+    """
+
+    def set_source_sections(
+        self,
+        citekey: str,
+        paper_id: str,
+        sections: list[str],
+        chapters: list[int],
+    ) -> None: ...
+
+    def get_coverage_stats(self) -> dict: ...
+
+    def get_reference_gaps(self, **kwargs: object) -> list[dict]: ...

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -85,7 +85,7 @@ Local-only paper acquisition pipeline: download → auto-extract metadata → Zo
 - `_store_pdf_locally()` — copy to Zotero storage dir (skipped when Zotero has the PDF)
 - `_generate_citekey()` — generates `author2024_title_slug` from metadata (fallback when Zotero/BBT unavailable)
 - `load_batch()` — parse JSON batch file
-- Dataclasses: `PaperMetadata`, `AcquireResult` (with `zotero_added` bool)
+- Dataclasses: `PaperMetadata`, `AcquireResult` (with `zotero_added` bool, `pdf_hash` str — SHA256 of PDF bytes, ADR-014)
 
 ### duplicate_checker.py (120 lines)
 Duplicate source detection by metadata. Pure skill — receives source list, returns duplicate pairs.

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -44,6 +44,7 @@ class AcquireResult:
     pdf_path: str = ""
     status: str = ""  # ok, download_failed
     zotero_added: bool = False
+    pdf_hash: str = ""  # SHA256 of PDF bytes (ADR-014: content-addressable dedup)
 
 
 def _is_allowed_download_url(url: str) -> bool:
@@ -621,6 +622,17 @@ def acquire_paper_local(
             doi=resolved.get("doi", ""),
         )
 
+    # Compute PDF hash before temp file cleanup (ADR-014: content-addressable dedup)
+    from ..hashing import compute_pdf_hash
+
+    hash_path = Path(permanent_path) if permanent_path else pdf_path
+    try:
+        pdf_hash = compute_pdf_hash(hash_path)
+        logger.info("PDF hash for %s: %s", citekey, pdf_hash[:12])
+    except Exception as e:
+        logger.debug("Could not compute PDF hash: %s", e)
+        pdf_hash = ""
+
     if not is_local_file:
         pdf_path.unlink(missing_ok=True)
     return AcquireResult(
@@ -628,6 +640,7 @@ def acquire_paper_local(
         pdf_path=permanent_path or str(pdf_path),
         status="ok",
         zotero_added=zotero_citekey is not None,
+        pdf_hash=pdf_hash,
     )
 
 

--- a/src/klemma/skills/extractor.py
+++ b/src/klemma/skills/extractor.py
@@ -81,6 +81,9 @@ def extract_fragments(
         logger.warning("No valid fragments extracted for %s", entry.id)
         return None
 
+    # Compute content hashes for future content-addressable storage (ADR-014)
+    from ..hashing import compute_content_hash
+
     # Save to database
     fragment_dicts = [
         {
@@ -92,6 +95,7 @@ def extract_fragments(
             "usage_hint": f.usage_hint,
             "page": f.page,
             "citation_intent": f.citation_intent,
+            "content_hash": compute_content_hash(entry.id, f.text, f.page),
         }
         for f in fragments
     ]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,7 +1,9 @@
 # Tests
 
-## Current test suite (807 tests)
+## Current test suite (832 tests)
 - `test_errors.py` (33 lines) — `KlemmaAIError` hierarchy, `retryable` classification, cause chaining
+- `test_hashing.py` (~80 lines) — 15 tests: `compute_pdf_hash` (determinism, different content, hex format, missing file), `compute_content_hash` (determinism, uniqueness by paper/text/page, None page, empty text), `compute_prompt_hash` (determinism, uniqueness, 16-char truncation, empty)
+- `test_protocols.py` (~80 lines) — 10 tests: `PaperRecord`/`FragmentRecord`/`UserSource` dataclass defaults + all-fields, runtime-checkable Protocol verification, non-implementing class rejection
 - `test_ai.py` (170 lines) — `extract_json()`, `AIProviderBase`, `AICallResult` dataclass, `call_with_meta()` base + Claude, `create_ai()` factory
 - `test_ai_litellm.py` (265 lines) — `LiteLLMClient` with mocked litellm: call, json_mode, base_url, api_key, reasoning model detection, retry, `call_with_meta()` with structured error mapping + token extraction
 - `test_ai_openai.py` (127 lines) — deprecated `OpenAIClient`: DeprecationWarning, delegation to LiteLLMClient, model prefixing

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,91 @@
+"""Tests for content-addressable hashing utilities (ADR-014)."""
+
+import pytest
+
+from klemma.hashing import compute_content_hash, compute_pdf_hash, compute_prompt_hash
+
+
+class TestComputePdfHash:
+    def test_deterministic(self, tmp_path):
+        pdf = tmp_path / "test.pdf"
+        pdf.write_bytes(b"%PDF-1.4 fake pdf content for testing")
+        assert compute_pdf_hash(pdf) == compute_pdf_hash(pdf)
+
+    def test_different_content_different_hash(self, tmp_path):
+        a = tmp_path / "a.pdf"
+        b = tmp_path / "b.pdf"
+        a.write_bytes(b"%PDF-1.4 content A")
+        b.write_bytes(b"%PDF-1.4 content B")
+        assert compute_pdf_hash(a) != compute_pdf_hash(b)
+
+    def test_returns_hex_string(self, tmp_path):
+        pdf = tmp_path / "test.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+        h = compute_pdf_hash(pdf)
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA256 hex
+        int(h, 16)  # valid hex
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            compute_pdf_hash(tmp_path / "nonexistent.pdf")
+
+
+class TestComputeContentHash:
+    def test_deterministic(self):
+        h1 = compute_content_hash("smith2024", "Important finding about X", 5)
+        h2 = compute_content_hash("smith2024", "Important finding about X", 5)
+        assert h1 == h2
+
+    def test_different_paper_different_hash(self):
+        h1 = compute_content_hash("smith2024", "Same text", 1)
+        h2 = compute_content_hash("jones2024", "Same text", 1)
+        assert h1 != h2
+
+    def test_different_text_different_hash(self):
+        h1 = compute_content_hash("smith2024", "Text A", 1)
+        h2 = compute_content_hash("smith2024", "Text B", 1)
+        assert h1 != h2
+
+    def test_different_page_different_hash(self):
+        h1 = compute_content_hash("smith2024", "Same text", 1)
+        h2 = compute_content_hash("smith2024", "Same text", 2)
+        assert h1 != h2
+
+    def test_none_page_uses_zero(self):
+        h_none = compute_content_hash("smith2024", "text", None)
+        h_zero = compute_content_hash("smith2024", "text", 0)
+        assert h_none == h_zero
+
+    def test_returns_hex_string(self):
+        h = compute_content_hash("paper", "text", 1)
+        assert isinstance(h, str)
+        assert len(h) == 64
+        int(h, 16)
+
+    def test_empty_text(self):
+        h = compute_content_hash("paper", "", None)
+        assert isinstance(h, str)
+        assert len(h) == 64
+
+
+class TestComputePromptHash:
+    def test_deterministic(self):
+        h1 = compute_prompt_hash("Extract fragments from {{ title }}")
+        h2 = compute_prompt_hash("Extract fragments from {{ title }}")
+        assert h1 == h2
+
+    def test_different_prompt_different_hash(self):
+        h1 = compute_prompt_hash("prompt v1")
+        h2 = compute_prompt_hash("prompt v2")
+        assert h1 != h2
+
+    def test_truncated_to_16_chars(self):
+        h = compute_prompt_hash("any prompt text")
+        assert len(h) == 16
+        int(h, 16)
+
+    def test_empty_prompt(self):
+        h = compute_prompt_hash("")
+        assert isinstance(h, str)
+        assert len(h) == 16

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,101 @@
+"""Tests for three-tier Protocol interfaces and data classes (ADR-014)."""
+
+from klemma.hashing import compute_content_hash
+from klemma.models import FragmentRecord, PaperRecord, UserSource
+from klemma.protocols import PaperStore, ProjectStore, UserLibrary
+
+
+class TestPaperRecord:
+    def test_required_field(self):
+        r = PaperRecord(paper_id="abc123")
+        assert r.paper_id == "abc123"
+        assert r.pdf_hash is None
+        assert r.doi is None
+        assert r.title == ""
+        assert r.year is None
+
+    def test_all_fields(self):
+        r = PaperRecord(
+            paper_id="abc",
+            pdf_hash="deadbeef",
+            doi="10.1234/test",
+            title="Test Paper",
+            authors="Smith J.",
+            year=2024,
+            abstract="Abstract text.",
+        )
+        assert r.doi == "10.1234/test"
+        assert r.year == 2024
+
+
+class TestFragmentRecord:
+    def test_required_fields(self):
+        r = FragmentRecord(
+            fragment_id="hash123",
+            paper_id="paper1",
+            fragment_text="Important finding",
+        )
+        assert r.fragment_id == "hash123"
+        assert r.fragment_type == "key_idea"
+        assert r.page_number is None
+        assert r.citation_intent is None
+
+    def test_content_hash_matches_fragment_id(self):
+        h = compute_content_hash("paper1", "text", 5)
+        r = FragmentRecord(
+            fragment_id=h,
+            paper_id="paper1",
+            fragment_text="text",
+            content_hash=h,
+        )
+        assert r.fragment_id == r.content_hash
+
+
+class TestUserSource:
+    def test_required_fields(self):
+        s = UserSource(citekey="smith2024", paper_id="abc")
+        assert s.status == "pending"
+        assert s.pdf_path is None
+        assert s.quality_score is None
+        assert s.chapters == []
+        assert s.sections == []
+
+    def test_all_fields(self):
+        s = UserSource(
+            citekey="smith2024",
+            paper_id="abc",
+            status="completed",
+            pdf_path="/path/to/pdf",
+            quality_score=4,
+            chapters=[1, 2],
+            sections=["1.1", "2.3"],
+        )
+        assert s.quality_score == 4
+        assert len(s.chapters) == 2
+
+
+class TestProtocolsAreRuntimeCheckable:
+    """Verify Protocols can be used with isinstance() checks."""
+
+    def test_paper_store_is_protocol(self):
+        assert hasattr(PaperStore, "__protocol_attrs__") or hasattr(
+            PaperStore, "_is_runtime_protocol"
+        )
+
+    def test_user_library_is_protocol(self):
+        assert hasattr(UserLibrary, "__protocol_attrs__") or hasattr(
+            UserLibrary, "_is_runtime_protocol"
+        )
+
+    def test_project_store_is_protocol(self):
+        assert hasattr(ProjectStore, "__protocol_attrs__") or hasattr(
+            ProjectStore, "_is_runtime_protocol"
+        )
+
+    def test_non_implementing_class_fails_check(self):
+        class Empty:
+            pass
+
+        assert not isinstance(Empty(), PaperStore)
+        assert not isinstance(Empty(), UserLibrary)
+        assert not isinstance(Empty(), ProjectStore)


### PR DESCRIPTION
## Summary

- Foundation layer for three-tier library split (#82). **Zero behavior change** — all 943 tests pass.
- New `protocols.py`: `PaperStore`, `UserLibrary`, `ProjectStore` — `@runtime_checkable` Protocol interfaces defining the boundary between Global Corpus, User Library, and Project tiers
- New `models.py`: `PaperRecord`, `FragmentRecord`, `UserSource` — storage-layer dataclasses (distinct from `literature/models.py` extraction-time Pydantic models)
- New `hashing.py`: `compute_pdf_hash` (SHA256 of PDF bytes), `compute_content_hash` (deterministic fragment ID), `compute_prompt_hash` (extraction prompt versioning)
- Acquirer computes `pdf_hash` after download (logged, not stored in DB yet)
- Extractor computes `content_hash` per fragment (added to dict, ignored by current DB schema)
- ADR-014 document added to `docs/adr/`

Closes #124
Part of #82

## Test plan

- [x] 25 new tests: hashing determinism/uniqueness/edge cases, dataclass defaults, runtime-checkable Protocol verification
- [x] 943 total tests pass (0 failures)
- [x] `ruff check` clean
- [x] Zero behavior change verified — existing fragment/acquire flows unchanged

## Release Note

### Problem
Klemma's monolithic per-project SQLite database duplicates paper extraction and embedding work across projects. The `inherit_db` mechanism is fragile and doesn't scale to SaaS. ADR-014 prescribes splitting into a shared library (`~/.klemma/library.db`) and per-project stores (`project.db`), but this requires typed interfaces and content-addressable IDs as a foundation.

### Academic Foundation
Content-addressable storage follows the Git object model — same content always produces the same hash, enabling deduplication without coordination. Fragment IDs use SHA256(paper_id + text + page), making extraction deterministic: re-processing the same PDF with the same prompt yields identical fragment IDs. This supports the reproducibility requirements identified in Chen 2025 (encoding domain knowledge in prompts).

### Implementation
Three new modules at package root: `protocols.py` (3 runtime-checkable Protocols), `models.py` (3 storage-layer dataclasses), `hashing.py` (3 pure-stdlib hash functions). Acquirer and extractor compute hashes additively — existing flows unchanged. No new DB tables or columns. ADR-014 documents the full execution plan (4 PRs).

### Results
529 lines added across 11 files. 25 new tests (943 total). Zero behavior change. Ruff clean. Foundation ready for PR B (LocalPaperStore + library.db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)