### PR TITLE
feat: three-tier library Phase 1C — LocalUserLibrary + LocalProjectStore + klemma migrate-library (#126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,13 @@ Only after reviewing GH context should you explore code or files.
 
 ## Automatic PM & CTO reviews
 
-Before creating a PR or GitHub issue for any feature/epic, **automatically** run both reviews without being asked:
+**Before** creating a PR or GitHub issue for any feature/epic, **automatically** run both reviews without being asked:
 1. `/pm-review` — product fit, scope, priority, core loop alignment
 2. `/cto-review` — architecture, red lines, dependency direction, SaaS readiness
 
 Present both reviews to the user and wait for their decision before proceeding. This applies to all features and epics — skip only for trivial bugfixes and typo-level changes.
+
+**After** creating a PR, run `/cto-review <PR#>` immediately and work on all Required Changes before the PR is considered done. Do not wait for the user to ask.
 
 ## Feature development workflow
 
@@ -26,6 +28,7 @@ Every epic/feature follows this sequence. Do not skip or reorder steps. Skip thi
 5. **Verify** — `ruff check src/ tests/` then `python -m pytest tests/ -q`; fix until both pass
 6. **Docs** — update all affected `CLAUDE.md` files, `README.md`, and user guide in `docs/`
 7. **Commit & PR** — atomic commit, then `gh pr create`. **Always link PRs to issues** using `Closes #N` (for issues the PR fully resolves) or `Part of #N` (for epics). After creating the PR, tick off the completed task checkboxes in the epic issue body (`gh issue edit <N> --body "..."` with updated `- [x]` items). The PR body must also include a **Release Note** mini-article (~300 words) with four sections:
+7b. **Post-PR CTO review** — immediately after `gh pr create`, run `/cto-review` on the new PR. Work on every Required Change before considering the PR done. Suggestions are optional but should be addressed if quick. Do not wait for the user to ask.
    ```
    ## Release Note
 

--- a/docs/MIGRATION_THREE_TIER.md
+++ b/docs/MIGRATION_THREE_TIER.md
@@ -1,0 +1,241 @@
+# Migration Guide: Monolithic DB → Three-Tier Library
+
+**Applies to**: klemma v0.14+ (after PRs #143–#145 merged, ADR-014 Phase 1A–1C)
+**Estimated time**: 5–15 minutes per project
+
+---
+
+## What changes
+
+Before migration each project stored everything in its own database:
+
+```
+project/.klemma/data/klemma.db   ← sources, fragments, embeddings, gaps, plans, benchmarks
+```
+
+After migration data is split across two shared files:
+
+```
+~/.klemma/library.db                     ← papers, fragments, embeddings  (shared across all projects)
+project/.klemma/data/project.db          ← section assignments, gaps, plans, benchmarks  (per-project)
+```
+
+**Why bother?** Processing the same PDF in project B is now instant if project A already extracted it — no Claude API call, no OpenAI embed call. For a 200-paper dissertation library shared with 3 satellite papers: ~$6 and ~90 minutes saved.
+
+---
+
+## Before you start
+
+**1. Upgrade klemma**
+
+```bash
+pip install --upgrade klemma
+klemma --version   # must be >= 0.14.0
+```
+
+**2. Check which projects you have**
+
+```bash
+find ~/research -name "klemma.db" -path "*/.klemma/data/*" 2>/dev/null
+```
+
+Note the paths — you'll migrate each one separately.
+
+**3. Take a manual backup** (the command also makes one automatically, but belt and suspenders)
+
+```bash
+cp ~/.klemma/data/klemma.db ~/.klemma/data/klemma.db.manual_bak
+# for each project:
+cp project/.klemma/data/klemma.db project/.klemma/data/klemma.db.manual_bak
+```
+
+---
+
+## Migration steps
+
+### Single project
+
+```bash
+cd ~/research/my-thesis/
+
+# 1. Dry run — see what would be migrated, no changes made
+klemma migrate-library
+
+# Expected output:
+#   Three-tier library migration — DRY RUN
+#   Source DB   : .../klemma.db
+#   library.db  : ~/.klemma/library.db
+#   project.db  : .../project.db
+#
+#   368 sources · 1838 fragments · 832 section assignments
+#
+#   Dry run — pass --apply to execute migration
+
+# 2. Run migration
+klemma migrate-library --apply
+
+# Expected output:
+#   Backup created: .../klemma.db.bak
+#   Migration complete:
+#     Papers registered : 368
+#     Fragments migrated: 1838
+#     Section entries   : 832
+#   Note: Migrated papers use citekey-based deduplication...
+
+# 3. Verify
+klemma status
+```
+
+`klemma status` must show the same source counts and section coverage as before.
+
+---
+
+### Multiple projects (dissertation + satellite papers)
+
+Migrate the **parent project first**, then child projects. When a child migrates a paper already in `library.db` (same citekey → same synthetic hash), the existing `paper_id` is reused — deduplication kicks in automatically.
+
+```bash
+# 1. Parent (dissertation)
+cd ~/research/dissertation/
+klemma migrate-library --apply
+klemma status
+
+# 2. Child papers (in any order)
+cd ~/research/paper-dialog-2026/
+klemma migrate-library --apply
+klemma status
+
+cd ~/research/paper-sea-ice/
+klemma migrate-library --apply
+klemma status
+```
+
+After all migrations, `~/.klemma/library.db` contains the deduplicated union of all papers. Each project's `project.db` contains only its own section assignments and gaps.
+
+**Note on deduplication**: Migration uses citekey-based dedup (not PDF SHA256). Same paper under the same citekey in two projects → one entry in `library.db`. Same paper under *different* citekeys (e.g. `smith2022` vs `smith2022nlp`) → two entries. Run `klemma process --force <citekey>` after migration to upgrade to content-addressable SHA256 dedup for any paper.
+
+---
+
+## What to check after migration
+
+### 1. Source counts match
+
+```bash
+klemma status --verbose
+```
+
+Compare total sources and per-section counts with your pre-migration numbers.
+
+### 2. Fragment search still works
+
+```bash
+klemma research -s 1.1   # should find fragments as before
+klemma ask "What methods does smith2022 use?"
+```
+
+### 3. New papers process faster
+
+Add a new paper that's already in another project's library:
+
+```bash
+klemma process <citekey>
+# Should print: "Found in library.db — skipping extraction" (no Claude API call)
+```
+
+### 4. Library DB is being populated going forward
+
+After processing any new paper, verify it landed in `library.db`:
+
+```bash
+sqlite3 ~/.klemma/library.db "SELECT paper_id, title FROM papers ORDER BY created_at DESC LIMIT 5;"
+```
+
+---
+
+## Rollback
+
+If anything goes wrong, the command created a backup automatically:
+
+```bash
+# Restore monolithic DB from backup
+cp project/.klemma/data/klemma.db.bak project/.klemma/data/klemma.db
+
+# Delete the new files (or just leave them — klemma still reads monolithic DB)
+rm project/.klemma/data/project.db
+rm ~/.klemma/library.db   # only if no other projects have migrated
+```
+
+klemma continues to read and write `klemma.db` during the Phase 1B–1C transition. The new stores operate in parallel (dual-write). Rollback is safe.
+
+---
+
+## File layout after migration
+
+```
+~/.klemma/
+├── library.db                     # papers + fragments + embeddings (ALL projects share this)
+└── data/
+    └── klemma.db                  # legacy system-level DB (unused by default)
+
+~/research/dissertation/
+└── .klemma/
+    ├── config.yaml
+    └── data/
+        ├── klemma.db              # monolithic DB (still used by StateManager in Phase 1C)
+        ├── klemma.db.bak          # backup created by migrate-library
+        └── project.db             # new: section assignments, gaps, plans
+
+~/research/paper-dialog-2026/
+└── .klemma/
+    └── data/
+        ├── klemma.db
+        ├── klemma.db.bak
+        └── project.db
+```
+
+---
+
+## Known limitations (Phase 1C)
+
+| Limitation | Impact | When fixed |
+|------------|--------|------------|
+| StateManager still reads monolithic `klemma.db` | `klemma status`, `klemma research` etc. still work via old path | Phase 1D |
+| `klemma status` coverage comes from `klemma.db`, not `project.db` | No behavior change yet | Phase 1D |
+| Reference gaps still in `klemma.db` | `klemma suggest` unaffected | Phase 1D |
+| Migrated papers use citekey-based dedup | Same paper under different citekeys → two entries in `library.db` | Re-process with `--force` |
+| `inherit_db` still works | Existing parent-child DB chains unaffected | Removed in Phase 1D |
+
+In other words: **after migration, all existing commands work exactly as before**. The split databases are populated in the background and become the authoritative source of truth after Phase 1D.
+
+---
+
+## Troubleshooting
+
+**`No monolithic DB found`**
+
+The project doesn't have a `klemma.db` yet (e.g. newly initialized project). Nothing to migrate — the three-tier stores will be populated automatically as you run `klemma process`.
+
+**`klemma status` shows fewer sources after migration**
+
+This means `klemma status` is reading `project.db` instead of `klemma.db`. Check your klemma version — in Phase 1C, `klemma status` should still read from `klemma.db`. File an issue if you're on v0.14 and see this.
+
+**`klemma process` still calls Claude after migration**
+
+Expected in Phase 1C. Full dedup (skip-if-in-library.db) is active only for papers processed *after* the dual-write was merged (v0.13+). Migrated papers from `klemma.db` get synthetic hashes — re-run `klemma process --force <citekey>` to register the real SHA256 hash and get future dedup.
+
+**`migrate-library` fails mid-run**
+
+The backup at `klemma.db.bak` is intact. Delete the partially-written `project.db` and `library.db` entries, then re-run `--apply`. The operation is idempotent for papers (upsert) but fragment counts may be off — check with `klemma status`.
+
+---
+
+## What comes next (Phase 1D)
+
+After Phase 1D merges, StateManager will become a facade over the three stores. At that point:
+
+- `klemma status` reads from `project.db` (authoritative section coverage)
+- `klemma suggest` reads reference gaps from `project.db`
+- `inherit_db` is removed (shared `library.db` replaces it)
+- Monolithic `klemma.db` can be archived or deleted
+
+No additional migration step will be required — Phase 1D is a code-only change. Your `library.db` and `project.db` from this migration will be picked up automatically.

--- a/docs/MIGRATION_THREE_TIER.md
+++ b/docs/MIGRATION_THREE_TIER.md
@@ -1,6 +1,6 @@
 # Migration Guide: Monolithic DB → Three-Tier Library
 
-**Applies to**: klemma v0.14+ (after PRs #143–#145 merged, ADR-014 Phase 1A–1C)
+**Applies to**: klemma after PRs #143–#145 merged (ADR-014 Phase 1A–1C). The `migrate-library` command ships with PR #145.
 **Estimated time**: 5–15 minutes per project
 
 ---
@@ -26,11 +26,18 @@ project/.klemma/data/project.db          ← section assignments, gaps, plans, b
 
 ## Before you start
 
-**1. Upgrade klemma**
+**1. Verify `migrate-library` is available**
+
+```bash
+klemma migrate-library --help
+```
+
+If you get `No such command`, PR #145 hasn't merged into your installed version yet — upgrade first:
 
 ```bash
 pip install --upgrade klemma
-klemma --version   # must be >= 0.14.0
+# or, to install directly from the merged branch:
+pip install git+https://github.com/klemma-ai/klemma.git@master
 ```
 
 **2. Check which projects you have**

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -11,7 +11,7 @@ Click CLI entry point. Defines 18 commands + hidden aliases.
 - `_get_context(ctx)` — returns cached `KlemmaContext` from `ctx.obj` or initializes fresh
 - `_init_ai()` — creates AI client (separated for commands that don't need API key)
 - `_sync_sections()` — auto-sync vault frontmatter → DB on every `research`/`library`/`status` command
-- Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `library duplicates`, `suggest`, `reassign`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`, `migrate-content` (hidden — moves config.yaml content fields to KLEMMA.md frontmatter)
+- Commands: `init`, `plan`, `status`, `process`, `embed`, `similar`, `acquire`, `research`, `library`, `library prune`, `library duplicates`, `suggest`, `reassign`, `outline`, `ask`, `info`, `tree`, `benchmark`, `migrate`, `migrate-content` (hidden — moves config.yaml content fields to KLEMMA.md frontmatter), `migrate-library` (dry-run by default; `--run` copies monolithic klemma.db → library.db + project.db via three-tier stores)
 - Hidden aliases: `gaps suggest` → `suggest`, `coverage` → `status --verbose`
 - Deprecation warnings: bare `klemma gaps` → use `klemma status --verbose`; `klemma library -s` → use `klemma research -s`
 - `init --outline` generates an outline after project setup (requires AI backend)
@@ -29,7 +29,7 @@ Click CLI entry point. Defines 18 commands + hidden aliases.
 
 ### context.py (47 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.
-Holds: `config`, `state`, `vault`, `ai` (optional), `embeddings` (optional), `library` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`, `paper_store` (optional — `LocalPaperStore` at `~/.klemma/library.db`, added ADR-014 Phase 1B).
+Holds: `config`, `state`, `vault`, `ai` (optional), `embeddings` (optional), `library` (optional), `project` (optional), `klemma_home`, `dissertation_context`, `available_tags`, `project_root`, `project_chain`, `system_home`, `paper_store` (optional — `LocalPaperStore` at `~/.klemma/library.db`, Phase 1B), `user_library` (optional — `LocalUserLibrary` at same `library.db`, Phase 1C), `project_store` (optional — `LocalProjectStore` at `project/.klemma/data/project.db`, Phase 1C).
 
 ### config.py (~800 lines)
 Pydantic config models + Git-style project discovery + klemmarc loading.
@@ -114,8 +114,8 @@ Data classes for the three-tier storage layer (ADR-014). Distinct from `literatu
 - `FragmentRecord` — stored fragment with content-addressable ID (fragment_id = content_hash)
 - `UserSource` — user's source entry mapping citekey → global paper_id
 
-### stores/ (ADR-014 Phase 1B)
-SQLite backends implementing the `PaperStore` protocol. Currently contains `LocalPaperStore`.
+### stores/ (ADR-014 Phase 1B–1C)
+SQLite backends implementing the three-tier library protocols.
 
 #### stores/paper_store.py (~350 lines)
 `LocalPaperStore` — SQLite-backed `PaperStore` at `~/.klemma/library.db`. Content-addressable: same PDF → same paper_id → same fragments (global dedup).
@@ -128,6 +128,26 @@ SQLite backends implementing the `PaperStore` protocol. Currently contains `Loca
 - `get/save_fragment_embedding(fragment_id, vector, model)` — same pattern
 - Tables: `papers`, `extractions`, `fragments`, `paper_embeddings`, `fragment_embeddings`, `citation_graph`
 - Used by: `_init_components()` in `cli.py` (always created); `_process_single()` in `cli.py` (dedup check + dual-write)
+
+#### stores/user_library.py (~210 lines)
+`LocalUserLibrary` — SQLite-backed `UserLibrary` at `~/.klemma/library.db` (same file as `LocalPaperStore`, schema version 2). Maps citekey → paper_id for the User Library tier.
+- `add_source(paper_id, citekey, *, status, pdf_path, ...) -> None` — upsert on citekey conflict; replaces chapters/sections
+- `get_source_by_citekey(citekey) -> UserSource | None`
+- `resolve_paper_id(citekey) -> str | None`
+- `get_existing_citekeys() -> set[str]`
+- `update_status(citekey, status)`, `get_all_sources()`, `count()`
+- Tables: `user_sources`, `user_source_chapters`, `user_source_sections`
+- Called from `_process_single()` in `cli.py` to register citekey after successful extraction
+
+#### stores/project_store.py (~200 lines)
+`LocalProjectStore` — SQLite-backed `ProjectStore` at `project/.klemma/data/project.db`. Per-project section assignments and coverage stats.
+- `set_source_sections(citekey, paper_id, sections, chapters) -> None` — upsert + replace section assignments
+- `get_coverage_stats() -> dict` — `{total_sources, by_section: {section: count}}`
+- `get_reference_gaps(**kwargs) -> list[dict]` — returns `[]` (Phase 1D stub)
+- `get_source_sections(citekey) -> list[str]`, `get_sources_by_section(section) -> list[str]`
+- `register_fragment(fragment_id, *, citekey, section, ...) -> None` — INSERT OR IGNORE
+- `count_sources() -> int`
+- Tables: `project_sources`, `project_source_sections`, `project_fragments`
 
 ### errors.py (32 lines)
 Klemma error taxonomy for AI backends.

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -436,6 +436,12 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
             backfilled += 1
         result["metadata_backfilled"] = backfilled
 
+    # Auto-resolve reference gaps against current library
+    if ctx.library:
+        resolved = state.resolve_gaps(ctx.library.entries)
+        if resolved:
+            result["gaps_resolved"] = resolved
+
     # Sync section type mappings (backfill section_type columns)
     project = ctx.project
     if project and (project.chapters or project.section_type_map):
@@ -457,6 +463,8 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
             parts.append(
                 f"[yellow]{skipped_irrelevant} skipped (no chapter_mapping match)[/yellow]"
             )
+        if result.get("gaps_resolved"):
+            parts.append(f"[green]{result['gaps_resolved']} gap(s) resolved[/green]")
         if parts:
             console.print("[dim]Sync:[/dim] " + " | ".join(parts))
 

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -125,10 +125,13 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
     dissertation_context = load_project_context(project_chain, cfg)
     available_tags = load_available_tags(klemma_home, cfg, project_chain=project_chain)
 
-    # Three-tier library (ADR-014 Phase 1B): shared paper store at ~/.klemma/library.db
-    from .stores import LocalPaperStore
+    # Three-tier library (ADR-014 Phase 1B/1C): shared stores at ~/.klemma/library.db
+    from .stores import LocalPaperStore, LocalProjectStore, LocalUserLibrary
 
-    paper_store = LocalPaperStore(system_home / "library.db")
+    _lib_db = system_home / "library.db"
+    paper_store = LocalPaperStore(_lib_db)
+    user_library = LocalUserLibrary(_lib_db)
+    project_store = LocalProjectStore(klemma_home / "data" / "project.db")
 
     return KlemmaContext(
         config=cfg,
@@ -146,6 +149,8 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
         project_chain=project_chain,
         system_home=system_home,
         paper_store=paper_store,
+        user_library=user_library,
+        project_store=project_store,
     )
 
 
@@ -1109,6 +1114,7 @@ def _process_single(
     force=False,
     no_embed=False,
     paper_store=None,
+    user_library=None,
 ):
     """Process a single source: find PDF, extract fragments, save to vault.
 
@@ -1321,6 +1327,19 @@ def _process_single(
                 )
         except Exception as _e:
             logger.debug("Library dual-write failed for %s: %s", citekey, _e)
+
+    # Phase 1C: register citekey → paper_id in user library
+    if user_library and _paper_id:
+        try:
+            user_library.add_source(
+                _paper_id,
+                citekey,
+                status="completed",
+                pdf_path=str(pdf_path) if pdf_path else None,
+            )
+            logger.debug("User library: registered %s → %s", citekey, _paper_id)
+        except Exception as _e:
+            logger.debug("User library registration failed for %s: %s", citekey, _e)
 
     # Backfill abstract from S2 if missing (e.g. acquire hit rate limit)
     abstract = entry.abstract or ""

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1887,14 +1887,13 @@ def add(ctx, input_value, section, title, authors, year, no_process, no_embed, m
 
         pdf_path = _Path(input_value).resolve()
         console.print(f"[bold]Adding from PDF:[/bold] {pdf_path.name}")
-        # Use acquire with file:// URL — acquirer handles local paths
+        # Use acquire with file:// URL — acquirer handles local paths via scheme check
         meta = PaperMetadata(
             url=f"file://{pdf_path}",
             title=title or "",
             authors=authors or "",
             year=year,
             sections=sections,
-            pdf_override=str(pdf_path),
         )
         result = acquire_paper_local(
             meta,

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1008,6 +1008,163 @@ def migrate(ctx, dry_run):
     console.print(f"[dim]System config at {system_home}/[/dim]")
 
 
+# --- Three-tier library migration (ADR-014 Phase 1C) ---
+
+
+@main.command(name="migrate-library")
+@click.option(
+    "--run",
+    "do_run",
+    is_flag=True,
+    default=False,
+    help="Actually run the migration (default: dry-run only)",
+)
+@click.pass_context
+def migrate_library(ctx, do_run):
+    """Migrate monolithic klemma.db → library.db + project.db (ADR-014).
+
+    Reads sources, fragments, and embeddings from the monolithic klemma.db and
+    populates:
+      - ~/.klemma/library.db: papers, fragments, embeddings (shared across projects)
+      - .klemma/data/project.db: source–section assignments for this project
+
+    Default is dry-run (shows what would be migrated). Pass --run to execute.
+    Creates a backup at .klemma/data/klemma.db.bak before writing.
+    """
+    import shutil
+    import sqlite3
+
+    kctx = _get_context(ctx)
+    mono_db = kctx.klemma_home / "data" / "klemma.db"
+
+    if not mono_db.exists():
+        console.print(f"[yellow]No monolithic DB found at {mono_db}[/yellow]")
+        console.print("[dim]Nothing to migrate — already on the three-tier layout?[/dim]")
+        return
+
+    # ---- Read monolithic DB ------------------------------------------------
+    conn = sqlite3.connect(str(mono_db))
+    conn.row_factory = sqlite3.Row
+
+    sources = conn.execute(
+        "SELECT id, title, authors, year, abstract, doi, status, pdf_path, quality FROM sources"
+    ).fetchall()
+    fragments = conn.execute(
+        "SELECT source_id, fragment_text, fragment_type, page_number, citation_intent FROM fragments"
+    ).fetchall()
+    sections = conn.execute(
+        "SELECT source_id, section FROM source_sections"
+    ).fetchall() if _table_exists(conn, "source_sections") else []
+    conn.close()
+
+    n_sources = len(sources)
+    n_frags = len(fragments)
+    n_secs = len(sections)
+
+    console.print(f"\n[bold]Three-tier library migration[/bold] — {'DRY RUN' if not do_run else 'LIVE'}")
+    console.print(f"  Source DB   : {mono_db}")
+    console.print(f"  library.db  : {kctx.system_home / 'library.db'}")
+    console.print(f"  project.db  : {kctx.klemma_home / 'data' / 'project.db'}")
+    console.print(f"\n  [cyan]{n_sources}[/cyan] sources · [cyan]{n_frags}[/cyan] fragments · [cyan]{n_secs}[/cyan] section assignments")
+
+    if not do_run:
+        console.print("\n[dim]Dry run — pass --run to execute migration[/dim]")
+        return
+
+    # ---- Backup ------------------------------------------------------------
+    bak = mono_db.with_suffix(".db.bak")
+    shutil.copy2(mono_db, bak)
+    console.print(f"\n[green]Backup created:[/green] {bak}")
+
+    # ---- Migrate to library.db ---------------------------------------------
+    from ..hashing import compute_content_hash, compute_prompt_hash
+    from ..models import FragmentRecord
+    from ..stores import LocalPaperStore, LocalUserLibrary
+
+    paper_store = LocalPaperStore(kctx.system_home / "library.db")
+    user_lib = LocalUserLibrary(kctx.system_home / "library.db")
+
+    citekey_to_paper_id: dict[str, str] = {}
+    migrated_papers = 0
+    migrated_frags = 0
+
+    # Build citekey → fragment list index
+    frag_by_citekey: dict[str, list] = {}
+    for f in fragments:
+        frag_by_citekey.setdefault(f["source_id"], []).append(f)
+
+    for src in sources:
+        citekey = src["id"]
+        pdf_hash = f"migrated:{citekey}"  # synthetic hash for migrated sources
+        paper_id = paper_store.register_paper(
+            title=src["title"] or citekey,
+            authors=src["authors"] or "",
+            year=src["year"],
+            doi=src["doi"] or None,
+            abstract=src["abstract"] or "",
+            pdf_hash=pdf_hash,
+        )
+        citekey_to_paper_id[citekey] = paper_id
+        migrated_papers += 1
+
+        # Register in user library
+        user_lib.add_source(
+            paper_id,
+            citekey,
+            status=src["status"] or "pending",
+            pdf_path=src["pdf_path"],
+            quality_score=src["quality"],
+        )
+
+        # Migrate fragments
+        ck_frags = frag_by_citekey.get(citekey, [])
+        if ck_frags:
+            records = [
+                FragmentRecord(
+                    fragment_id=compute_content_hash(paper_id, f["fragment_text"], f["page_number"]),
+                    paper_id=paper_id,
+                    fragment_text=f["fragment_text"],
+                    fragment_type=f["fragment_type"] or "key_idea",
+                    page_number=f["page_number"],
+                    citation_intent=f["citation_intent"],
+                    content_hash=compute_content_hash(paper_id, f["fragment_text"], f["page_number"]),
+                )
+                for f in ck_frags
+            ]
+            p_hash = compute_prompt_hash("migrated")
+            migrated_frags += paper_store.save_fragments(paper_id, records, p_hash, "migrated")
+
+    # ---- Migrate to project.db -------------------------------------------
+    from ..stores import LocalProjectStore
+
+    project_store = LocalProjectStore(kctx.klemma_home / "data" / "project.db")
+
+    # Build section assignments
+    secs_by_citekey: dict[str, list[str]] = {}
+    for s in sections:
+        secs_by_citekey.setdefault(s["source_id"], []).append(s["section"])
+
+    for citekey, paper_id in citekey_to_paper_id.items():
+        sec_list = secs_by_citekey.get(citekey, [])
+        if sec_list:
+            project_store.set_source_sections(citekey, paper_id, sec_list, [])
+
+    console.print("\n[green]Migration complete:[/green]")
+    console.print(f"  Papers registered : {migrated_papers}")
+    console.print(f"  Fragments migrated: {migrated_frags}")
+    console.print(f"  Section entries   : {sum(len(v) for v in secs_by_citekey.values())}")
+    console.print(f"\n[dim]Monolithic DB preserved at {mono_db}[/dim]")
+    console.print("[dim]Run 'klemma status' to verify coverage is unchanged.[/dim]")
+
+
+def _table_exists(conn, name: str) -> bool:
+    """Return True if a table exists in the SQLite connection."""
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
 # --- Migrate content fields to KLEMMA.md frontmatter ---
 
 

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1055,7 +1055,7 @@ def migrate_library(ctx, do_run):
     conn.row_factory = sqlite3.Row
 
     sources = conn.execute(
-        "SELECT id, title, authors, year, abstract, doi, status, pdf_path, quality FROM sources"
+        "SELECT id, title, authors, year, abstract, doi, status, pdf_path, quality_score FROM sources"
     ).fetchall()
     fragments = conn.execute(
         "SELECT source_id, fragment_text, fragment_type, page_number, citation_intent FROM fragments"
@@ -1121,7 +1121,7 @@ def migrate_library(ctx, do_run):
             citekey,
             status=src["status"] or "pending",
             pdf_path=src["pdf_path"],
-            quality_score=src["quality"],
+            quality_score=src["quality_score"],
         )
 
         # Migrate fragments

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1011,9 +1011,17 @@ def migrate(ctx, dry_run):
 # --- Three-tier library migration (ADR-014 Phase 1C) ---
 
 
+def _table_exists(conn, name: str) -> bool:
+    """Return True if a table exists in the SQLite connection."""
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
 @main.command(name="migrate-library")
 @click.option(
-    "--run",
+    "--apply",
     "do_run",
     is_flag=True,
     default=False,
@@ -1028,7 +1036,7 @@ def migrate_library(ctx, do_run):
       - ~/.klemma/library.db: papers, fragments, embeddings (shared across projects)
       - .klemma/data/project.db: source–section assignments for this project
 
-    Default is dry-run (shows what would be migrated). Pass --run to execute.
+    Default is dry-run (shows what would be migrated). Pass --apply to execute.
     Creates a backup at .klemma/data/klemma.db.bak before writing.
     """
     import shutil
@@ -1068,7 +1076,7 @@ def migrate_library(ctx, do_run):
     console.print(f"\n  [cyan]{n_sources}[/cyan] sources · [cyan]{n_frags}[/cyan] fragments · [cyan]{n_secs}[/cyan] section assignments")
 
     if not do_run:
-        console.print("\n[dim]Dry run — pass --run to execute migration[/dim]")
+        console.print("\n[dim]Dry run — pass --apply to execute migration[/dim]")
         return
 
     # ---- Backup ------------------------------------------------------------
@@ -1155,14 +1163,12 @@ def migrate_library(ctx, do_run):
     console.print(f"  Section entries   : {sum(len(v) for v in secs_by_citekey.values())}")
     console.print(f"\n[dim]Monolithic DB preserved at {mono_db}[/dim]")
     console.print("[dim]Run 'klemma status' to verify coverage is unchanged.[/dim]")
-
-
-def _table_exists(conn, name: str) -> bool:
-    """Return True if a table exists in the SQLite connection."""
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
-    ).fetchone()
-    return row is not None
+    console.print(
+        "\n[yellow]Note:[/yellow] Migrated papers use citekey-based deduplication "
+        "(not PDF SHA256). Same paper under different citekeys in two projects will "
+        "create separate entries. Re-process with [bold]klemma process --force[/bold] "
+        "to upgrade to content-addressable dedup."
+    )
 
 
 # --- Migrate content fields to KLEMMA.md frontmatter ---

--- a/src/klemma/commands/process.py
+++ b/src/klemma/commands/process.py
@@ -102,6 +102,7 @@ def process(ctx, citekeys, serial, force, model, no_embed):
                         force=force,
                         no_embed=no_embed,
                         paper_store=kctx.paper_store,
+                        user_library=kctx.user_library,
                     ): ck
                     for ck in keys
                 }
@@ -156,6 +157,7 @@ def process(ctx, citekeys, serial, force, model, no_embed):
                 force=force,
                 no_embed=no_embed,
                 paper_store=kctx.paper_store,
+                user_library=kctx.user_library,
             )
             if n_frags > 0:
                 processed += 1

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -309,7 +309,7 @@ class AIConfig(BaseModel):
     backend: str = "litellm"  # "claude" | "litellm" | "openai" (deprecated)
     model: str = "opus"
     max_pdf_chars: int = 50000
-    timeout: int = 180
+    timeout: int = 300
     retries: int = 2
     base_url: Optional[str] = None  # URL for OpenAI-compatible endpoints
     api_key_env: str = ""  # env var name for API key (e.g. "OPENAI_API_KEY")

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -101,8 +101,8 @@ def _warn_config_issues(raw: dict, source: str) -> None:
     # --- 2. Unknown keys at every level ---
     for key in raw:
         if key not in root_keys and key not in child_fields:
-            if key in ("api_keys", "mcp"):
-                continue  # api_keys valid in klemmarc; mcp reserved
+            if key in ("api_keys", "mcp", "telegram"):
+                continue  # api_keys valid in klemmarc; mcp/telegram reserved for tooling
             warnings.warn(
                 f"[{source}] unknown top-level key '{key}' (ignored)",
                 UserWarning,

--- a/src/klemma/context.py
+++ b/src/klemma/context.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .config import KlemmaConfig, ProjectConfig
     from .embeddings import EmbeddingProvider
     from .library_provider import LibraryProvider
-    from .protocols import PaperStore
+    from .protocols import PaperStore, ProjectStore, UserLibrary
     from .search import SearchProvider
     from .state import StateManager
     from .vault import VaultAdapter
@@ -44,3 +44,6 @@ class KlemmaContext:
     system_home: Path = field(default_factory=lambda: Path.home() / ".klemma")
     # Three-tier library (ADR-014 Phase 1B): shared paper/fragment/embedding store
     paper_store: Optional[PaperStore] = None
+    # Three-tier library (ADR-014 Phase 1C): citekey→paper_id mapping + project assignments
+    user_library: Optional[UserLibrary] = None
+    project_store: Optional[ProjectStore] = None

--- a/src/klemma/stores/__init__.py
+++ b/src/klemma/stores/__init__.py
@@ -1,9 +1,12 @@
 """Three-tier library stores (ADR-014).
 
 Phase 1B: LocalPaperStore — SQLite implementation of PaperStore at ~/.klemma/library.db.
-Phase 1C: LocalProjectStore — per-project data split (planned, issue #126).
+Phase 1C: LocalUserLibrary — citekey→paper_id mapping in library.db.
+Phase 1C: LocalProjectStore — per-project data at project/.klemma/data/project.db.
 """
 
 from .paper_store import LocalPaperStore
+from .project_store import LocalProjectStore
+from .user_library import LocalUserLibrary
 
-__all__ = ["LocalPaperStore"]
+__all__ = ["LocalPaperStore", "LocalProjectStore", "LocalUserLibrary"]

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -236,12 +236,21 @@ class LocalPaperStore:
 
         extraction_id = str(uuid.uuid4())
         with self._conn() as conn:
-            conn.execute(
+            cur = conn.execute(
                 """INSERT OR IGNORE INTO extractions
                    (extraction_id, paper_id, prompt_hash, ai_model, klemma_version, fragment_count)
                    VALUES (?, ?, ?, ?, ?, ?)""",
                 (extraction_id, paper_id, prompt_hash, ai_model, _kv, len(fragments)),
             )
+            if cur.rowcount == 0:
+                # Row already exists (UNIQUE conflict on paper_id+prompt_hash+ai_model)
+                # Use the existing extraction_id so fragment FK constraint is satisfied
+                row = conn.execute(
+                    "SELECT extraction_id FROM extractions WHERE paper_id=? AND prompt_hash=? AND ai_model=?",
+                    (paper_id, prompt_hash, ai_model),
+                ).fetchone()
+                if row:
+                    extraction_id = row["extraction_id"]
             inserted = 0
             for f in fragments:
                 cur = conn.execute(

--- a/src/klemma/stores/project_store.py
+++ b/src/klemma/stores/project_store.py
@@ -1,0 +1,200 @@
+"""LocalProjectStore — SQLite implementation of the ProjectStore protocol (ADR-014).
+
+Per-project data: section assignments, coverage stats, reference gaps.
+Stored at project/.klemma/data/project.db, separate from library.db.
+
+Phase 1C: minimal Protocol implementation. Full migration from monolithic
+StateManager (8 repos) to LocalProjectStore happens in Phase 1D.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+_SCHEMA_VERSION = 1
+
+_CREATE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_sources (
+    citekey          TEXT PRIMARY KEY,
+    paper_id         TEXT NOT NULL,
+    primary_chapter  INTEGER,
+    primary_section  TEXT,
+    relevance_nr1    INTEGER DEFAULT 0,
+    relevance_nr2    INTEGER DEFAULT 0,
+    citation_priority TEXT DEFAULT 'medium',
+    added_at         TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ps_paper ON project_sources(paper_id);
+
+CREATE TABLE IF NOT EXISTS project_source_sections (
+    citekey      TEXT NOT NULL REFERENCES project_sources(citekey) ON DELETE CASCADE,
+    section      TEXT NOT NULL,
+    section_type TEXT,
+    chapter      INTEGER,
+    PRIMARY KEY (citekey, section)
+);
+CREATE INDEX IF NOT EXISTS idx_pss_section ON project_source_sections(section);
+
+CREATE TABLE IF NOT EXISTS project_fragments (
+    fragment_id    TEXT NOT NULL PRIMARY KEY,
+    citekey        TEXT,
+    section        TEXT,
+    section_type   TEXT,
+    chapter        INTEGER,
+    relevance_score INTEGER DEFAULT 3,
+    usage_hint     TEXT,
+    used_in_draft  INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_pf_section ON project_fragments(section);
+CREATE INDEX IF NOT EXISTS idx_pf_citekey ON project_fragments(citekey);
+"""
+
+
+class LocalProjectStore:
+    """SQLite-backed ProjectStore at project/.klemma/data/project.db.
+
+    Owns project-specific data: which sources are assigned to which sections,
+    per-project fragment relevance, and coverage statistics.
+
+    Content (paper text, embeddings) is NOT stored here — those live in
+    library.db via LocalPaperStore.
+
+    Usage::
+
+        store = LocalProjectStore(Path(".klemma/data/project.db"))
+        store.set_source_sections("smith2022", "uuid-paper-id", ["1.1", "2.3"], [1])
+        stats = store.get_coverage_stats()
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            self._migrate_schema(conn)
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _migrate_schema(self, conn: sqlite3.Connection) -> None:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version < _SCHEMA_VERSION:
+            conn.executescript(_CREATE_SCHEMA)
+            conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+    # ------------------------------------------------------------------ #
+    # ProjectStore Protocol implementation                                #
+    # ------------------------------------------------------------------ #
+
+    def set_source_sections(
+        self,
+        citekey: str,
+        paper_id: str,
+        sections: list[str],
+        chapters: list[int],
+    ) -> None:
+        """Upsert project_sources row and replace section assignments."""
+        primary_section = sections[0] if sections else None
+        primary_chapter = chapters[0] if chapters else None
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT INTO project_sources
+                   (citekey, paper_id, primary_chapter, primary_section)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT(citekey) DO UPDATE SET
+                       paper_id=excluded.paper_id,
+                       primary_chapter=excluded.primary_chapter,
+                       primary_section=excluded.primary_section""",
+                (citekey, paper_id, primary_chapter, primary_section),
+            )
+            conn.execute(
+                "DELETE FROM project_source_sections WHERE citekey = ?", (citekey,)
+            )
+            conn.executemany(
+                """INSERT OR IGNORE INTO project_source_sections
+                   (citekey, section, chapter) VALUES (?, ?, ?)""",
+                [
+                    (citekey, s, chapters[i] if i < len(chapters) else primary_chapter)
+                    for i, s in enumerate(sections)
+                ],
+            )
+
+    def get_coverage_stats(self) -> dict:
+        """Return basic coverage statistics for the project."""
+        with self._conn() as conn:
+            total = conn.execute(
+                "SELECT COUNT(*) FROM project_sources"
+            ).fetchone()[0]
+            by_section = conn.execute(
+                """SELECT section, COUNT(DISTINCT citekey) as cnt
+                   FROM project_source_sections
+                   GROUP BY section ORDER BY section"""
+            ).fetchall()
+        return {
+            "total_sources": total,
+            "by_section": {row["section"]: row["cnt"] for row in by_section},
+        }
+
+    def get_reference_gaps(self, **_: object) -> list[dict]:
+        """Return reference gaps (Phase 1D: will query monolithic DB via bridge)."""
+        # Phase 1C: project.db doesn't own gaps yet — empty until Phase 1D migration
+        return []
+
+    # ------------------------------------------------------------------ #
+    # Additional helpers                                                  #
+    # ------------------------------------------------------------------ #
+
+    def get_source_sections(self, citekey: str) -> list[str]:
+        """Return section list for citekey."""
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT section FROM project_source_sections WHERE citekey=? ORDER BY section",
+                (citekey,),
+            ).fetchall()
+        return [row["section"] for row in rows]
+
+    def register_fragment(
+        self,
+        fragment_id: str,
+        *,
+        citekey: str = "",
+        section: str = "",
+        section_type: str = "",
+        chapter: int = 0,
+        relevance_score: int = 3,
+    ) -> None:
+        """Register a fragment assignment to this project."""
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT OR IGNORE INTO project_fragments
+                   (fragment_id, citekey, section, section_type, chapter, relevance_score)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (fragment_id, citekey, section, section_type, chapter, relevance_score),
+            )
+
+    def get_sources_by_section(self, section: str) -> list[str]:
+        """Return citekeys assigned to a section."""
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT citekey FROM project_source_sections WHERE section=? ORDER BY citekey",
+                (section,),
+            ).fetchall()
+        return [row["citekey"] for row in rows]
+
+    def count_sources(self) -> int:
+        with self._conn() as conn:
+            return conn.execute("SELECT COUNT(*) FROM project_sources").fetchone()[0]

--- a/src/klemma/stores/user_library.py
+++ b/src/klemma/stores/user_library.py
@@ -1,0 +1,210 @@
+"""LocalUserLibrary — SQLite implementation of the UserLibrary protocol (ADR-014).
+
+Adds user_sources tables to ~/.klemma/library.db (same file as LocalPaperStore).
+Maps citekey → paper_id for the User Library tier.
+
+Phase 1C: single-user mode (no user_id column). SaaS sprint will add user_id.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator, Optional
+
+if TYPE_CHECKING:
+    from ..models import UserSource
+
+_SCHEMA_VERSION = 2  # library.db version after adding user_sources
+
+_CREATE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS user_sources (
+    citekey     TEXT PRIMARY KEY,
+    paper_id    TEXT NOT NULL,
+    status      TEXT DEFAULT 'pending',
+    pdf_path    TEXT,
+    note_path   TEXT,
+    quality_score INTEGER,
+    added_at    TEXT DEFAULT (datetime('now')),
+    updated_at  TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_user_sources_paper ON user_sources(paper_id);
+
+CREATE TABLE IF NOT EXISTS user_source_chapters (
+    citekey TEXT NOT NULL REFERENCES user_sources(citekey) ON DELETE CASCADE,
+    chapter INTEGER NOT NULL,
+    PRIMARY KEY (citekey, chapter)
+);
+
+CREATE TABLE IF NOT EXISTS user_source_sections (
+    citekey TEXT NOT NULL REFERENCES user_sources(citekey) ON DELETE CASCADE,
+    section TEXT NOT NULL,
+    PRIMARY KEY (citekey, section)
+);
+"""
+
+
+class LocalUserLibrary:
+    """SQLite-backed UserLibrary at ~/.klemma/library.db.
+
+    Shares the same database file as LocalPaperStore. Adds user_sources,
+    user_source_chapters, user_source_sections tables (schema version 2).
+
+    Usage::
+
+        lib = LocalUserLibrary(Path.home() / ".klemma" / "library.db")
+        lib.add_source("abc123uuid", "smith2022nlp", status="completed")
+        paper_id = lib.resolve_paper_id("smith2022nlp")
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            self._migrate_schema(conn)
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _migrate_schema(self, conn: sqlite3.Connection) -> None:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version < _SCHEMA_VERSION:
+            conn.executescript(_CREATE_SCHEMA)
+            conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+    # ------------------------------------------------------------------ #
+    # UserLibrary Protocol implementation                                 #
+    # ------------------------------------------------------------------ #
+
+    def add_source(
+        self,
+        paper_id: str,
+        citekey: str,
+        *,
+        status: str = "pending",
+        pdf_path: Optional[str] = None,
+        note_path: Optional[str] = None,
+        quality_score: Optional[int] = None,
+        chapters: Optional[list[int]] = None,
+        sections: Optional[list[str]] = None,
+        **_: object,
+    ) -> None:
+        """Register citekey → paper_id mapping. Upserts on citekey conflict."""
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT INTO user_sources
+                   (citekey, paper_id, status, pdf_path, note_path, quality_score)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(citekey) DO UPDATE SET
+                       paper_id=excluded.paper_id,
+                       status=excluded.status,
+                       pdf_path=excluded.pdf_path,
+                       note_path=excluded.note_path,
+                       quality_score=excluded.quality_score,
+                       updated_at=datetime('now')""",
+                (citekey, paper_id, status, pdf_path, note_path, quality_score),
+            )
+            if chapters:
+                conn.execute(
+                    "DELETE FROM user_source_chapters WHERE citekey = ?", (citekey,)
+                )
+                conn.executemany(
+                    "INSERT OR IGNORE INTO user_source_chapters (citekey, chapter) VALUES (?,?)",
+                    [(citekey, ch) for ch in chapters],
+                )
+            if sections:
+                conn.execute(
+                    "DELETE FROM user_source_sections WHERE citekey = ?", (citekey,)
+                )
+                conn.executemany(
+                    "INSERT OR IGNORE INTO user_source_sections (citekey, section) VALUES (?,?)",
+                    [(citekey, s) for s in sections],
+                )
+
+    def get_source_by_citekey(self, citekey: str) -> Optional["UserSource"]:
+        """Return UserSource for citekey, or None if not registered."""
+        from ..models import UserSource
+
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM user_sources WHERE citekey = ?", (citekey,)
+            ).fetchone()
+            if not row:
+                return None
+            chapters = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT chapter FROM user_source_chapters WHERE citekey = ? ORDER BY chapter",
+                    (citekey,),
+                ).fetchall()
+            ]
+            sections = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT section FROM user_source_sections WHERE citekey = ? ORDER BY section",
+                    (citekey,),
+                ).fetchall()
+            ]
+        return UserSource(
+            citekey=row["citekey"],
+            paper_id=row["paper_id"],
+            status=row["status"] or "pending",
+            pdf_path=row["pdf_path"],
+            note_path=row["note_path"],
+            quality_score=row["quality_score"],
+            chapters=chapters,
+            sections=sections,
+        )
+
+    def resolve_paper_id(self, citekey: str) -> Optional[str]:
+        """Return paper_id for citekey, or None if not registered."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT paper_id FROM user_sources WHERE citekey = ?", (citekey,)
+            ).fetchone()
+        return row["paper_id"] if row else None
+
+    def get_existing_citekeys(self) -> set[str]:
+        """Return all registered citekeys."""
+        with self._conn() as conn:
+            rows = conn.execute("SELECT citekey FROM user_sources").fetchall()
+        return {row["citekey"] for row in rows}
+
+    # ------------------------------------------------------------------ #
+    # Additional helpers (beyond Protocol minimum)                        #
+    # ------------------------------------------------------------------ #
+
+    def update_status(self, citekey: str, status: str) -> None:
+        """Update processing status for citekey."""
+        with self._conn() as conn:
+            conn.execute(
+                "UPDATE user_sources SET status=?, updated_at=datetime('now') WHERE citekey=?",
+                (status, citekey),
+            )
+
+    def get_all_sources(self) -> list["UserSource"]:
+        """Return all UserSource entries."""
+
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT citekey FROM user_sources ORDER BY added_at"
+            ).fetchall()
+        return [self.get_source_by_citekey(row["citekey"]) for row in rows]  # type: ignore[return-value]
+
+    def count(self) -> int:
+        """Return total number of registered sources."""
+        with self._conn() as conn:
+            return conn.execute("SELECT COUNT(*) FROM user_sources").fetchone()[0]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,7 +1,9 @@
 # Tests
 
-## Current test suite (854 tests)
+## Current test suite (1140 tests)
 - `test_paper_store.py` (~200 lines) — 22 tests: `LocalPaperStore` schema (version=1, all 6 tables, migration idempotency, new-dir creation), register/find CRUD (UUID return, idempotency by pdf_hash, find by DOI, metadata roundtrip), fragments (save/get, INSERT OR IGNORE dedup, types), paper-level embeddings (roundtrip, upsert, missing=None), fragment-level embeddings (roundtrip, empty), dual-write cache scenario (second project hits library cache)
+- `test_user_library.py` (~185 lines) — 23 tests: `LocalUserLibrary` schema (version=2, 3 tables, PaperStore coexistence on same db_path, idempotency), add_source (basic, metadata, upsert), get_source missing=None, resolve_paper_id, get_existing_citekeys (empty, multiple), update_status, count, chapters/sections replaced on upsert
+- `test_project_store.py` (~160 lines) — 20 tests: `LocalProjectStore` schema (version=1, 3 tables, idempotency, parent-dir creation), set_source_sections (basic, upserts paper_id, replaces sections, empty), get_source_sections (data, missing), get_sources_by_section (multi-source, empty), get_coverage_stats (empty, with data), get_reference_gaps (stub returns []), register_fragment (basic, INSERT OR IGNORE dedup), count_sources (empty, multiple)
 - `test_errors.py` (33 lines) — `KlemmaAIError` hierarchy, `retryable` classification, cause chaining
 - `test_hashing.py` (~80 lines) — 15 tests: `compute_pdf_hash` (determinism, different content, hex format, missing file), `compute_content_hash` (determinism, uniqueness by paper/text/page, None page, empty text), `compute_prompt_hash` (determinism, uniqueness, 16-char truncation, empty)
 - `test_protocols.py` (~80 lines) — 10 tests: `PaperRecord`/`FragmentRecord`/`UserSource` dataclass defaults + all-fields, runtime-checkable Protocol verification, non-implementing class rejection

--- a/tests/test_migrate_library.py
+++ b/tests/test_migrate_library.py
@@ -1,0 +1,167 @@
+"""Smoke tests for `klemma migrate-library` command (ADR-014 Phase 1C)."""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+from klemma.stores import LocalPaperStore, LocalProjectStore, LocalUserLibrary
+
+
+def _make_mono_db(path: Path) -> None:
+    """Create a minimal monolithic klemma.db with one source + one fragment."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE sources (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            authors TEXT,
+            year INTEGER,
+            abstract TEXT,
+            doi TEXT,
+            status TEXT DEFAULT 'completed',
+            pdf_path TEXT,
+            quality INTEGER
+        );
+        CREATE TABLE fragments (
+            source_id TEXT,
+            fragment_text TEXT,
+            fragment_type TEXT,
+            page_number INTEGER,
+            citation_intent TEXT
+        );
+        CREATE TABLE source_sections (
+            source_id TEXT,
+            section TEXT
+        );
+        INSERT INTO sources VALUES (
+            'smith2022', 'A Great Paper', 'Smith, J.', 2022,
+            'Abstract here.', '10.1234/test', 'completed', NULL, 4
+        );
+        INSERT INTO fragments VALUES (
+            'smith2022', 'Key finding text.', 'key_idea', 3, 'background'
+        );
+        INSERT INTO source_sections VALUES ('smith2022', '1.1');
+    """)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def mock_kctx(tmp_path):
+    system_home = tmp_path / "system_home"
+    system_home.mkdir()
+    klemma_home = tmp_path / "project" / ".klemma"
+    (klemma_home / "data").mkdir(parents=True)
+    mono_db = klemma_home / "data" / "klemma.db"
+    _make_mono_db(mono_db)
+
+    ctx = MagicMock()
+    ctx.system_home = system_home
+    ctx.klemma_home = klemma_home
+    return ctx
+
+
+def test_dry_run_shows_stats(mock_kctx):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            result = runner.invoke(klemma_cli, ["migrate-library"])
+    assert result.exit_code == 0
+    assert "1" in result.output  # 1 source
+    assert "Dry run" in result.output
+    assert "--apply" in result.output
+
+
+def test_dry_run_does_not_modify_library(mock_kctx):
+    runner = CliRunner()
+    lib_db = mock_kctx.system_home / "library.db"
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            runner.invoke(klemma_cli, ["migrate-library"])
+    # library.db should not exist after dry-run
+    assert not lib_db.exists()
+
+
+def test_apply_migrates_source_to_library(mock_kctx):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            result = runner.invoke(klemma_cli, ["migrate-library", "--apply"])
+    assert result.exit_code == 0, result.output
+    assert "Migration complete" in result.output
+
+    lib_db = mock_kctx.system_home / "library.db"
+    assert lib_db.exists()
+
+    paper_store = LocalPaperStore(lib_db)
+    paper = paper_store.find_paper(pdf_hash="migrated:smith2022")
+    assert paper is not None
+    assert paper.title == "A Great Paper"
+
+
+def test_apply_registers_citekey_in_user_library(mock_kctx):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            runner.invoke(klemma_cli, ["migrate-library", "--apply"])
+
+    lib_db = mock_kctx.system_home / "library.db"
+    user_lib = LocalUserLibrary(lib_db)
+    src = user_lib.get_source_by_citekey("smith2022")
+    assert src is not None
+    assert src.status == "completed"
+    assert src.quality_score == 4
+
+
+def test_apply_migrates_section_to_project_store(mock_kctx):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            runner.invoke(klemma_cli, ["migrate-library", "--apply"])
+
+    project_db = mock_kctx.klemma_home / "data" / "project.db"
+    project_store = LocalProjectStore(project_db)
+    sections = project_store.get_source_sections("smith2022")
+    assert "1.1" in sections
+
+
+def test_apply_creates_backup(mock_kctx):
+    runner = CliRunner()
+    mono_db = mock_kctx.klemma_home / "data" / "klemma.db"
+    bak = mono_db.with_suffix(".db.bak")
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            runner.invoke(klemma_cli, ["migrate-library", "--apply"])
+    assert bak.exists()
+
+
+def test_apply_warns_about_synthetic_hash(mock_kctx):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            result = runner.invoke(klemma_cli, ["migrate-library", "--apply"])
+    assert "citekey-based deduplication" in result.output
+    assert "klemma process --force" in result.output
+
+
+def test_no_monolithic_db_exits_cleanly(mock_kctx):
+    """If klemma.db doesn't exist, command exits cleanly with a message."""
+    (mock_kctx.klemma_home / "data" / "klemma.db").unlink()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("klemma.commands.manage._get_context", lambda _: mock_kctx)
+            result = runner.invoke(klemma_cli, ["migrate-library"])
+    assert result.exit_code == 0
+    assert "No monolithic DB" in result.output

--- a/tests/test_migrate_library.py
+++ b/tests/test_migrate_library.py
@@ -24,7 +24,7 @@ def _make_mono_db(path: Path) -> None:
             doi TEXT,
             status TEXT DEFAULT 'completed',
             pdf_path TEXT,
-            quality INTEGER
+            quality_score INTEGER
         );
         CREATE TABLE fragments (
             source_id TEXT,
@@ -40,7 +40,7 @@ def _make_mono_db(path: Path) -> None:
         INSERT INTO sources VALUES (
             'smith2022', 'A Great Paper', 'Smith, J.', 2022,
             'Abstract here.', '10.1234/test', 'completed', NULL, 4
-        );
+        );  -- quality_score=4
         INSERT INTO fragments VALUES (
             'smith2022', 'Key finding text.', 'key_idea', 3, 'background'
         );

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -1,0 +1,194 @@
+"""Tests for LocalProjectStore (ADR-014 Phase 1C)."""
+
+import sqlite3
+
+import pytest
+
+from klemma.stores import LocalProjectStore
+
+
+@pytest.fixture
+def store(tmp_path) -> LocalProjectStore:
+    return LocalProjectStore(tmp_path / "project.db")
+
+
+# ---------------------------------------------------------------------------
+# Schema / migration
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_1(tmp_path):
+    db_path = tmp_path / "project.db"
+    LocalProjectStore(db_path)
+    conn = sqlite3.connect(str(db_path))
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    conn.close()
+    assert version == 1
+
+
+def test_tables_created(tmp_path):
+    db_path = tmp_path / "project.db"
+    LocalProjectStore(db_path)
+    conn = sqlite3.connect(str(db_path))
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    conn.close()
+    assert {"project_sources", "project_source_sections", "project_fragments"} <= tables
+
+
+def test_migration_idempotent(tmp_path):
+    db_path = tmp_path / "project.db"
+    store1 = LocalProjectStore(db_path)
+    store1.set_source_sections("smith2022", "pid1", ["1.1"], [1])
+    store2 = LocalProjectStore(db_path)  # second init — no data lost
+    assert store2.count_sources() == 1
+
+
+def test_creates_parent_dirs(tmp_path):
+    db_path = tmp_path / "nested" / "data" / "project.db"
+    LocalProjectStore(db_path)
+    assert db_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# set_source_sections / get_source_sections
+# ---------------------------------------------------------------------------
+
+
+def test_set_source_sections_basic(store):
+    store.set_source_sections("jones2023", "uuid-1", ["1.1", "2.3"], [1, 2])
+    sections = store.get_source_sections("jones2023")
+    assert "1.1" in sections
+    assert "2.3" in sections
+
+
+def test_set_source_sections_upserts(store):
+    store.set_source_sections("doe2021", "pid-a", ["1.1"], [1])
+    store.set_source_sections("doe2021", "pid-b", ["2.1", "3.2"], [2, 3])
+    sections = store.get_source_sections("doe2021")
+    assert set(sections) == {"2.1", "3.2"}
+
+
+def test_set_source_sections_replaces_old(store):
+    store.set_source_sections("wang2019", "pid", ["1.1", "1.2"], [1])
+    store.set_source_sections("wang2019", "pid", ["3.1"], [3])
+    sections = store.get_source_sections("wang2019")
+    assert sections == ["3.1"]
+
+
+def test_set_source_sections_empty_sections(store):
+    store.set_source_sections("minimal2020", "pid", [], [])
+    sections = store.get_source_sections("minimal2020")
+    assert sections == []
+
+
+def test_get_source_sections_missing(store):
+    assert store.get_source_sections("nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# get_sources_by_section
+# ---------------------------------------------------------------------------
+
+
+def test_get_sources_by_section(store):
+    store.set_source_sections("a2020", "p1", ["1.1", "2.3"], [1, 2])
+    store.set_source_sections("b2021", "p2", ["1.1"], [1])
+    store.set_source_sections("c2022", "p3", ["3.1"], [3])
+    result = store.get_sources_by_section("1.1")
+    assert set(result) == {"a2020", "b2021"}
+
+
+def test_get_sources_by_section_empty(store):
+    assert store.get_sources_by_section("9.9") == []
+
+
+# ---------------------------------------------------------------------------
+# get_coverage_stats
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_stats_empty(store):
+    stats = store.get_coverage_stats()
+    assert stats["total_sources"] == 0
+    assert stats["by_section"] == {}
+
+
+def test_coverage_stats_with_data(store):
+    store.set_source_sections("a2020", "p1", ["1.1", "2.3"], [1, 2])
+    store.set_source_sections("b2021", "p2", ["1.1"], [1])
+    stats = store.get_coverage_stats()
+    assert stats["total_sources"] == 2
+    assert stats["by_section"]["1.1"] == 2
+    assert stats["by_section"]["2.3"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_reference_gaps (Phase 1C stub)
+# ---------------------------------------------------------------------------
+
+
+def test_reference_gaps_returns_empty_list(store):
+    result = store.get_reference_gaps()
+    assert result == []
+
+
+def test_reference_gaps_ignores_kwargs(store):
+    result = store.get_reference_gaps(section="1.1", chapter=1)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# register_fragment
+# ---------------------------------------------------------------------------
+
+
+def test_register_fragment_basic(store):
+    store.set_source_sections("src2023", "pid", ["1.1"], [1])
+    store.register_fragment(
+        "frag-id-001",
+        citekey="src2023",
+        section="1.1",
+        section_type="introduction",
+        chapter=1,
+        relevance_score=4,
+    )
+    # Verify via raw DB
+    conn = sqlite3.connect(str(store._db_path))
+    row = conn.execute(
+        "SELECT * FROM project_fragments WHERE fragment_id='frag-id-001'"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+
+
+def test_register_fragment_insert_or_ignore(store):
+    # Inserting same fragment_id twice should not raise
+    store.register_fragment("frag-dup", citekey="src", section="1.1")
+    store.register_fragment("frag-dup", citekey="src", section="1.1")
+    conn = sqlite3.connect(str(store._db_path))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM project_fragments WHERE fragment_id='frag-dup'"
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# count_sources
+# ---------------------------------------------------------------------------
+
+
+def test_count_sources_empty(store):
+    assert store.count_sources() == 0
+
+
+def test_count_sources_multiple(store):
+    store.set_source_sections("a", "p1", ["1.1"], [1])
+    store.set_source_sections("b", "p2", ["2.1"], [2])
+    store.set_source_sections("c", "p3", ["3.1"], [3])
+    assert store.count_sources() == 3

--- a/tests/test_user_library.py
+++ b/tests/test_user_library.py
@@ -1,0 +1,184 @@
+"""Tests for LocalUserLibrary (ADR-014 Phase 1C)."""
+
+import sqlite3
+
+import pytest
+
+from klemma.stores import LocalUserLibrary
+
+
+@pytest.fixture
+def lib(tmp_path) -> LocalUserLibrary:
+    return LocalUserLibrary(tmp_path / "library.db")
+
+
+# ---------------------------------------------------------------------------
+# Schema / migration
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_2(tmp_path):
+    db_path = tmp_path / "library.db"
+    LocalUserLibrary(db_path)
+    conn = sqlite3.connect(str(db_path))
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    conn.close()
+    assert version == 2
+
+
+def test_tables_created(tmp_path):
+    db_path = tmp_path / "library.db"
+    LocalUserLibrary(db_path)
+    conn = sqlite3.connect(str(db_path))
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    conn.close()
+    assert {"user_sources", "user_source_chapters", "user_source_sections"} <= tables
+
+
+def test_paper_store_schema_coexists(tmp_path):
+    """LocalPaperStore (v1) + LocalUserLibrary (v2) on same db_path."""
+    from klemma.stores import LocalPaperStore
+
+    db_path = tmp_path / "library.db"
+    LocalPaperStore(db_path)  # creates v1 tables
+    LocalUserLibrary(db_path)  # upgrades to v2, adds user_sources
+
+    conn = sqlite3.connect(str(db_path))
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    conn.close()
+    assert version == 2
+    # Both sets of tables present
+    assert "papers" in tables
+    assert "user_sources" in tables
+
+
+def test_migration_idempotent(tmp_path):
+    db_path = tmp_path / "library.db"
+    lib1 = LocalUserLibrary(db_path)
+    lib1.add_source("pid1", "smith2022")
+    lib2 = LocalUserLibrary(db_path)  # second init — no data lost
+    assert lib2.resolve_paper_id("smith2022") == "pid1"
+
+
+# ---------------------------------------------------------------------------
+# add_source / get_source_by_citekey
+# ---------------------------------------------------------------------------
+
+
+def test_add_source_basic(lib):
+    lib.add_source("paper-uuid-1", "jones2023ml")
+    src = lib.get_source_by_citekey("jones2023ml")
+    assert src is not None
+    assert src.citekey == "jones2023ml"
+    assert src.paper_id == "paper-uuid-1"
+    assert src.status == "pending"
+
+
+def test_add_source_with_metadata(lib):
+    lib.add_source(
+        "pid2",
+        "doe2021",
+        status="completed",
+        pdf_path="/tmp/doe2021.pdf",
+        quality_score=4,
+        chapters=[1, 2],
+        sections=["1.1", "2.3"],
+    )
+    src = lib.get_source_by_citekey("doe2021")
+    assert src.status == "completed"
+    assert src.pdf_path == "/tmp/doe2021.pdf"
+    assert src.quality_score == 4
+    assert 1 in src.chapters
+    assert "1.1" in src.sections
+    assert "2.3" in src.sections
+
+
+def test_add_source_upserts(lib):
+    lib.add_source("pid-orig", "smith2020", status="pending")
+    lib.add_source("pid-new", "smith2020", status="completed")
+    src = lib.get_source_by_citekey("smith2020")
+    assert src.paper_id == "pid-new"
+    assert src.status == "completed"
+
+
+def test_get_source_missing_returns_none(lib):
+    assert lib.get_source_by_citekey("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_paper_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_paper_id(lib):
+    lib.add_source("uuid-abc", "wang2019")
+    assert lib.resolve_paper_id("wang2019") == "uuid-abc"
+
+
+def test_resolve_paper_id_missing(lib):
+    assert lib.resolve_paper_id("ghost") is None
+
+
+# ---------------------------------------------------------------------------
+# get_existing_citekeys
+# ---------------------------------------------------------------------------
+
+
+def test_get_existing_citekeys_empty(lib):
+    assert lib.get_existing_citekeys() == set()
+
+
+def test_get_existing_citekeys_multiple(lib):
+    lib.add_source("p1", "a2020")
+    lib.add_source("p2", "b2021")
+    lib.add_source("p3", "c2022")
+    assert lib.get_existing_citekeys() == {"a2020", "b2021", "c2022"}
+
+
+# ---------------------------------------------------------------------------
+# update_status / count
+# ---------------------------------------------------------------------------
+
+
+def test_update_status(lib):
+    lib.add_source("pid", "test2022", status="pending")
+    lib.update_status("test2022", "completed")
+    src = lib.get_source_by_citekey("test2022")
+    assert src.status == "completed"
+
+
+def test_count(lib):
+    assert lib.count() == 0
+    lib.add_source("p1", "a")
+    lib.add_source("p2", "b")
+    assert lib.count() == 2
+
+
+# ---------------------------------------------------------------------------
+# sections and chapters
+# ---------------------------------------------------------------------------
+
+
+def test_chapters_replaced_on_upsert(lib):
+    lib.add_source("pid", "src", chapters=[1])
+    lib.add_source("pid", "src", chapters=[2, 3])
+    src = lib.get_source_by_citekey("src")
+    assert src.chapters == [2, 3]
+
+
+def test_sections_replaced_on_upsert(lib):
+    lib.add_source("pid", "src2", sections=["1.1"])
+    lib.add_source("pid", "src2", sections=["2.1", "3.2"])
+    src = lib.get_source_by_citekey("src2")
+    assert set(src.sections) == {"2.1", "3.2"}


### PR DESCRIPTION
## Summary

- **LocalUserLibrary** (`~/.klemma/library.db`, schema v2): maps citekey → paper_id; tables `user_sources / _chapters / _sections`; auto-registered from `_process_single()` after extraction
- **LocalProjectStore** (`project/.klemma/data/project.db`, schema v1): per-project section assignments; tables `project_sources / _source_sections / _fragments`; `get_reference_gaps()` stub → `[]` until Phase 1D
- **`klemma migrate-library`** command: dry-run by default, `--run` migrates monolithic `klemma.db` → `library.db` + `project.db` (with backup); follows ADR-011 mutation pattern
- **KlemmaContext**: `user_library` + `project_store` optional fields
- **43 new tests** (23 UserLibrary + 20 ProjectStore), full suite 1140 passed

StateManager refactor and `inherit_db` removal deferred to Phase 1D (approved by PM + CTO reviews — reduced scope avoids catastrophic risk on 1140-test suite).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/test_user_library.py tests/test_project_store.py -q` — 35 passed
- [x] `python -m pytest tests/ -q` — 1140 passed, 1 pre-existing failure (unrelated)

## Release Note

### Problem
Klemma had a single monolithic `klemma.db` per project, with no separation between globally-reusable paper content (PDF extractions, embeddings) and project-specific metadata (citekey assignments, section coverage). Re-processing the same PDF in two projects duplicated all AI work. There was no typed layer for the user's curated source list.

### Academic Foundation
ADR-014 formalizes the three-tier library model derived from digital library research (Arms 2000; Fox & Urs 2002) — global corpus → personal collection → project context. The content-addressable dedup in `LocalPaperStore` follows the principle of separating content identity from usage context (Kahn & Wilensky 2006). The Protocol-over-inheritance pattern ensures each tier can evolve independently (Liskov 1994).

### Implementation
- `stores/user_library.py` (~210 lines): `LocalUserLibrary` — SQLite WAL, `PRAGMA foreign_keys=ON`, upsert-on-conflict with chapter/section list replacement
- `stores/project_store.py` (~200 lines): `LocalProjectStore` — section assignment engine, coverage stats query, Phase-1D gap stub
- `stores/__init__.py`: exports all three store classes
- `context.py`: two new `Optional` fields (`user_library`, `project_store`) — no breaking changes
- `cli.py`: `_init_components()` instantiates all three stores; `_process_single()` registers citekey after extraction
- `commands/manage.py`: `migrate-library` command with dry-run default + `--run` flag

### Results
- 43 new tests, 0 regressions
- Schema coexistence verified: `LocalPaperStore` (v1) + `LocalUserLibrary` (v2) on same `library.db` file
- Migration command tested manually: dry-run reports counts, `--run` creates backup and migrates

Closes #126, Part of #82