### PR TITLE
feat: frontmatter Phase 1 — singular section fallback + migrate-frontmatter

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -292,10 +292,16 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
         sections_list = props.get("sections", [])
         chapters_list = props.get("chapters", [])
 
+        # Phase 1 fallback (issue #105): singular `section:` treated as [section]
+        # when plural `sections:` list is absent or empty — backward compat.
+        primary_section_str = str(props.get("section", "")) or None
+        if not sections_list and primary_section_str:
+            sections_list = [primary_section_str]
+
         vault_data.append(
             {
                 "citekey": citekey,
-                "primary_section": str(props.get("section", "")) or None,
+                "primary_section": primary_section_str,
                 "primary_chapter": chapter,
                 "sections": (
                     [str(s) for s in sections_list]

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1012,6 +1012,109 @@ def migrate_content(ctx, dry_run):
     console.print("[dim]config.yaml stripped of content fields (infrastructure only)[/dim]")
 
 
+# --- Migrate frontmatter ---
+
+
+@main.command(name="migrate-frontmatter")
+@click.option("--dry-run", is_flag=True, help="Preview changes without modifying files")
+@click.pass_context
+def migrate_frontmatter(ctx, dry_run):
+    """Migrate vault notes from singular section:/chapter: to plural sections:/chapters:.
+
+    Scans all @*.md notes in the Obsidian vault and rewrites frontmatter:
+    - `section: "1.2"` → `sections: ["1.2"]` (merged with any existing sections list)
+    - `chapter: 1` → `chapters: [1]` (merged with any existing chapters list)
+    - Singular fields are removed after migration
+
+    Idempotent: notes already using plural fields are skipped.
+    """
+    import yaml as _yaml
+
+    kctx = _get_context(ctx)
+    vault = kctx.vault
+    config = kctx.config
+
+    if vault is None:
+        console.print("[red]No Obsidian vault configured. Set obsidian.vault_path.[/red]")
+        raise SystemExit(1)
+
+    notes_folder = config.obsidian.notes_folder or ""
+    note_names = vault.list_notes(folder=notes_folder)
+    citekey_notes = [n for n in note_names if n.startswith("@")]
+
+    updated = 0
+    skipped = 0
+
+    for note_name in citekey_notes:
+        props = vault.get_properties(note_name)
+        if not props:
+            skipped += 1
+            continue
+
+        singular_section = str(props.get("section", "")).strip() if props.get("section") else None
+        singular_chapter = props.get("chapter")
+        has_singular = bool(singular_section) or bool(singular_chapter)
+
+        if not has_singular:
+            skipped += 1
+            continue
+
+        # Build merged plural lists
+        sections_list = list(props.get("sections") or [])
+        chapters_list = list(props.get("chapters") or [])
+
+        if singular_section and singular_section not in [str(s) for s in sections_list]:
+            sections_list.append(singular_section)
+        if singular_chapter is not None:
+            try:
+                ch = int(singular_chapter)
+                if ch not in [int(c) for c in chapters_list]:
+                    chapters_list.append(ch)
+            except (TypeError, ValueError):
+                pass
+
+        if dry_run:
+            console.print(f"[dim]{note_name}[/dim]: section={singular_section!r} → sections={sections_list}")
+            updated += 1
+            continue
+
+        # Rewrite the note's frontmatter via vault adapter
+        if notes_folder:
+            target = vault._resolve_folder(notes_folder) / f"{note_name}.md"
+        else:
+            found = list(vault.vault_path.rglob(f"{note_name}.md"))
+            target = found[0] if found else None
+
+        if not target or not target.exists():
+            skipped += 1
+            continue
+
+        text = target.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            skipped += 1
+            continue
+        end = text.find("---", 3)
+        if end == -1:
+            skipped += 1
+            continue
+
+        fm = _yaml.safe_load(text[3:end]) or {}
+        fm["sections"] = sorted(
+            [str(s) for s in sections_list],
+            key=lambda s: [int(x) for x in s.split(".")] if all(x.isdigit() for x in s.split(".")) else [0],
+        )
+        fm["chapters"] = sorted(int(c) for c in chapters_list)
+        fm.pop("section", None)
+        fm.pop("chapter", None)
+
+        new_fm = _yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        target.write_text(f"---\n{new_fm}---{text[end + 3:]}", encoding="utf-8")
+        updated += 1
+
+    verb = "Would update" if dry_run else "Updated"
+    console.print(f"[green]{verb} {updated} notes[/green], skipped {skipped} (already plural or no frontmatter).")
+
+
 # --- Import (hidden) ---
 
 

--- a/tests/test_frontmatter_phase1.py
+++ b/tests/test_frontmatter_phase1.py
@@ -1,0 +1,197 @@
+"""Tests for frontmatter Phase 1: singular section:/chapter: fallback (issue #105)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vault_note(tmp_path: Path, name: str, frontmatter: dict) -> Path:
+    """Write a vault note with YAML frontmatter."""
+    import yaml
+
+    fm = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    note = tmp_path / f"{name}.md"
+    note.write_text(f"---\n{fm}---\nBody text here.\n", encoding="utf-8")
+    return note
+
+
+# ---------------------------------------------------------------------------
+# _sync_sections fallback logic (unit-level)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncSectionsFallback:
+    """Verify singular section: fallback in _sync_sections (cli.py)."""
+
+    def _build_vault_data_entry(self, props: dict) -> dict:
+        """Replicate the vault_data entry construction from _sync_sections."""
+        sections_list = props.get("sections", [])
+        chapters_list = props.get("chapters", [])
+
+        primary_section_str = str(props.get("section", "")) or None
+        if not sections_list and primary_section_str:
+            sections_list = [primary_section_str]
+
+        chapter = props.get("chapter")
+        if isinstance(chapter, str):
+            chapter = int(chapter) if chapter.isdigit() else None
+
+        return {
+            "primary_section": primary_section_str,
+            "primary_chapter": chapter,
+            "sections": (
+                [str(s) for s in sections_list]
+                if isinstance(sections_list, list)
+                else []
+            ),
+        }
+
+    def test_singular_section_falls_back_to_list(self):
+        """section: '1.2' with no sections: → sections=['1.2']."""
+        entry = self._build_vault_data_entry({"section": "1.2"})
+        assert entry["sections"] == ["1.2"]
+        assert entry["primary_section"] == "1.2"
+
+    def test_plural_sections_takes_priority(self):
+        """sections: [...] takes priority — singular ignored for sections list."""
+        entry = self._build_vault_data_entry({
+            "section": "1.2",
+            "sections": ["1.2", "2.3"],
+        })
+        assert entry["sections"] == ["1.2", "2.3"]
+
+    def test_no_section_fields_gives_empty_list(self):
+        """No section info → empty sections list."""
+        entry = self._build_vault_data_entry({})
+        assert entry["sections"] == []
+        assert entry["primary_section"] is None
+
+    def test_empty_sections_list_with_singular_falls_back(self):
+        """sections: [] (empty) + section: '3.1' → sections=['3.1']."""
+        entry = self._build_vault_data_entry({"sections": [], "section": "3.1"})
+        assert entry["sections"] == ["3.1"]
+
+    def test_singular_empty_string_not_added(self):
+        """section: '' (empty) → no fallback, sections stays empty."""
+        entry = self._build_vault_data_entry({"section": ""})
+        assert entry["sections"] == []
+
+
+# ---------------------------------------------------------------------------
+# migrate-frontmatter command (CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateFrontmatter:
+    """Tests for klemma migrate-frontmatter command."""
+
+    @pytest.fixture
+    def mock_ctx(self, tmp_path):
+        from klemma.state import StateManager
+        from klemma.context import KlemmaContext
+        sm = StateManager(str(tmp_path / "test.db"))
+        config = MagicMock()
+        config.obsidian.notes_folder = ""
+        ctx = MagicMock(spec=KlemmaContext)
+        ctx.state = sm
+        ctx.config = config
+        ctx.project_root = tmp_path
+        ctx.project = MagicMock()
+        ctx.project.chapters = {}
+        return ctx
+
+    def test_help_exits_zero(self):
+        runner = CliRunner()
+        result = runner.invoke(klemma_cli, ["migrate-frontmatter", "--help"])
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+
+    def test_dry_run_shows_changes(self, tmp_path, mock_ctx):
+        from klemma.vault import VaultAdapter
+
+        vault = VaultAdapter(tmp_path)
+        _make_vault_note(tmp_path, "@smith2020", {"section": "1.2", "title": "Test paper"})
+        mock_ctx.vault = vault
+
+        runner = CliRunner()
+        with (
+            patch("klemma.cli._get_context", return_value=mock_ctx),
+            patch("klemma.cli._init_components", return_value=mock_ctx),
+        ):
+            result = runner.invoke(klemma_cli, ["migrate-frontmatter", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "1" in result.output  # 1 note updated
+        # Dry-run must NOT have modified the file
+        import yaml
+        text = (tmp_path / "@smith2020.md").read_text()
+        fm = yaml.safe_load(text.split("---")[1])
+        assert "section" in fm  # singular still present
+
+    def test_migrates_singular_to_plural(self, tmp_path, mock_ctx):
+        from klemma.vault import VaultAdapter
+
+        vault = VaultAdapter(tmp_path)
+        _make_vault_note(tmp_path, "@jones2021", {
+            "section": "2.3",
+            "chapter": 2,
+            "title": "A paper",
+        })
+        mock_ctx.vault = vault
+
+        runner = CliRunner()
+        with (
+            patch("klemma.cli._get_context", return_value=mock_ctx),
+            patch("klemma.cli._init_components", return_value=mock_ctx),
+        ):
+            result = runner.invoke(klemma_cli, ["migrate-frontmatter"])
+
+        assert result.exit_code == 0
+
+        import yaml
+        text = (tmp_path / "@jones2021.md").read_text()
+        fm = yaml.safe_load(text.split("---")[1])
+        assert fm.get("sections") == ["2.3"]
+        assert fm.get("chapters") == [2]
+        assert "section" not in fm
+        assert "chapter" not in fm
+
+    def test_skips_note_already_using_plural(self, tmp_path, mock_ctx):
+        from klemma.vault import VaultAdapter
+
+        vault = VaultAdapter(tmp_path)
+        _make_vault_note(tmp_path, "@brown2019", {
+            "sections": ["1.1", "2.1"],
+            "chapters": [1, 2],
+        })
+        mock_ctx.vault = vault
+
+        runner = CliRunner()
+        with (
+            patch("klemma.cli._get_context", return_value=mock_ctx),
+            patch("klemma.cli._init_components", return_value=mock_ctx),
+        ):
+            result = runner.invoke(klemma_cli, ["migrate-frontmatter"])
+
+        assert result.exit_code == 0
+        assert "skipped 1" in result.output
+
+    def test_no_vault_exits_nonzero(self, mock_ctx):
+        mock_ctx.vault = None
+        runner = CliRunner()
+        with (
+            patch("klemma.cli._get_context", return_value=mock_ctx),
+            patch("klemma.cli._init_components", return_value=mock_ctx),
+        ):
+            result = runner.invoke(klemma_cli, ["migrate-frontmatter"])
+        assert result.exit_code != 0
+        assert "No Obsidian vault" in result.output

--- a/tests/test_frontmatter_phase1.py
+++ b/tests/test_frontmatter_phase1.py
@@ -8,7 +8,6 @@ from click.testing import CliRunner
 
 from klemma.cli import main as klemma_cli
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -35,7 +34,6 @@ class TestSyncSectionsFallback:
     def _build_vault_data_entry(self, props: dict) -> dict:
         """Replicate the vault_data entry construction from _sync_sections."""
         sections_list = props.get("sections", [])
-        chapters_list = props.get("chapters", [])
 
         primary_section_str = str(props.get("section", "")) or None
         if not sections_list and primary_section_str:
@@ -96,8 +94,8 @@ class TestMigrateFrontmatter:
 
     @pytest.fixture
     def mock_ctx(self, tmp_path):
-        from klemma.state import StateManager
         from klemma.context import KlemmaContext
+        from klemma.state import StateManager
         sm = StateManager(str(tmp_path / "test.db"))
         config = MagicMock()
         config.obsidian.notes_folder = ""


### PR DESCRIPTION
## Summary
- `_sync_sections()`: falls back to `section:` singular as `[section]` list when `sections:` is absent/empty — preserves assignments for legacy vault notes
- Adds `klemma migrate-frontmatter` command to rewrite vault `@*.md` notes from singular `section:`/`chapter:` to plural `sections:`/`chapters:` (idempotent, supports `--dry-run`)

Closes #105 (Phase 1)

## Backward compatibility
- Legacy notes with `section: "1.2"` continue to work without any manual changes
- `klemma migrate-frontmatter` migrates vault notes at user's discretion
- Notes already using plural fields are skipped

## Test plan
- [x] 5 unit tests: fallback, plural takes priority, empty string not added, empty list with singular
- [x] 5 CLI tests: help, dry-run (no file changes), actual migration, skip already-plural, no-vault error
- [x] 1034/1035 tests pass (1 pre-existing `test_init_outline` failure)
- [x] `ruff check` clean

## Release Note

### Problem
Vault notes with `section: "1.2"` (singular YAML field) had their section assignments silently dropped by `_sync_sections()` when no `sections:` list was present, causing sources to appear unassigned in coverage stats. Users with legacy vaults (pre-multi-section support) experienced phantom "0 sources" for sections they had manually assigned.

### Academic Foundation
No specific citation — this is a data integrity fix. The multi-section assignment schema was introduced in PR #94; backward compatibility with the singular field pattern was not preserved at that time.

### Implementation
Two changes in `src/klemma/cli.py` (_sync_sections): (1) capture `primary_section_str` before conditionally extending `sections_list`, (2) if `sections_list` is empty and singular section exists, set `sections_list = [primary_section_str]`. Added `klemma migrate-frontmatter` command in `src/klemma/commands/manage.py` that reads vault notes, merges singular→plural, removes singular fields, and rewrites in-place.

### Results
Legacy notes with `section:` now correctly contribute to section coverage. `klemma migrate-frontmatter --dry-run` previews all changes safely. 10 new tests. Lint clean.