### PR TITLE
feat: add klemma bib export command

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1964,6 +1964,7 @@ from .commands import (  # noqa: E402, F401
     acquire,
     analyze,
     benchmark,
+    bib,
     manage,
     process,
     research,

--- a/src/klemma/commands/__init__.py
+++ b/src/klemma/commands/__init__.py
@@ -4,4 +4,4 @@ Each module registers its commands/groups against ``main`` from ``..cli``.
 Importing this package triggers registration of all commands.
 """
 
-from . import acquire, analyze, benchmark, manage, process, research, write  # noqa: F401
+from . import acquire, analyze, benchmark, bib, manage, process, research, write  # noqa: F401

--- a/src/klemma/commands/bib.py
+++ b/src/klemma/commands/bib.py
@@ -1,0 +1,173 @@
+"""Bibliography commands: bib export."""
+
+import re
+import sys
+from pathlib import Path
+
+import click
+
+from ..cli import _get_context, main
+
+
+def _parse_bib_entries(bib_text: str) -> dict[str, str]:
+    """Parse BibTeX text into a dict of {citekey: full_entry_text}.
+
+    Uses a simple block-matching approach: each entry starts with
+    @type{citekey, and ends at the matching closing brace.
+    """
+    entries: dict[str, str] = {}
+    # Find all entry start positions: @word{citekey,
+    entry_starts = list(re.finditer(r"@\w+\s*\{([^,\s]+)\s*,", bib_text))
+    for i, match in enumerate(entry_starts):
+        citekey = match.group(1)
+        start = match.start()
+        # Entry block ends at the matching closing brace
+        end = entry_starts[i + 1].start() if i + 1 < len(entry_starts) else len(bib_text)
+        block = bib_text[start:end].rstrip()
+        # Trim any trailing whitespace between entries
+        entries[citekey] = block
+    return entries
+
+
+def _parse_section_range(section_str: str) -> list[str]:
+    """Parse section range string into list of top-level section prefixes.
+
+    Examples:
+      "1..6"  -> ["1", "2", "3", "4", "5", "6"]
+      "1..3"  -> ["1", "2", "3"]
+      "2"     -> ["2"]
+      "1.1"   -> ["1.1"]  (subsection — returned as-is)
+    """
+    range_match = re.match(r"^(\d+)\.\.(\d+)$", section_str.strip())
+    if range_match:
+        start = int(range_match.group(1))
+        end = int(range_match.group(2))
+        return [str(n) for n in range(start, end + 1)]
+    # Single section — return as-is
+    return [section_str.strip()]
+
+
+def _get_citekeys_for_sections(state, section_prefixes: list[str]) -> set[str]:
+    """Query DB for all source IDs assigned to the given section prefixes.
+
+    Uses get_section_sources() which returns IDs regardless of processing status,
+    so pending sources are included in bib export (they may still be in the bib file).
+    """
+    citekeys: set[str] = set()
+    for prefix in section_prefixes:
+        ids = state.get_section_sources(prefix)
+        citekeys.update(ids)
+    return citekeys
+
+
+@main.group()
+def bib():
+    """Bibliography utilities.
+
+    Subcommands:
+      klemma bib export   -- export filtered .bib subset
+    """
+
+
+@bib.command("export")
+@click.option(
+    "--citekeys",
+    default=None,
+    help="Comma-separated citekeys to export (e.g. @smith2020,@jones2021)",
+)
+@click.option(
+    "--section",
+    default=None,
+    help="Section range to export refs for (e.g. 1..6 or 2.3)",
+)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    type=click.Path(),
+    help="Output file path (default: stdout)",
+)
+@click.option(
+    "--bib",
+    "bib_path",
+    default=None,
+    type=click.Path(),
+    help="Path to references.bib (overrides config)",
+)
+@click.pass_context
+def bib_export(ctx, citekeys, section, output, bib_path):
+    """Export a filtered subset of a BibTeX bibliography.
+
+    Filter by explicit citekeys:
+      klemma bib export --citekeys @smith2020,@jones2021
+
+    Filter by section range (uses DB source assignments):
+      klemma bib export --section 1..6
+
+    Write to file instead of stdout:
+      klemma bib export --citekeys @key1 --output paper.bib
+
+    The --bib flag overrides the bib file path. If not given, the command
+    looks for a .bib file adjacent to the project root (references.bib).
+    """
+    if not citekeys and not section:
+        raise click.UsageError("Provide at least --citekeys or --section.")
+
+    # Resolve bib file
+    if not bib_path:
+        kctx = _get_context(ctx)
+        # Try zotero.library_json (.bib export) or project root references.bib
+        lib_json = kctx.config.zotero.library_json if kctx.config.zotero else None
+        if lib_json and Path(lib_json).suffix.lower() == ".bib" and Path(lib_json).exists():
+            resolved_bib = Path(lib_json)
+        else:
+            # Fallback: look for references.bib next to project root
+            project_root = kctx.project_root
+            candidate = project_root / "references.bib"
+            if not candidate.exists():
+                raise click.ClickException(
+                    "No BibTeX file found. Use --bib to specify the path to your .bib file."
+                )
+            resolved_bib = candidate
+    else:
+        resolved_bib = Path(bib_path)
+
+    if not resolved_bib.exists():
+        raise click.ClickException(f"BibTeX file not found: {resolved_bib}")
+
+    bib_text = resolved_bib.read_text(encoding="utf-8")
+    all_entries = _parse_bib_entries(bib_text)
+
+    # Determine which citekeys to export
+    wanted: set[str] = set()
+
+    if citekeys:
+        # Parse comma-separated list, strip @ prefix
+        for key in citekeys.split(","):
+            wanted.add(key.strip().lstrip("@"))
+
+    if section:
+        kctx = _get_context(ctx)
+        prefixes = _parse_section_range(section)
+        db_keys = _get_citekeys_for_sections(kctx.state, prefixes)
+        wanted.update(db_keys)
+
+    # Filter entries
+    matched = {k: v for k, v in all_entries.items() if k in wanted}
+
+    # Report any requested keys not found in bib
+    missing = wanted - set(all_entries.keys())
+    if missing:
+        click.echo(
+            f"Warning: {len(missing)} citekey(s) not found in bib: "
+            f"{', '.join(sorted(missing))}",
+            err=True,
+        )
+
+    result_text = "\n\n".join(matched[k] for k in sorted(matched)) + "\n"
+
+    if output:
+        Path(output).write_text(result_text, encoding="utf-8")
+        click.echo(f"Exported {len(matched)} entries to {output}", err=True)
+    else:
+        sys.stdout.write(result_text)

--- a/tests/test_bib_export.py
+++ b/tests/test_bib_export.py
@@ -1,0 +1,250 @@
+"""Tests for `klemma bib export` command (#59)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+from klemma.state import StateManager
+
+# --- Fixtures ---
+
+
+SAMPLE_BIB = """\
+@article{smith2020,
+  author = {Smith, John},
+  title = {A Study of Things},
+  journal = {Journal of Things},
+  year = {2020},
+}
+
+@inproceedings{jones2021,
+  author = {Jones, Alice},
+  title = {Deep Learning for Something},
+  booktitle = {Proceedings of Conf},
+  year = {2021},
+}
+
+@book{taylor2019,
+  author = {Taylor, Bob},
+  title = {Classic Textbook},
+  publisher = {Academic Press},
+  year = {2019},
+}
+"""
+
+
+def _make_mock_ctx(state, bib_path=None):
+    mock_ctx = MagicMock()
+    mock_ctx.state = state
+    mock_ctx.config = MagicMock()
+    mock_ctx.config.zotero.library_json = str(bib_path) if bib_path else None
+    mock_ctx.project = MagicMock()
+    mock_ctx.project_root = Path("/tmp/fake_project")
+    return mock_ctx
+
+
+# --- Test: help shows expected options ---
+
+
+def test_bib_export_help():
+    """klemma bib export --help exits 0 and shows expected options."""
+    runner = CliRunner()
+    result = runner.invoke(klemma_cli, ["bib", "export", "--help"])
+    assert result.exit_code == 0
+    assert "--citekeys" in result.output
+    assert "--section" in result.output
+    assert "--output" in result.output
+
+
+# --- Test: export by citekeys filters bib entries ---
+
+
+def test_bib_export_by_citekeys(tmp_path):
+    """klemma bib export --citekeys @smith2020,@jones2021 outputs only those 2 entries."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    mock_ctx = _make_mock_ctx(sm)
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            ["bib", "export", "--citekeys", "@smith2020,@jones2021", "--bib", str(bib_file)],
+        )
+
+    assert result.exit_code == 0
+    assert "smith2020" in result.output
+    assert "jones2021" in result.output
+    assert "taylor2019" not in result.output
+
+
+def test_bib_export_strips_at_prefix(tmp_path):
+    """citekeys with and without @ prefix both work."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    mock_ctx = _make_mock_ctx(sm)
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            # Mix of @ and bare citekeys
+            ["bib", "export", "--citekeys", "smith2020,@taylor2019", "--bib", str(bib_file)],
+        )
+
+    assert result.exit_code == 0
+    assert "smith2020" in result.output
+    assert "taylor2019" in result.output
+    assert "jones2021" not in result.output
+
+
+# --- Test: export by section range uses DB source assignments ---
+
+
+def test_bib_export_by_section(tmp_path):
+    """klemma bib export --section 1..2 exports refs assigned to sections 1.x and 2.x."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    # Register and assign sources to sections
+    sm.register_sources(["smith2020", "jones2021", "taylor2019"])
+    sm.set_source_sections("smith2020", ["1.1"], [1])
+    sm.set_source_sections("jones2021", ["2.1"], [2])
+    sm.set_source_sections("taylor2019", ["3.1"], [3])
+
+    mock_ctx = _make_mock_ctx(sm)
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            ["bib", "export", "--section", "1..2", "--bib", str(bib_file)],
+        )
+
+    assert result.exit_code == 0
+    assert "smith2020" in result.output
+    assert "jones2021" in result.output
+    assert "taylor2019" not in result.output
+
+
+def test_bib_export_section_single(tmp_path):
+    """klemma bib export --section 1 exports only section 1.x sources."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    sm.register_sources(["smith2020", "jones2021"])
+    sm.set_source_sections("smith2020", ["1.1"], [1])
+    sm.set_source_sections("jones2021", ["2.3"], [2])
+
+    mock_ctx = _make_mock_ctx(sm)
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            ["bib", "export", "--section", "1", "--bib", str(bib_file)],
+        )
+
+    assert result.exit_code == 0
+    assert "smith2020" in result.output
+    assert "jones2021" not in result.output
+
+
+# --- Test: --output writes to file ---
+
+
+def test_bib_export_writes_to_file(tmp_path):
+    """--output writes filtered bib to file; stdout is empty or minimal."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    out_file = tmp_path / "paper.bib"
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    mock_ctx = _make_mock_ctx(sm)
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            [
+                "bib", "export",
+                "--citekeys", "@smith2020",
+                "--bib", str(bib_file),
+                "--output", str(out_file),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "smith2020" in content
+    assert "jones2021" not in content
+
+
+# --- Test: missing bib file gives clear error ---
+
+
+def test_bib_export_missing_bib(tmp_path):
+    """If bib file does not exist, exit with non-zero and informative message."""
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+    mock_ctx = _make_mock_ctx(sm)
+
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            ["bib", "export", "--citekeys", "@smith2020", "--bib", str(tmp_path / "nope.bib")],
+        )
+
+    assert result.exit_code != 0
+
+
+# --- Test: no filter flags gives clear error ---
+
+
+def test_bib_export_requires_filter(tmp_path):
+    """Running export with neither --citekeys nor --section gives error."""
+    bib_file = tmp_path / "references.bib"
+    bib_file.write_text(SAMPLE_BIB)
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+    mock_ctx = _make_mock_ctx(sm)
+
+    runner = CliRunner()
+    with (
+        patch("klemma.cli._get_context", return_value=mock_ctx),
+        patch("klemma.cli._init_components", return_value=mock_ctx),
+    ):
+        result = runner.invoke(
+            klemma_cli,
+            ["bib", "export", "--bib", str(bib_file)],
+        )
+
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- Adds `klemma bib export` command for extracting filtered bibliography subsets from a `.bib` file
- Supports `--citekeys @key1,@key2` for explicit selection and `--section 1..6` for section-based filtering using DB source assignments
- `--output paper.bib` writes to file; default prints to stdout
- `--bib` flag allows explicit `.bib` path; falls back to `references.bib` at project root

## Test plan
- [x] `test_bib_export_help` — `klemma bib export --help` exits 0 with expected options
- [x] `test_bib_export_by_citekeys` — filter by explicit citekeys outputs only matching entries
- [x] `test_bib_export_strips_at_prefix` — mix of `@key` and `key` formats both work
- [x] `test_bib_export_by_section` — section range `1..2` returns sources assigned to those sections
- [x] `test_bib_export_section_single` — single section filter excludes other sections
- [x] `test_bib_export_writes_to_file` — `--output` writes file, bib entry present in file
- [x] `test_bib_export_missing_bib` — missing `.bib` file exits non-zero
- [x] `test_bib_export_requires_filter` — no filter flags exits non-zero
- [x] Full test suite: 950 passed, 1 pre-existing failure unrelated to this PR
- [x] `ruff check` clean

Closes #59

## Release Note

### Problem
No command existed to extract a bibliography subset for conference papers. Users had to manually filter `references.bib` — tedious and error-prone when working from a 300+ source library. The workaround documented in issue #59 required manually extracting 24 of ~300 references for the Dialog-2026 paper.

### Academic Foundation
Modular bibliography management is standard practice in large-scale academic writing (Patashnik & Lamport, 1988 — BibTeX design philosophy: separate content from formatting). Section-scoped reference export aligns with document-centric citation management patterns where each section of a dissertation has its own citation context.

### Implementation
Added `klemma bib` command group with `export` subcommand in `src/klemma/commands/bib.py`, registered in `src/klemma/commands/__init__.py` and `src/klemma/cli.py`. BibTeX parsing uses lightweight regex block extraction (`_parse_bib_entries()`) to avoid adding new dependencies. Section range `1..6` resolves via `_parse_section_range()` to integer prefixes, then calls `state.get_section_sources()` which queries `source_sections` table regardless of processing status. The `--bib` flag path overrides config; fallback discovers `references.bib` at project root.

### Results
`klemma bib export --section 1..4 --output chapter.bib` produces a filtered `.bib` in one command. 8 tests added covering all major paths. Lint clean. No new dependencies.