### PR TITLE
feat: add klemma source show command

### DIFF
--- a/src/klemma/commands/analyze.py
+++ b/src/klemma/commands/analyze.py
@@ -487,3 +487,78 @@ def role(ctx, citekey, role):
     console.print(f"[green]@{citekey}[/green] \u2192 {label}")
 
 
+@source.command()
+@click.argument("citekey")
+@click.pass_context
+def show(ctx, citekey):
+    """Display full source card: metadata, sections, fragments."""
+    kctx = _get_context(ctx)
+    src = kctx.state.get_source(citekey)
+    if not src:
+        console.print(f"[red]Source '{citekey}' not found.[/red]")
+        raise SystemExit(1)
+
+    # Header
+    title = src.get("title") or "(no title)"
+    authors = src.get("authors") or "(no authors)"
+    year = src.get("year") or "?"
+    console.print(f"\n[bold]@{citekey}[/bold]")
+    console.print(f"  [cyan]{title}[/cyan]")
+    console.print(f"  {authors} ({year})")
+
+    # Metadata
+    doi = src.get("doi")
+    if doi:
+        console.print(f"  DOI: {doi}")
+    status = src.get("status", "?")
+    console.print(f"  Status: {status}")
+    source_role = src.get("source_role")
+    if source_role and source_role != "external":
+        from ..source_role import ROLE_LABELS
+        console.print(f"  Role: {ROLE_LABELS.get(source_role, source_role)}")
+    priority = src.get("citation_priority")
+    if priority:
+        console.print(f"  Priority: {priority}")
+    quality = src.get("quality_score")
+    if quality is not None:
+        console.print(f"  Quality: {quality}")
+    nr1 = src.get("relevance_nr1", 0)
+    nr2 = src.get("relevance_nr2", 0)
+    if nr1 or nr2:
+        console.print(f"  Relevance: NR1={nr1} NR2={nr2}")
+
+    # Sections
+    fragments = kctx.state.get_fragments(source_id=citekey, limit=500)
+    sections = sorted({f["section"] for f in fragments if f.get("section")})
+    if sections:
+        console.print(f"  Sections: {', '.join(sections)}")
+
+    # Paths
+    pdf = src.get("pdf_path")
+    if pdf:
+        console.print(f"  PDF: {pdf}")
+    note = src.get("note_path")
+    if note:
+        console.print(f"  Note: {note}")
+
+    # Fragments
+    frag_count = src.get("fragment_count", 0) or len(fragments)
+    console.print(f"\n  [bold]Fragments[/bold]: {frag_count}")
+    if fragments:
+        tbl = Table(show_header=True, box=None, padding=(0, 1))
+        tbl.add_column("#", style="dim", width=4)
+        tbl.add_column("Section", width=8)
+        tbl.add_column("Type", width=10)
+        tbl.add_column("Text", max_width=80)
+        for i, f in enumerate(fragments, 1):
+            text = (f.get("fragment_text") or "")[:120]
+            if len(f.get("fragment_text") or "") > 120:
+                text += "..."
+            tbl.add_row(
+                str(i),
+                f.get("section") or "-",
+                f.get("fragment_type") or "-",
+                text,
+            )
+        console.print(tbl)
+    console.print()

--- a/tests/test_source_show.py
+++ b/tests/test_source_show.py
@@ -1,0 +1,103 @@
+"""Tests for `klemma source show <citekey>` command."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+from klemma.commands import analyze as analyze_mod
+from klemma.state import StateManager
+
+
+def _make_ctx(state):
+    mock_ctx = MagicMock()
+    mock_ctx.state = state
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = None
+    mock_ctx.embeddings = None
+    return mock_ctx
+
+
+def _run(runner, mock_ctx, tmp_path, args):
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch.object(analyze_mod, "_get_context", return_value=mock_ctx):
+        return runner.invoke(klemma_cli, args)
+
+
+def test_source_show_displays_metadata(tmp_path):
+    """source show prints title, authors, year, sections, fragments."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["goessling2016"])
+    sm.update_source_info(
+        "goessling2016",
+        title="Predictability of Arctic Sea Ice",
+        authors="Goessling HF, Jung T",
+        year=2016,
+        doi="10.1002/2016GL071665",
+    )
+    sm.mark_completed("goessling2016", "notes/goessling2016.md")
+    sm.save_fragments("goessling2016", [
+        {"text": "IIEE measures ice edge error", "type": "definition", "section": "1.1"},
+        {"text": "Misplacement error dominates", "type": "result", "section": "2.3"},
+    ])
+
+    mock_ctx = _make_ctx(sm)
+    runner = CliRunner()
+    result = _run(runner, mock_ctx, tmp_path, ["source", "show", "goessling2016"])
+
+    assert result.exit_code == 0, result.output
+    assert "goessling2016" in result.output
+    assert "Predictability of Arctic Sea Ice" in result.output
+    assert "Goessling HF, Jung T" in result.output
+    assert "2016" in result.output
+    assert "10.1002/2016GL071665" in result.output
+    assert "1.1" in result.output
+    assert "2.3" in result.output
+    assert "IIEE measures ice edge error" in result.output
+
+
+def test_source_show_not_found(tmp_path):
+    """source show exits with error for unknown citekey."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+
+    mock_ctx = _make_ctx(sm)
+    runner = CliRunner()
+    result = _run(runner, mock_ctx, tmp_path, ["source", "show", "nonexistent2024"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_source_show_no_fragments(tmp_path):
+    """source show works for a source with no fragments."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["empty2024"])
+    sm.update_source_info("empty2024", title="Empty Paper", authors="Nobody", year=2024)
+
+    mock_ctx = _make_ctx(sm)
+    runner = CliRunner()
+    result = _run(runner, mock_ctx, tmp_path, ["source", "show", "empty2024"])
+
+    assert result.exit_code == 0, result.output
+    assert "Empty Paper" in result.output
+    assert "Fragments" in result.output
+
+
+def test_source_show_help(tmp_path):
+    """source show appears in source group help."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+
+    mock_ctx = _make_ctx(sm)
+    runner = CliRunner()
+    result = _run(runner, mock_ctx, tmp_path, ["source", "--help"])
+    assert "show" in result.output
+    assert "role" in result.output


### PR DESCRIPTION
## Summary
- Adds `klemma source show <citekey>` subcommand that displays a full source card: title, authors, year, DOI, status, role, quality, relevance, assigned sections, PDF/note paths, and a fragment table
- Closes #132 — previously required raw SQL queries to inspect source metadata

## Test plan
- [x] 4 new tests in `tests/test_source_show.py` (metadata display, not found, no fragments, help output)
- [x] `ruff check` clean
- [x] 946/947 tests pass (1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)