### PR TITLE
feat: add --output/-o flag to draft -s command

### DIFF
--- a/src/klemma/commands/write.py
+++ b/src/klemma/commands/write.py
@@ -1,5 +1,10 @@
 """Draft group and outline commands."""
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
 import click
 from rich.panel import Panel
 from rich.table import Table
@@ -15,6 +20,27 @@ from ..cli import (
 )
 
 
+def _resolve_output(
+    output: Optional[str],
+    project_root: Optional[Path],
+    section: str,
+    no_save: bool,
+) -> Optional[Path]:
+    """Resolve output path for draft -s.
+
+    Returns None if draft should be printed (no_save=True or no project_root).
+    -o path overrides default notes/drafts/ location.
+    --no-save takes priority over -o.
+    """
+    if no_save:
+        return None
+    if output:
+        return Path(output).expanduser()
+    if project_root:
+        return project_root / "notes" / "drafts" / f"Draft_{section}.md"
+    return None
+
+
 @main.group(invoke_without_command=True)
 @click.option(
     "--section",
@@ -24,6 +50,12 @@ from ..cli import (
 )
 @click.option("--model", default=None, help="Override AI model")
 @click.option("--no-save", is_flag=True, help="Print draft without saving to file")
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Write draft to this path instead of default notes/drafts/",
+)
 @click.option(
     "--no-rag",
     is_flag=True,
@@ -36,7 +68,7 @@ from ..cli import (
     help="Custom directive for AI (e.g. 'rely on goessling2016 and previous_paper.md')",
 )
 @click.pass_context
-def draft(ctx, section, model, no_save, no_rag, prompt):
+def draft(ctx, section, model, no_save, output, no_rag, prompt):
     """Generate dissertation section drafts.
 
     Standalone mode: klemma draft -s 1.3.2
@@ -256,14 +288,13 @@ def draft(ctx, section, model, no_save, no_rag, prompt):
         console.print("[red]AI returned empty result.[/red]")
         raise SystemExit(1)
 
-    # 8. Save to notes/drafts/
-    if not no_save and kctx.project_root:
-        drafts_dir = kctx.project_root / "notes" / "drafts"
-        drafts_dir.mkdir(parents=True, exist_ok=True)
-        out_path = drafts_dir / f"Draft_{section}.md"
+    # 8. Save draft
+    out_path = _resolve_output(output, kctx.project_root, section, no_save)
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(result.text, encoding="utf-8")
         console.print(f"[green]Saved to {out_path}[/green]")
-    elif no_save:
+    else:
         console.print(result.text)
 
     # 9. Summary

--- a/tests/test_draft_output_option.py
+++ b/tests/test_draft_output_option.py
@@ -1,0 +1,38 @@
+"""Tests for _resolve_output helper and draft -s --output flag (issue #92)."""
+
+from klemma.commands.write import _resolve_output
+
+
+class TestResolveOutput:
+    def test_default_path_uses_notes_drafts(self, tmp_path):
+        result = _resolve_output(None, tmp_path, "1.1", no_save=False)
+        assert result == tmp_path / "notes" / "drafts" / "Draft_1.1.md"
+
+    def test_output_flag_overrides_default(self, tmp_path):
+        custom = tmp_path / "my_draft.md"
+        result = _resolve_output(str(custom), tmp_path, "1.1", no_save=False)
+        assert result == custom
+
+    def test_no_save_returns_none_even_with_output(self, tmp_path):
+        custom = tmp_path / "my_draft.md"
+        result = _resolve_output(str(custom), tmp_path, "1.1", no_save=True)
+        assert result is None
+
+    def test_no_save_returns_none_with_default(self, tmp_path):
+        result = _resolve_output(None, tmp_path, "2.3", no_save=True)
+        assert result is None
+
+    def test_no_project_root_returns_none(self):
+        result = _resolve_output(None, None, "1.1", no_save=False)
+        assert result is None
+
+    def test_output_with_tilde_expands(self, tmp_path, monkeypatch):
+        # expanduser should be applied
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = _resolve_output("~/output.md", None, "1.1", no_save=False)
+        assert result == tmp_path / "output.md"
+
+    def test_section_id_embedded_in_default_filename(self, tmp_path):
+        result = _resolve_output(None, tmp_path, "3.2.1", no_save=False)
+        assert result is not None
+        assert result.name == "Draft_3.2.1.md"


### PR DESCRIPTION
## Summary
- Adds `--output` / `-o` option to `klemma draft -s X.X` for writing to an arbitrary path
- `--no-save` continues to take priority over `-o`
- No change to `draft introduction` (already has `-o`)

Closes #92

## Test plan
- [x] `_resolve_output()`: 7 tests — default path, `-o` override, `--no-save` priority, tilde expansion, section ID in filename
- [x] 1031/1032 tests pass (1 pre-existing `test_init_outline` failure unrelated)
- [x] `ruff check` clean

## Release Note

### Problem
`klemma draft -s X.X` wrote the draft to a hardcoded `notes/drafts/Draft_{section}.md` with no way to redirect output. When working in a dissertation project directory, users frequently need to write drafts directly into their dissertation folder structure rather than the klemma notes directory.

### Academic Foundation
No specific citation needed — this is a usability improvement based on standard CLI conventions (GNU `--output`/`-o` pattern).

### Implementation
Added `--output`/`-o` Click option to the `draft` group in `src/klemma/commands/write.py`. Extracted a `_resolve_output()` helper that applies priority: `--no-save > -o > default notes/drafts/`. The helper handles `expanduser()` for `~`-prefixed paths and creates parent directories automatically.

### Results
`klemma draft -s 1.1 -o ~/research/dissertation/Chapter1_1.1.md` now works. 7 new tests added. No new dependencies.