### PR TITLE
feat: online source ingest via BibTeX @online and URL fetch

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1142,29 +1142,48 @@ def _process_single(
             f"[blue]Processing: {entry.authors_str} ({entry.year or '?'})[/blue] [dim]@{citekey}[/dim]"
         )
 
-    # Find PDF
-    pdf_search_paths = [Path(cfg.zotero.storage_path)]
-    pdf_path = pdf_extractor.find_pdf(
-        citekey,
-        pdf_search_paths,
-        entry_title=entry.title or "",
-        direct_path=source.get("pdf_path") if source else entry.pdf_path,
-        pdf_lookup=library.pdf_paths,
-    )
-
-    if not pdf_path:
+    # Online source: fetch URL text instead of PDF
+    source_type = source.get("source_type", "") if source else ""
+    if source_type == "online":
+        source_url = source.get("url", "") if source else ""
+        if not source_url:
+            if not quiet:
+                console.print("  [red]Online source has no URL[/red]")
+            state.sources.mark_skipped(citekey, "online source missing URL")
+            return (0, "online source missing URL")
         if not quiet:
-            console.print("  [red]PDF not found[/red]")
-        state.sources.mark_skipped(citekey, "PDF not found")
-        return (0, "PDF not found")
+            console.print(f"  [dim]Fetching URL: {source_url[:80]}[/dim]")
+        from .literature.web import fetch_url_text
+        pdf_text = fetch_url_text(source_url, max_chars=cfg.ai.max_pdf_chars)
+        if not pdf_text or len(pdf_text) < 100:
+            if not quiet:
+                console.print("  [red]URL fetch failed or content too short[/red]")
+            state.sources.mark_skipped(citekey, "URL fetch failed")
+            return (0, "URL fetch failed")
+    else:
+        # Find PDF
+        pdf_search_paths = [Path(cfg.zotero.storage_path)]
+        pdf_path = pdf_extractor.find_pdf(
+            citekey,
+            pdf_search_paths,
+            entry_title=entry.title or "",
+            direct_path=source.get("pdf_path") if source else entry.pdf_path,
+            pdf_lookup=library.pdf_paths,
+        )
 
-    # Extract text
-    pdf_text = pdf_extractor.extract(pdf_path)
-    if not pdf_text or len(pdf_text) < cfg.processing.min_pdf_length:
-        if not quiet:
-            console.print("  [red]PDF extraction failed or text too short[/red]")
-        state.sources.mark_skipped(citekey, "text too short")
-        return (0, "text too short")
+        if not pdf_path:
+            if not quiet:
+                console.print("  [red]PDF not found[/red]")
+            state.sources.mark_skipped(citekey, "PDF not found")
+            return (0, "PDF not found")
+
+        # Extract text
+        pdf_text = pdf_extractor.extract(pdf_path)
+        if not pdf_text or len(pdf_text) < cfg.processing.min_pdf_length:
+            if not quiet:
+                console.print("  [red]PDF extraction failed or text too short[/red]")
+            state.sources.mark_skipped(citekey, "text too short")
+            return (0, "text too short")
 
     # If reprocessing, clear old fragments before extracting fresh ones
     if force:

--- a/src/klemma/commands/acquire.py
+++ b/src/klemma/commands/acquire.py
@@ -34,6 +34,19 @@ from ..cli import (
     help="JSON file with papers list",
 )
 @click.option(
+    "--bibtex",
+    "bibtex_str",
+    default=None,
+    help="BibTeX @online{...} entry string to register as online source",
+)
+@click.option(
+    "--bibtex-file",
+    "bibtex_file",
+    type=click.Path(exists=True),
+    default=None,
+    help=".bib file containing one @online{...} entry to register",
+)
+@click.option(
     "--no-process", is_flag=True, help="Skip fragment extraction after adding"
 )
 @click.pass_context
@@ -49,6 +62,8 @@ def acquire(
     section,
     pdf_url,
     batch_path,
+    bibtex_str,
+    bibtex_file,
     no_process,
 ):
     """Download PDF, add to Zotero, register in klemma.
@@ -56,13 +71,100 @@ def acquire(
     Single paper: klemma acquire <pdf_url> --title "..." --authors "..." --year 2022 --section 1.2
     With DOI + direct PDF: klemma acquire <doi_url> --pdf <direct_pdf_url> --section 1.3
     Batch: klemma acquire --batch papers.json
+    Online source: klemma acquire --bibtex '@online{key2024, title={...}, url={...}}'
+    Online from file: klemma acquire --bibtex-file source.bib --section 1.2
     """
-    from ..skills.acquirer import PaperMetadata, acquire_paper_local, load_batch
+    from ..skills.acquirer import (
+        PaperMetadata,
+        acquire_paper_local,
+        load_batch,
+        parse_bibtex_online,
+    )
 
     kctx = _get_context(ctx)
     cfg, state = kctx.config, kctx.state
 
-    # Build paper list
+    # --- BibTeX @online mode ---
+    if bibtex_str or bibtex_file:
+        if bibtex_file:
+            from pathlib import Path as _Path
+            bib_text = _Path(bibtex_file).read_text(encoding="utf-8")
+        else:
+            bib_text = bibtex_str
+
+        records = parse_bibtex_online(bib_text)
+        if not records:
+            console.print("[red]No @online{} entries found in BibTeX input.[/red]")
+            return
+
+        ok = 0
+        for rec in records:
+            console.print(f"\n[bold]Online source:[/bold] {rec.citekey}")
+            state.register_online_source(
+                citekey=rec.citekey,
+                title=rec.title,
+                authors=rec.authors,
+                year=rec.year,
+                url=rec.url,
+                abstract=rec.abstract,
+            )
+            if list(section):
+                sections_list = list(section)
+                chapters = list({int(s.split(".")[0]) for s in sections_list if "." in s})
+                state.set_source_sections(rec.citekey, sections_list, chapters)
+                console.print(f"  [dim]sections: {', '.join(sections_list)}[/dim]")
+
+            console.print(f"  [green]@{rec.citekey}[/green]")
+            if rec.title:
+                console.print(f"  Title: {rec.title}")
+            if rec.authors:
+                console.print(f"  Authors: {rec.authors}")
+            if rec.year:
+                console.print(f"  Year: {rec.year}")
+            if rec.url:
+                console.print(f"  URL: {rec.url}")
+            console.print("  [yellow]Online source (no PDF — use 'klemma process' to fetch text)[/yellow]")
+
+            if not no_process and rec.url:
+                try:
+                    ai = _init_ai(cfg)
+                except Exception as e:
+                    console.print(
+                        f"  [yellow]Skipping auto-process (AI unavailable: {e})[/yellow]"
+                    )
+                    console.print(
+                        f"  [dim]Run manually: klemma process {rec.citekey}[/dim]"
+                    )
+                    ai = None
+
+                if ai:
+                    from ..literature.pdf import PDFExtractor
+
+                    pdf_extractor = PDFExtractor(max_chars=cfg.ai.max_pdf_chars)
+                    with console.status(
+                        f"Extracting fragments from @{rec.citekey}", spinner="arc"
+                    ):
+                        _process_single(
+                            rec.citekey,
+                            cfg,
+                            state,
+                            kctx.vault,
+                            ai,
+                            pdf_extractor,
+                            kctx.library,
+                            dissertation_context=kctx.dissertation_context,
+                            available_tags=kctx.available_tags,
+                            klemma_home=kctx.klemma_home,
+                            project_type=(
+                                kctx.project.type if kctx.project else "dissertation"
+                            ),
+                        )
+            ok += 1
+
+        console.print(f"\n[green]Done: {ok}/{len(records)} online source(s) registered.[/green]")
+        return
+
+    # --- Build paper list (URL / batch mode) ---
     if batch_path:
         papers = load_batch(batch_path)
         console.print(f"[blue]Loaded {len(papers)} papers from batch file[/blue]")
@@ -81,7 +183,7 @@ def acquire(
             )
         ]
     else:
-        console.print("[red]Provide a URL or --batch file[/red]")
+        console.print("[red]Provide a URL, --batch file, or --bibtex entry[/red]")
         return
 
     ok = 0

--- a/src/klemma/literature/web.py
+++ b/src/klemma/literature/web.py
@@ -1,0 +1,129 @@
+"""Fetch and strip HTML from web pages for online source processing."""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from html.parser import HTMLParser
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "Mozilla/5.0 (compatible; Klemma/1.0; +https://github.com/klemma-ai/klemma)"
+_FETCH_TIMEOUT = 15  # seconds
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB response cap
+
+
+class _TextExtractor(HTMLParser):
+    """Minimal HTML parser that extracts visible text, skipping script/style."""
+
+    _SKIP_TAGS = {"script", "style", "noscript", "head", "meta", "link"}
+    _BLOCK_TAGS = {
+        "p", "div", "br", "li", "tr", "td", "th", "h1", "h2", "h3",
+        "h4", "h5", "h6", "blockquote", "article", "section", "header",
+        "footer", "nav", "aside", "figure", "figcaption",
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip_depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        tag = tag.lower()
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+        elif tag in self._BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in self._SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        elif tag in self._BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        raw = "".join(self._parts)
+        raw = html.unescape(raw)
+        # Collapse whitespace, preserve paragraph breaks
+        lines = [line.strip() for line in raw.splitlines()]
+        # Remove blank line runs > 2
+        collapsed: list[str] = []
+        blank_run = 0
+        for line in lines:
+            if not line:
+                blank_run += 1
+                if blank_run <= 2:
+                    collapsed.append("")
+            else:
+                blank_run = 0
+                collapsed.append(line)
+        return "\n".join(collapsed).strip()
+
+
+def _strip_html(html_text: str) -> str:
+    """Strip HTML tags and return plain text."""
+    parser = _TextExtractor()
+    try:
+        parser.feed(html_text)
+        return parser.get_text()
+    except Exception:
+        # Fallback: regex tag stripping
+        text = re.sub(r"<[^>]+>", " ", html_text)
+        return html.unescape(text).strip()
+
+
+def fetch_url_text(url: str, max_chars: int = 200_000) -> str:
+    """Fetch a URL and return stripped plain text.
+
+    Returns empty string on network/HTTP errors. Caps output at max_chars.
+    Handles gzip-encoded responses transparently (requests does this).
+    """
+    import requests
+
+    try:
+        resp = requests.get(
+            url,
+            timeout=_FETCH_TIMEOUT,
+            headers={"User-Agent": _USER_AGENT, "Accept-Language": "en-US,en;q=0.9"},
+            stream=True,
+        )
+        resp.raise_for_status()
+
+        # Content-type check — only process text/html and text/plain
+        ct = resp.headers.get("content-type", "").lower()
+        if "html" not in ct and "text" not in ct:
+            logger.warning("fetch_url_text: unexpected content-type '%s' for %s", ct, url[:60])
+            return ""
+
+        # Stream with byte cap
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_content(chunk_size=65536):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total >= _MAX_BYTES:
+                logger.debug("fetch_url_text: capped at %d bytes for %s", _MAX_BYTES, url[:60])
+                break
+
+        raw = b"".join(chunks).decode("utf-8", errors="replace")
+
+        if "html" in ct:
+            text = _strip_html(raw)
+        else:
+            text = raw
+
+        if len(text) > max_chars:
+            text = text[:max_chars]
+
+        logger.debug("fetch_url_text: %d chars from %s", len(text), url[:60])
+        return text
+
+    except Exception as exc:
+        logger.warning("fetch_url_text failed for '%s': %s", url[:60], exc)
+        return ""

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -33,6 +33,37 @@ class SourceRepository(BaseRepository):
                 [(sid,) for sid in source_ids],
             )
 
+    def register_online_source(
+        self,
+        citekey: str,
+        title: str,
+        authors: str,
+        year: Optional[int],
+        url: str,
+        abstract: str = "",
+    ) -> None:
+        """Register an online source (no PDF) with metadata in one step.
+
+        Inserts into sources with source_type='online', then sets metadata.
+        Idempotent — safe to call if citekey already exists.
+        """
+        with self._conn() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO sources (id, source_type) VALUES (?, 'online')",
+                (citekey,),
+            )
+            conn.execute(
+                """UPDATE sources SET
+                    title = COALESCE(NULLIF(?, ''), title),
+                    authors = COALESCE(NULLIF(?, ''), authors),
+                    year = COALESCE(?, year),
+                    abstract = COALESCE(NULLIF(?, ''), abstract),
+                    url = COALESCE(NULLIF(?, ''), url),
+                    source_type = 'online'
+                WHERE id = ?""",
+                (title, authors, year, abstract, url, citekey),
+            )
+
     def set_pdf_path(self, source_id: str, path: str):
         """Set the direct PDF path for a source."""
         with self._conn() as conn:
@@ -166,8 +197,10 @@ class SourceRepository(BaseRepository):
         year: Optional[int] = None,
         abstract: str = "",
         doi: str = "",
+        url: str = "",
+        source_type: str = "",
     ):
-        """Persist paper metadata (title/authors/year/abstract/doi).
+        """Persist paper metadata (title/authors/year/abstract/doi/url/source_type).
 
         Only sets non-empty values — existing data is preserved via COALESCE.
         """
@@ -178,9 +211,11 @@ class SourceRepository(BaseRepository):
                     authors = COALESCE(NULLIF(?, ''), authors),
                     year = COALESCE(?, year),
                     abstract = COALESCE(NULLIF(?, ''), abstract),
-                    doi = COALESCE(NULLIF(?, ''), doi)
+                    doi = COALESCE(NULLIF(?, ''), doi),
+                    url = COALESCE(NULLIF(?, ''), url),
+                    source_type = COALESCE(NULLIF(?, ''), source_type)
                 WHERE id = ?""",
-                (title, authors, year, abstract, doi, source_id),
+                (title, authors, year, abstract, doi, url, source_type, source_id),
             )
 
     def get_source(self, source_id: str) -> Optional[dict]:

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -662,3 +662,96 @@ def load_batch(path: str) -> list[PaperMetadata]:
             sections=item.get("sections", []),
         ))
     return papers
+
+
+@dataclass
+class OnlineSourceRecord:
+    """Parsed BibTeX @online entry for direct DB registration."""
+
+    citekey: str
+    title: str
+    authors: str
+    year: Optional[int]
+    url: str
+    abstract: str = ""
+
+
+def parse_bibtex_online(bibtex_text: str) -> list[OnlineSourceRecord]:
+    """Parse @online{} BibTeX entries from a string.
+
+    Supports single or multiple entries. Only @online type is accepted —
+    @article, @book, etc. are ignored (those go through acquire).
+
+    Field extraction handles:
+    - Braced values: title = {Some Title}
+    - Quoted values: title = "Some Title"
+    - Multiline values (braces must be balanced within the block)
+
+    Returns list of OnlineSourceRecord (empty list if none found).
+    """
+    records = []
+
+    # Find all @online{...} blocks
+    entry_pattern = re.compile(
+        r"@online\s*\{([^,]+),([^@]*)\}",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    for match in entry_pattern.finditer(bibtex_text):
+        citekey = match.group(1).strip()
+        fields_text = match.group(2)
+
+        def _extract_field(name: str, text: str) -> str:
+            """Extract a BibTeX field value (braced or quoted)."""
+            # Braced: field = {value}
+            m = re.search(
+                rf"(?i)\b{name}\s*=\s*\{{((?:[^{{}}]|\{{[^{{}}]*\}})*)\}}",
+                text,
+            )
+            if m:
+                return m.group(1).strip()
+            # Quoted: field = "value"
+            m = re.search(rf'(?i)\b{name}\s*=\s*"([^"]*)"', text)
+            if m:
+                return m.group(1).strip()
+            return ""
+
+        title = _extract_field("title", fields_text)
+        url = _extract_field("url", fields_text)
+        abstract = _extract_field("abstract", fields_text)
+
+        # Authors: try "author" field first
+        raw_authors = _extract_field("author", fields_text)
+        # Normalise "Last, First and Last2, First2" → "Last First, Last2 First2"
+        if " and " in raw_authors:
+            parts = [a.strip() for a in raw_authors.split(" and ")]
+            normalised = []
+            for part in parts:
+                if "," in part:
+                    last, first = part.split(",", 1)
+                    normalised.append(f"{first.strip()} {last.strip()}")
+                else:
+                    normalised.append(part)
+            authors = ", ".join(normalised)
+        else:
+            authors = raw_authors
+
+        # Year
+        year_str = _extract_field("year", fields_text)
+        year: Optional[int] = None
+        if year_str and year_str.isdigit():
+            year = int(year_str)
+
+        if not citekey:
+            continue
+
+        records.append(OnlineSourceRecord(
+            citekey=citekey,
+            title=title,
+            authors=authors,
+            year=year,
+            url=url,
+            abstract=abstract,
+        ))
+
+    return records

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -206,7 +206,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 11  # bump this when adding new migrations
+        target = 12  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -442,12 +442,38 @@ class StateManager:
                     cur.rowcount,
                 )
 
+        if version < 12:
+            existing_src = {
+                row[1] for row in conn.execute("PRAGMA table_info(sources)")
+            }
+            for col, col_type in [
+                ("url", "TEXT"),
+                ("source_type", "TEXT DEFAULT 'pdf'"),
+            ]:
+                if col not in existing_src:
+                    conn.execute(
+                        f"ALTER TABLE sources ADD COLUMN {col} {col_type}"
+                    )
+
         conn.execute(f"PRAGMA user_version = {target}")
 
     # ── Source delegation ─────────────────────────────────────────────────
 
     def register_sources(self, source_ids: list[str]):
         return self.sources.register_sources(source_ids)
+
+    def register_online_source(
+        self,
+        citekey: str,
+        title: str,
+        authors: str,
+        year: Optional[int],
+        url: str,
+        abstract: str = "",
+    ) -> None:
+        return self.sources.register_online_source(
+            citekey, title, authors, year, url, abstract
+        )
 
     def set_pdf_path(self, source_id: str, path: str):
         return self.sources.set_pdf_path(source_id, path)
@@ -491,8 +517,11 @@ class StateManager:
         return self.sources.get_source(source_id)
 
     def update_source_info(self, source_id: str, title: str = "", authors: str = "",
-                           year: Optional[int] = None, abstract: str = "", doi: str = ""):
-        return self.sources.update_source_info(source_id, title, authors, year, abstract, doi)
+                           year: Optional[int] = None, abstract: str = "", doi: str = "",
+                           url: str = "", source_type: str = ""):
+        return self.sources.update_source_info(
+            source_id, title, authors, year, abstract, doi, url, source_type
+        )
 
     def set_source_role(self, source_id: str, role: str):
         return self.sources.set_source_role(source_id, role)

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 11
+        assert version == 12
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 11
+        assert version == 12
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_online_source.py
+++ b/tests/test_online_source.py
@@ -1,0 +1,264 @@
+"""Tests for online source ingest — BibTeX parsing, web fetch, DB migration."""
+
+from unittest.mock import MagicMock, patch
+
+from klemma.literature.web import _strip_html, fetch_url_text
+from klemma.skills.acquirer import parse_bibtex_online
+
+# ── BibTeX @online parser ─────────────────────────────────────────────────
+
+
+class TestParseBibtexOnline:
+    def test_basic_entry(self):
+        bib = """
+@online{ipcc2023,
+  title = {Climate Change 2023: Synthesis Report},
+  author = {IPCC},
+  year = {2023},
+  url = {https://www.ipcc.ch/report/ar6/syr/},
+}
+"""
+        records = parse_bibtex_online(bib)
+        assert len(records) == 1
+        r = records[0]
+        assert r.citekey == "ipcc2023"
+        assert r.title == "Climate Change 2023: Synthesis Report"
+        assert r.year == 2023
+        assert r.url == "https://www.ipcc.ch/report/ar6/syr/"
+
+    def test_author_and_normalisation(self):
+        bib = """
+@online{smith2020,
+  title = {A Study},
+  author = {Smith, John and Doe, Jane},
+  year = {2020},
+  url = {https://example.com/},
+}
+"""
+        records = parse_bibtex_online(bib)
+        assert len(records) == 1
+        r = records[0]
+        assert "John Smith" in r.authors
+        assert "Jane Doe" in r.authors
+
+    def test_ignores_non_online_entries(self):
+        bib = """
+@article{jones2021,
+  title = {An Article},
+  author = {Jones, Alice},
+  year = {2021},
+}
+@online{web2022,
+  title = {A Web Page},
+  year = {2022},
+  url = {https://example.com/page},
+}
+"""
+        records = parse_bibtex_online(bib)
+        assert len(records) == 1
+        assert records[0].citekey == "web2022"
+
+    def test_multiple_online_entries(self):
+        bib = """
+@online{a2020, title = {First}, year = {2020}, url = {https://a.com/}}
+@online{b2021, title = {Second}, year = {2021}, url = {https://b.com/}}
+"""
+        records = parse_bibtex_online(bib)
+        assert len(records) == 2
+        assert {r.citekey for r in records} == {"a2020", "b2021"}
+
+    def test_empty_input(self):
+        assert parse_bibtex_online("") == []
+
+    def test_no_online_entries(self):
+        bib = "@book{foo2020, title={Foo}, author={Bar}}"
+        assert parse_bibtex_online(bib) == []
+
+    def test_abstract_field(self):
+        bib = """
+@online{doc2022,
+  title = {Documentation},
+  abstract = {This is the abstract.},
+  url = {https://docs.example.com/},
+  year = {2022},
+}
+"""
+        records = parse_bibtex_online(bib)
+        assert records[0].abstract == "This is the abstract."
+
+    def test_missing_year_is_none(self):
+        bib = "@online{nodate, title = {No Date}, url = {https://example.com/}}"
+        records = parse_bibtex_online(bib)
+        assert records[0].year is None
+
+    def test_case_insensitive_type(self):
+        bib = "@ONLINE{upper2023, title = {Upper}, url = {https://u.com/}, year = {2023}}"
+        records = parse_bibtex_online(bib)
+        assert len(records) == 1
+        assert records[0].citekey == "upper2023"
+
+
+# ── HTML stripping ────────────────────────────────────────────────────────
+
+
+class TestStripHtml:
+    def test_basic_tags_removed(self):
+        text = _strip_html("<p>Hello <b>world</b></p>")
+        assert "Hello" in text
+        assert "world" in text
+        assert "<" not in text
+
+    def test_script_and_style_content_removed(self):
+        html = "<div>Content</div><script>var x = 1;</script><style>.cls{}</style>"
+        text = _strip_html(html)
+        assert "Content" in text
+        assert "var x" not in text
+        assert ".cls" not in text
+
+    def test_html_entities_decoded(self):
+        text = _strip_html("<p>Sea &amp; ice &lt;prediction&gt;</p>")
+        assert "&amp;" not in text
+        assert "Sea & ice" in text
+
+    def test_empty_html(self):
+        assert _strip_html("") == ""
+
+    def test_plain_text_unchanged(self):
+        text = _strip_html("no tags here")
+        assert text == "no tags here"
+
+
+# ── fetch_url_text ────────────────────────────────────────────────────────
+
+
+class TestFetchUrlText:
+    @patch("requests.get")
+    def test_fetches_html_and_strips(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_resp.iter_content.return_value = [
+            b"<html><body><p>Sea ice prediction methods</p></body></html>"
+        ]
+        mock_get.return_value = mock_resp
+
+        text = fetch_url_text("https://example.com/paper")
+        assert "Sea ice prediction methods" in text
+
+    @patch("requests.get")
+    def test_returns_empty_on_error(self, mock_get):
+        mock_get.side_effect = Exception("Connection refused")
+        text = fetch_url_text("https://example.com/bad")
+        assert text == ""
+
+    @patch("requests.get")
+    def test_returns_empty_for_non_text_content_type(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/pdf"}
+        mock_resp.iter_content.return_value = [b"%PDF-1.4"]
+        mock_get.return_value = mock_resp
+
+        text = fetch_url_text("https://example.com/doc.pdf")
+        assert text == ""
+
+    @patch("requests.get")
+    def test_respects_max_chars(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/html"}
+        content = b"<p>" + b"A" * 10000 + b"</p>"
+        mock_resp.iter_content.return_value = [content]
+        mock_get.return_value = mock_resp
+
+        text = fetch_url_text("https://example.com/long", max_chars=100)
+        assert len(text) <= 100
+
+
+# ── DB schema v12 migration ───────────────────────────────────────────────
+
+
+class TestSchemaV12:
+    def test_url_and_source_type_columns_exist(self, tmp_path):
+        """v12 migration adds url and source_type to sources."""
+
+        from klemma.state import StateManager
+
+        db_path = tmp_path / "test.db"
+        state = StateManager(str(db_path))
+        state._init_db()
+
+        with state._conn() as conn:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
+        assert "url" in cols
+        assert "source_type" in cols
+
+    def test_register_online_source_roundtrip(self, tmp_path):
+        """register_online_source() writes url/source_type and can be read back."""
+        from klemma.state import StateManager
+
+        db_path = tmp_path / "test.db"
+        state = StateManager(str(db_path))
+        state._init_db()
+
+        state.register_online_source(
+            citekey="ipcc2023",
+            title="IPCC AR6 Synthesis",
+            authors="IPCC",
+            year=2023,
+            url="https://www.ipcc.ch/report/ar6/syr/",
+        )
+
+        source = state.get_source("ipcc2023")
+        assert source is not None
+        assert source["title"] == "IPCC AR6 Synthesis"
+        assert source["authors"] == "IPCC"
+        assert source["year"] == 2023
+        assert source["url"] == "https://www.ipcc.ch/report/ar6/syr/"
+        assert source["source_type"] == "online"
+
+    def test_register_online_source_idempotent(self, tmp_path):
+        """Calling register_online_source twice is safe."""
+        from klemma.state import StateManager
+
+        db_path = tmp_path / "test.db"
+        state = StateManager(str(db_path))
+        state._init_db()
+
+        state.register_online_source(
+            citekey="web2022",
+            title="Original Title",
+            authors="Author A",
+            year=2022,
+            url="https://example.com/",
+        )
+        # Second call should not raise and preserves existing data
+        state.register_online_source(
+            citekey="web2022",
+            title="",  # empty — should not overwrite
+            authors="",
+            year=None,
+            url="",
+        )
+        source = state.get_source("web2022")
+        assert source["title"] == "Original Title"
+        assert source["source_type"] == "online"
+
+    def test_update_source_info_url_and_source_type(self, tmp_path):
+        """update_source_info() accepts url and source_type kwargs."""
+        from klemma.state import StateManager
+
+        db_path = tmp_path / "test.db"
+        state = StateManager(str(db_path))
+        state._init_db()
+
+        state.register_sources(["mykey2024"])
+        state.update_source_info(
+            "mykey2024",
+            title="My Title",
+            url="https://example.com/my",
+            source_type="online",
+        )
+        source = state.get_source("mykey2024")
+        assert source["url"] == "https://example.com/my"
+        assert source["source_type"] == "online"

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 11
+    assert version == 12
     conn.close()
 
 


### PR DESCRIPTION
Closes #39

## Summary
- DB schema v12: adds `url` and `source_type` columns to `sources` table
- `klemma acquire --bibtex '<@online{...}>'` / `--bibtex-file path.bib` — registers BibTeX `@online` entries as online sources with no PDF
- `klemma process` extended: detects `source_type='online'`, fetches URL text via HTTP instead of PDF lookup, then runs fragment extraction normally
- `literature/web.py` — streaming HTML fetcher with tag stripping and entity decoding

## Release Note

### Problem
Klemma could only process sources backed by a PDF. Web-based references — W3C specs, documentation, IPCC reports, government databases, conference proceedings behind paywalls — couldn't be tracked, embedded, or annotated. Users had to skip entire categories of literature.

### Academic Foundation
Systematic literature reviews (Pautasso 2013) require comprehensive source coverage across publication types. Online-only sources are increasingly cited in climate science, computer science, and interdisciplinary fields (Cohan et al. 2019). Excluding them from the knowledge base creates coverage gaps that bias section research and reference-gap scoring.

### Implementation
- **DB v12 migration** in `state.py`: idempotent `ALTER TABLE sources ADD COLUMN url TEXT` and `source_type TEXT DEFAULT 'pdf'`. Schema version bumped 11→12.
- **`register_online_source()`** in `repositories/sources.py` and `state.py` facade: single-step INSERT + UPDATE with `source_type='online'`.
- **`parse_bibtex_online()`** in `skills/acquirer.py`: regex-based parser for `@online{...}` BibTeX entries; handles braced and quoted field values, normalises `Last, First and ...` author format.
- **`acquire --bibtex` / `--bibtex-file`** in `commands/acquire.py`: new options call the parser, register each entry, optionally auto-process.
- **`_process_single()` in `cli.py`**: checks `source.source_type == 'online'` before PDF lookup; calls `fetch_url_text(source.url)` from `literature/web.py`.
- **`literature/web.py`**: streaming HTTP GET with 5 MB cap, `_TextExtractor(HTMLParser)` skips `<script>/<style>`, collapses whitespace, decodes HTML entities; falls back to regex stripping on parse error.

### Results
- 22 new tests: BibTeX parsing (9), HTML stripping (5), `fetch_url_text` mock (4), DB schema v12 (4)
- 1083 tests total (+22 over baseline), 1 pre-existing unrelated failure unchanged
- `ruff check src/ tests/` — clean