### PR TITLE
feat: acquire dedup against library.db (ADR-014 Phase 1E)

### DIFF
--- a/src/klemma/commands/acquire.py
+++ b/src/klemma/commands/acquire.py
@@ -196,9 +196,11 @@ def acquire(
             meta,
             storage_path=cfg.zotero.storage_path,
             state=state,
+            paper_store=kctx.paper_store,
+            user_library=kctx.user_library,
         )
 
-        if result.status in ("ok", "ok_no_pdf"):
+        if result.status in ("ok", "ok_no_pdf", "ok_library_doi"):
             console.print(f"  [green]@{result.citekey}[/green]")
             if meta.title:
                 auto = " [dim](auto-extracted)[/dim]" if not title else ""
@@ -217,6 +219,8 @@ def acquire(
                     console.print(
                         "  [dim]Tip: use Zotero → Right-click → Find Available PDF[/dim]"
                     )
+            if result.status == "ok_library_doi":
+                console.print("  [dim](from library — download skipped)[/dim]")
             if meta.sections:
                 console.print(f"  [dim]sections: {', '.join(meta.sections)}[/dim]")
 

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -78,9 +78,14 @@ Project outline generation from directory contents + database context. Two modes
 - `OutlineResult` dataclass: title, description, chapters, sections, scientific_results, outline_text, update_summary
 - CLI options: `-p/--prompt` (custom directive), `--fresh` (force full regeneration)
 
-### acquirer.py (~240 lines)
-Local-only paper acquisition pipeline: download → auto-extract metadata → Zotero → local storage → DB.
-- `acquire_paper_local()` — orchestrates full pipeline; calls `resolve_metadata()` after download, then attempts Zotero integration (create item + get BBT citekey), falls back to local citekey generation
+### acquirer.py (~260 lines)
+Local-only paper acquisition pipeline: download → dedup → auto-extract metadata → Zotero → local storage → DB.
+- `acquire_paper_local(meta, storage_path, state?, paper_store?, user_library?)` — orchestrates full pipeline with three dedup gates (ADR-014 Phase 1E):
+  1. **DOI pre-check** — if `meta.url` is a DOI and `paper_store.find_paper(doi=...)` hits → returns `ok_library_doi` without downloading; registers citekey in `user_library` and `state`
+  2. **Hash dedup** — after download, `compute_pdf_hash()` then `paper_store.find_paper(pdf_hash=...)` hit → skip `resolve_metadata()`; uses library record for citekey generation; registers citekey in `user_library` via **step 6b**
+  3. **Write-through** — new paper (no dedup hit) → `resolve_metadata()` → Zotero → `paper_store.register_paper()` → `user_library.add_source()`
+  - All three paths call `user_library.add_source(paper_id, citekey, status="completed")` to map citekey → paper_id
+  - Returns `AcquireResult` with `status` (`"ok"`, `"ok_library_doi"`, `"download_failed"`, etc.), `citekey`, `pdf_hash`
 - `download_pdf()` — HTTP stream with validation (min 10KB, content-type check)
 - `_store_pdf_locally()` — copy to Zotero storage dir (skipped when Zotero has the PDF)
 - `_generate_citekey()` — generates `author2024_title_slug` from metadata (fallback when Zotero/BBT unavailable)
@@ -124,7 +129,7 @@ If vault note missing: triggers `literature.note_factory.create_vault_note()` fi
 `klemma research -s X.X` → `_sync_sections()` → `researcher.research_section()` → auto-extracts fragments (if needed) → builds context → Claude → `ResearchResult` → `project_root/notes/research/Research_{section}.md` (reads legacy `project_root/Research_{section}.md` as fallback).
 
 ### Paper acquisition
-`klemma acquire <url>` → `acquirer.acquire_paper_local()` → download PDF → `resolve_metadata()` (PDF props + S2 API) → if Zotero running: create item via Connector + get BBT citekey → else: local citekey + local PDF storage → `state.register_sources()` + `state.update_source_info()` (title/authors/year/abstract/doi).
+`klemma acquire <url>` → `acquirer.acquire_paper_local()` → **DOI pre-check** (library hit → skip download, return `ok_library_doi`) → download PDF → **hash dedup** (library hit → skip extraction, use library metadata) → `resolve_metadata()` (PDF props + S2 API) → if Zotero running: create item via Connector + get BBT citekey → else: local citekey + local PDF storage → `paper_store.register_paper()` → `user_library.add_source()` → `state.register_sources()` + `state.update_source_info()`.
 
 ### Library analysis
 `klemma library` → `librarian.analyze_library()` → `LibraryReport` → `project_root/notes/library/Library_{mode}_{date}.md`.

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -13,6 +13,9 @@ from urllib.parse import urlparse
 
 import requests
 
+from ..hashing import compute_pdf_hash
+from ..literature.metadata import resolve_metadata
+
 logger = logging.getLogger(__name__)
 
 MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024  # 50 MB hard limit
@@ -504,6 +507,8 @@ def acquire_paper_local(
     meta: PaperMetadata,
     storage_path: str,
     state=None,
+    paper_store=None,
+    user_library=None,
 ) -> AcquireResult:
     """Local acquire: download PDF → auto-extract metadata → generate citekey → store → register in DB."""
     # 0a. Extract DOI from URL before any URL rewriting
@@ -511,7 +516,61 @@ def acquire_paper_local(
     if doi_from_url and not meta.doi:
         meta.doi = doi_from_url
 
-    # 0b. Resolve effective download URL
+    # 0b. DOI dedup check — skip download if library already has this paper
+    if meta.doi and paper_store:
+        _lib_paper = paper_store.find_paper(doi=meta.doi)
+        if _lib_paper:
+            logger.info(
+                "Library hit (DOI %s, paper_id=%s...)", meta.doi, _lib_paper.paper_id[:8]
+            )
+            if not meta.title and _lib_paper.title:
+                meta.title = _lib_paper.title
+            if not meta.authors and _lib_paper.authors:
+                meta.authors = _lib_paper.authors
+            if meta.year is None and _lib_paper.year:
+                meta.year = _lib_paper.year
+            citekey = _generate_citekey(meta)
+            _doi_resolved = {
+                "title": _lib_paper.title,
+                "authors": _lib_paper.authors,
+                "year": _lib_paper.year,
+                "doi": meta.doi,
+                "abstract": _lib_paper.abstract,
+            }
+            zotero_citekey = _try_zotero(meta, _doi_resolved, pdf_path=None)
+            if zotero_citekey:
+                citekey = zotero_citekey
+            if state:
+                state.register_sources([citekey])
+                if meta.sections:
+                    chapters = list({int(s.split(".")[0]) for s in meta.sections if "." in s})
+                    state.set_source_sections(citekey, meta.sections, chapters)
+                state.update_source_info(
+                    citekey,
+                    title=_lib_paper.title,
+                    authors=_lib_paper.authors,
+                    year=_lib_paper.year,
+                    abstract=_lib_paper.abstract,
+                    doi=meta.doi,
+                )
+            if user_library:
+                try:
+                    user_library.add_source(
+                        _lib_paper.paper_id, citekey,
+                        status="completed" if _lib_paper.pdf_hash else "pending",
+                        pdf_path="",
+                    )
+                except Exception:
+                    pass
+            return AcquireResult(
+                citekey=citekey,
+                pdf_path="",
+                status="ok_library_doi",
+                zotero_added=zotero_citekey is not None,
+                pdf_hash=_lib_paper.pdf_hash,
+            )
+
+    # 0c. Resolve effective download URL
     # Priority: --pdf override > arXiv resolve > DOI resolve > original URL
     arxiv_pdf = _resolve_arxiv_pdf_url(meta.url)
     if meta.pdf_override:
@@ -525,7 +584,7 @@ def acquire_paper_local(
         else:
             logger.warning("Could not resolve DOI %s to a PDF URL", doi_from_url)
 
-    # 0c. Handle local file:// URLs directly
+    # 0d. Handle local file:// URLs directly
     parsed_url = urlparse(meta.url)
     if parsed_url.scheme == "file":
         from urllib.parse import unquote
@@ -545,49 +604,83 @@ def acquire_paper_local(
 
     is_local_file = parsed_url.scheme == "file"
 
-    # 2. Auto-extract metadata (CLI flags win → PDF → S2 → empty)
+    # 1.5. Compute PDF hash early for content-addressable dedup (ADR-014)
+    _pdf_hash = ""
     try:
-        from ..literature.metadata import resolve_metadata
-
-        resolved = resolve_metadata(
-            pdf_path,
-            cli_title=meta.title,
-            cli_authors=meta.authors,
-            cli_year=meta.year,
-            cli_doi=meta.doi,
-        )
-        # Fill in blanks on meta from resolved data
-        if not meta.title and resolved.get("title"):
-            meta.title = resolved["title"]
-        if not meta.authors and resolved.get("authors"):
-            meta.authors = resolved["authors"]
-        if meta.year is None and resolved.get("year"):
-            meta.year = resolved["year"]
-        if not meta.doi and resolved.get("doi"):
-            meta.doi = resolved["doi"]
+        _pdf_hash = compute_pdf_hash(pdf_path)
+        logger.info("PDF hash: %s...", _pdf_hash[:12])
     except Exception as e:
-        logger.warning("Metadata extraction failed, continuing: %s", e)
-        resolved = {}
+        logger.debug("Could not compute PDF hash: %s", e)
 
-    # 2a. CrossRef fallback — when S2 is unavailable (429) and key fields missing
-    if meta.doi and (not meta.authors or meta.year is None):
+    # 1.6. Hash dedup check — library already has this exact PDF
+    _lib_resolved = None
+    if _pdf_hash and paper_store:
+        _hash_paper = paper_store.find_paper(pdf_hash=_pdf_hash)
+        if _hash_paper:
+            logger.info(
+                "Library hash hit: %s... (paper_id=%s...)",
+                _pdf_hash[:8], _hash_paper.paper_id[:8],
+            )
+            if not meta.title and _hash_paper.title:
+                meta.title = _hash_paper.title
+            if not meta.authors and _hash_paper.authors:
+                meta.authors = _hash_paper.authors
+            if meta.year is None and _hash_paper.year:
+                meta.year = _hash_paper.year
+            if not meta.doi and _hash_paper.doi:
+                meta.doi = _hash_paper.doi
+            _lib_resolved = {
+                "title": _hash_paper.title,
+                "authors": _hash_paper.authors,
+                "year": _hash_paper.year,
+                "doi": _hash_paper.doi,
+                "abstract": _hash_paper.abstract,
+            }
+
+    # 2. Auto-extract metadata (CLI flags win → PDF → S2 → empty)
+    if _lib_resolved is None:
         try:
-            cr = _lookup_crossref_by_doi(meta.doi)
-            if cr:
-                # CrossRef title is authoritative — prefer over PDF-extracted
-                if cr.get("title"):
-                    meta.title = cr["title"]
-                    resolved["title"] = cr["title"]
-                if not meta.authors and cr.get("authors"):
-                    meta.authors = cr["authors"]
-                if meta.year is None and cr.get("year"):
-                    meta.year = cr["year"]
-                if not resolved.get("authors") and cr.get("authors"):
-                    resolved["authors"] = cr["authors"]
-                if not resolved.get("year") and cr.get("year"):
-                    resolved["year"] = cr["year"]
+            resolved = resolve_metadata(
+                pdf_path,
+                cli_title=meta.title,
+                cli_authors=meta.authors,
+                cli_year=meta.year,
+                cli_doi=meta.doi,
+            )
+            # Fill in blanks on meta from resolved data
+            if not meta.title and resolved.get("title"):
+                meta.title = resolved["title"]
+            if not meta.authors and resolved.get("authors"):
+                meta.authors = resolved["authors"]
+            if meta.year is None and resolved.get("year"):
+                meta.year = resolved["year"]
+            if not meta.doi and resolved.get("doi"):
+                meta.doi = resolved["doi"]
         except Exception as e:
-            logger.debug("CrossRef fallback failed: %s", e)
+            logger.warning("Metadata extraction failed, continuing: %s", e)
+            resolved = {}
+
+        # 2a. CrossRef fallback — when S2 is unavailable (429) and key fields missing
+        if meta.doi and (not meta.authors or meta.year is None):
+            try:
+                cr = _lookup_crossref_by_doi(meta.doi)
+                if cr:
+                    # CrossRef title is authoritative — prefer over PDF-extracted
+                    if cr.get("title"):
+                        meta.title = cr["title"]
+                        resolved["title"] = cr["title"]
+                    if not meta.authors and cr.get("authors"):
+                        meta.authors = cr["authors"]
+                    if meta.year is None and cr.get("year"):
+                        meta.year = cr["year"]
+                    if not resolved.get("authors") and cr.get("authors"):
+                        resolved["authors"] = cr["authors"]
+                    if not resolved.get("year") and cr.get("year"):
+                        resolved["year"] = cr["year"]
+            except Exception as e:
+                logger.debug("CrossRef fallback failed: %s", e)
+    else:
+        resolved = _lib_resolved
 
     # 2b. Add to Zotero if running
     zotero_citekey = _try_zotero(meta, resolved, pdf_path)
@@ -622,16 +715,28 @@ def acquire_paper_local(
             doi=resolved.get("doi", ""),
         )
 
-    # Compute PDF hash before temp file cleanup (ADR-014: content-addressable dedup)
-    from ..hashing import compute_pdf_hash
-
-    hash_path = Path(permanent_path) if permanent_path else pdf_path
-    try:
-        pdf_hash = compute_pdf_hash(hash_path)
-        logger.info("PDF hash for %s: %s", citekey, pdf_hash[:12])
-    except Exception as e:
-        logger.debug("Could not compute PDF hash: %s", e)
-        pdf_hash = ""
+    # 6. Write-through to library (ADR-014): register new paper for cross-project dedup
+    if paper_store and _pdf_hash and _lib_resolved is None:
+        try:
+            paper_id = paper_store.register_paper(
+                title=resolved.get("title", meta.title),
+                pdf_hash=_pdf_hash,
+                doi=meta.doi or resolved.get("doi", ""),
+                authors=resolved.get("authors", meta.authors),
+                year=meta.year or resolved.get("year"),
+                abstract=resolved.get("abstract", ""),
+            )
+            if user_library and paper_id:
+                try:
+                    user_library.add_source(
+                        paper_id, citekey,
+                        status="completed",
+                        pdf_path=permanent_path or "",
+                    )
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.debug("Library write-through failed: %s", e)
 
     if not is_local_file:
         pdf_path.unlink(missing_ok=True)
@@ -640,7 +745,7 @@ def acquire_paper_local(
         pdf_path=permanent_path or str(pdf_path),
         status="ok",
         zotero_added=zotero_citekey is not None,
-        pdf_hash=pdf_hash,
+        pdf_hash=_pdf_hash,
     )
 
 

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -614,6 +614,7 @@ def acquire_paper_local(
 
     # 1.6. Hash dedup check — library already has this exact PDF
     _lib_resolved = None
+    _lib_paper_id = None  # paper_id from hash hit — for user_library registration below
     if _pdf_hash and paper_store:
         _hash_paper = paper_store.find_paper(pdf_hash=_pdf_hash)
         if _hash_paper:
@@ -629,6 +630,7 @@ def acquire_paper_local(
                 meta.year = _hash_paper.year
             if not meta.doi and _hash_paper.doi:
                 meta.doi = _hash_paper.doi
+            _lib_paper_id = _hash_paper.paper_id
             _lib_resolved = {
                 "title": _hash_paper.title,
                 "authors": _hash_paper.authors,
@@ -731,12 +733,24 @@ def acquire_paper_local(
                     user_library.add_source(
                         paper_id, citekey,
                         status="completed",
-                        pdf_path=permanent_path or "",
+                        pdf_path=permanent_path or None,
                     )
                 except Exception:
                     pass
         except Exception as e:
             logger.debug("Library write-through failed: %s", e)
+
+    # 6b. Hash-hit path: register new citekey → existing paper_id in user_library
+    # (step 6 is skipped when _lib_resolved is set, so we register here instead)
+    if user_library and _lib_paper_id:
+        try:
+            user_library.add_source(
+                _lib_paper_id, citekey,
+                status="completed",
+                pdf_path=permanent_path or None,
+            )
+        except Exception:
+            pass
 
     if not is_local_file:
         pdf_path.unlink(missing_ok=True)

--- a/tests/test_acquire_dedup.py
+++ b/tests/test_acquire_dedup.py
@@ -1,0 +1,280 @@
+"""Tests for acquire library dedup (ADR-014 Phase 1E)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from klemma.models import PaperRecord
+from klemma.skills.acquirer import PaperMetadata, acquire_paper_local
+from klemma.state import StateManager
+
+
+def _make_paper_record(**kwargs) -> PaperRecord:
+    defaults = dict(
+        paper_id="uuid-paper-1",
+        pdf_hash="abc123hash",
+        doi="10.1234/test",
+        title="Test Paper Title",
+        authors="Smith, John",
+        year=2023,
+        abstract="Test abstract",
+    )
+    defaults.update(kwargs)
+    return PaperRecord(**defaults)
+
+
+# ── DOI pre-check ──────────────────────────────────────────────────────────
+
+
+def test_acquire_doi_dedup_returns_ok_library_doi():
+    """DOI already in library → returns ok_library_doi without downloading."""
+    record = _make_paper_record()
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = record
+    mock_user_library = MagicMock()
+
+    meta = PaperMetadata(url="https://doi.org/10.1234/test")
+    result = acquire_paper_local(
+        meta, storage_path="", state=None,
+        paper_store=mock_paper_store, user_library=mock_user_library,
+    )
+
+    assert result.status == "ok_library_doi"
+    assert result.pdf_hash == "abc123hash"
+    mock_paper_store.find_paper.assert_called_with(doi="10.1234/test")
+
+
+def test_acquire_doi_dedup_skips_download():
+    """DOI dedup should never call download_pdf."""
+    record = _make_paper_record()
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = record
+
+    meta = PaperMetadata(url="https://doi.org/10.1234/test")
+    with patch("klemma.skills.acquirer.download_pdf") as mock_dl:
+        acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
+        mock_dl.assert_not_called()
+
+
+def test_acquire_doi_dedup_registers_in_state(tmp_path):
+    """DOI dedup registers citekey in local state DB."""
+    db = tmp_path / "state.db"
+    sm = StateManager(db)
+
+    record = _make_paper_record()
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = record
+
+    meta = PaperMetadata(url="https://doi.org/10.1234/test")
+    result = acquire_paper_local(
+        meta, storage_path="", state=sm, paper_store=mock_paper_store,
+    )
+
+    assert result.status == "ok_library_doi"
+    # get_all_sources() filters by status=completed; use get_source() instead
+    src = sm.get_source(result.citekey)
+    assert src is not None, f"citekey {result.citekey!r} not found in DB"
+
+
+def test_acquire_doi_dedup_registers_in_user_library():
+    """DOI dedup calls user_library.add_source with correct paper_id."""
+    record = _make_paper_record(paper_id="paper-uuid-99")
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = record
+    mock_user_library = MagicMock()
+
+    meta = PaperMetadata(url="https://doi.org/10.1234/test")
+    result = acquire_paper_local(
+        meta, storage_path="", state=None,
+        paper_store=mock_paper_store, user_library=mock_user_library,
+    )
+
+    assert result.status == "ok_library_doi"
+    mock_user_library.add_source.assert_called_once()
+    call_kwargs = mock_user_library.add_source.call_args
+    assert call_kwargs[0][0] == "paper-uuid-99"  # paper_id positional
+
+
+def test_acquire_doi_dedup_fills_meta_from_library():
+    """DOI dedup fills meta fields from library record for citekey generation."""
+    record = _make_paper_record(title="Library Paper", authors="Jones, Alice", year=2021)
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = record
+
+    # meta has no title/authors — should be filled from library
+    meta = PaperMetadata(url="https://doi.org/10.1234/test")
+    result = acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
+
+    assert result.status == "ok_library_doi"
+    # citekey should include author name and year (Jones2021_...)
+    assert "Jones" in result.citekey or "jones" in result.citekey.lower()
+
+
+def test_acquire_no_doi_no_paper_store_no_dedup():
+    """Without DOI or paper_store, dedup is skipped (no crash)."""
+    meta = PaperMetadata(url="https://example.com/paper.pdf")
+    with patch("klemma.skills.acquirer.download_pdf", return_value=None):
+        result = acquire_paper_local(meta, storage_path="")
+    # No crash — download failed, no DOI → download_failed
+    assert result.status == "download_failed"
+
+
+# ── Hash dedup (post-download, pre-extraction) ────────────────────────────
+
+
+def _make_tmp_pdf(tmp_path: Path) -> Path:
+    """Create a minimal fake PDF file."""
+    p = tmp_path / "test.pdf"
+    p.write_bytes(b"%PDF-1.4 fake content for test" + b"\x00" * 100)
+    return p
+
+
+def test_acquire_hash_dedup_skips_metadata_extraction(tmp_path):
+    """Hash match: library metadata used instead of calling resolve_metadata.
+
+    We verify this behaviorally: register_paper is NOT called (paper already
+    in library), and the result uses library data.
+    """
+    fake_pdf = _make_tmp_pdf(tmp_path)
+    record = _make_paper_record(
+        pdf_hash="deadbeef", doi="10.9999/hash-test",
+        title="Hash Paper", authors="Green, Alice", year=2019,
+    )
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.side_effect = lambda **kw: (
+        None if kw.get("doi") else record  # DOI miss, hash hit
+    )
+
+    meta = PaperMetadata(url="https://example.com/paper.pdf")
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="deadbeef"), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="", paper_store=mock_paper_store,
+        )
+
+    assert result.status == "ok"
+    # Library data used → register_paper NOT called (already in library)
+    mock_paper_store.register_paper.assert_not_called()
+    # Library author propagated to citekey
+    assert "Green" in result.citekey or "green" in result.citekey.lower()
+
+
+def test_acquire_hash_dedup_uses_library_metadata(tmp_path):
+    """Hash match uses library metadata for citekey generation."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+    record = _make_paper_record(
+        pdf_hash="deadbeef", title="Hash Match Paper", authors="Brown, Bob", year=2020,
+    )
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.side_effect = lambda **kw: (
+        None if kw.get("doi") else record
+    )
+
+    meta = PaperMetadata(url="https://example.com/paper.pdf")
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="deadbeef"), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
+
+    assert "Brown" in result.citekey or "brown" in result.citekey.lower()
+
+
+# ── Write-through (new paper → library) ───────────────────────────────────
+
+
+def test_acquire_write_through_registers_paper_in_library(tmp_path):
+    """New paper (no dedup hit) is registered in paper_store after acquire."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = None
+    mock_paper_store.register_paper.return_value = "new-paper-uuid"
+    mock_user_library = MagicMock()
+
+    meta = PaperMetadata(
+        url="https://example.com/paper.pdf",
+        title="New Paper",
+        authors="Taylor, Carl",
+        year=2024,
+        doi="10.5555/new",
+    )
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="newhash123"), \
+         patch("klemma.skills.acquirer.resolve_metadata", return_value={}), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="",
+            paper_store=mock_paper_store, user_library=mock_user_library,
+        )
+
+    assert result.status == "ok"
+    assert result.pdf_hash == "newhash123"
+    mock_paper_store.register_paper.assert_called_once()
+    call_kwargs = mock_paper_store.register_paper.call_args[1]
+    assert call_kwargs["pdf_hash"] == "newhash123"
+    assert call_kwargs["doi"] == "10.5555/new"
+
+
+def test_acquire_write_through_registers_citekey_in_user_library(tmp_path):
+    """New paper: citekey registered in user_library after acquire."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.return_value = None
+    mock_paper_store.register_paper.return_value = "new-paper-uuid"
+    mock_user_library = MagicMock()
+
+    meta = PaperMetadata(
+        url="https://example.com/paper.pdf",
+        title="New Paper", authors="Taylor, Carl", year=2024,
+    )
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="newhash123"), \
+         patch("klemma.skills.acquirer.resolve_metadata", return_value={}), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="",
+            paper_store=mock_paper_store, user_library=mock_user_library,
+        )
+
+    assert result.status == "ok"
+    mock_user_library.add_source.assert_called_once()
+    call_args = mock_user_library.add_source.call_args
+    assert call_args[0][0] == "new-paper-uuid"  # paper_id
+    assert call_args[0][1] == result.citekey    # citekey
+    assert call_args[1]["status"] == "completed"
+
+
+def test_acquire_write_through_skipped_on_hash_dedup(tmp_path):
+    """Hash dedup hit should NOT call register_paper (already in library)."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+    record = _make_paper_record(pdf_hash="existinghash")
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.side_effect = lambda **kw: (
+        None if kw.get("doi") else record
+    )
+
+    meta = PaperMetadata(url="https://example.com/paper.pdf")
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="existinghash"), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
+
+    mock_paper_store.register_paper.assert_not_called()
+
+
+def test_acquire_without_paper_store_unchanged_behavior(tmp_path):
+    """Without paper_store, behavior is identical to pre-dedup code."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+
+    meta = PaperMetadata(url="https://example.com/paper.pdf", title="Legacy", year=2020)
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.resolve_metadata", return_value={"title": "Legacy"}), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(meta, storage_path="")
+
+    assert result.status == "ok"
+    assert result.citekey  # some citekey generated

--- a/tests/test_acquirer.py
+++ b/tests/test_acquirer.py
@@ -181,6 +181,33 @@ def test_acquire_hash_dedup_uses_library_metadata(tmp_path):
     assert "Brown" in result.citekey or "brown" in result.citekey.lower()
 
 
+def test_acquire_hash_dedup_registers_citekey_in_user_library(tmp_path):
+    """Hash hit: new citekey must be registered in user_library (step 6b)."""
+    fake_pdf = _make_tmp_pdf(tmp_path)
+    record = _make_paper_record(pdf_hash="existinghash", paper_id="existing-pid")
+
+    mock_paper_store = MagicMock()
+    mock_paper_store.find_paper.side_effect = lambda **kw: (
+        None if kw.get("doi") else record  # DOI miss, hash hit
+    )
+    mock_user_library = MagicMock()
+
+    meta = PaperMetadata(url="https://example.com/paper.pdf")
+    with patch("klemma.skills.acquirer.download_pdf", return_value=fake_pdf), \
+         patch("klemma.skills.acquirer.compute_pdf_hash", return_value="existinghash"), \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="",
+            paper_store=mock_paper_store, user_library=mock_user_library,
+        )
+
+    assert result.status == "ok"
+    mock_user_library.add_source.assert_called_once()
+    call_args = mock_user_library.add_source.call_args
+    assert call_args[0][0] == "existing-pid"   # paper_id
+    assert call_args[0][1] == result.citekey    # citekey
+
+
 # ── Write-through (new paper → library) ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `acquire_paper_local()` now accepts `paper_store` and `user_library` params
- **DOI pre-check** (step 0b): if DOI already in `library.db`, skip download entirely and return `ok_library_doi`
- **Hash post-check** (step 1.6): after download, compute PDF hash; if match in library, use library metadata and skip S2/CrossRef API calls
- **Write-through** (step 6): new paper registered in `paper_store` + `user_library` for cross-project dedup
- `commands/acquire.py` passes `paper_store`/`user_library` from context; handles `ok_library_doi` in output

## Test plan

- [x] 12 new tests in `tests/test_acquire_dedup.py` — DOI dedup, hash dedup, write-through, user_library registration, backward compat without paper_store
- [x] Full suite: 1164 tests pass
- [x] `ruff check src/ tests/` clean

Part of #82

## Release Note

### Problem
`klemma acquire` downloaded and re-extracted metadata for every paper acquisition, even when the same paper had already been acquired in another project. This wasted API calls (S2/CrossRef), bandwidth, and storage space across multi-project workflows.

### Academic Foundation
Content-addressable dedup is a standard technique from database systems literature. The ADR-014 three-tier library design formalizes this for the academic library use case: global corpus (library.db) provides a shared cache layer that eliminates redundant work across all projects on the same machine.

### Implementation
Two dedup gates in `acquire_paper_local()`: (1) DOI pre-check at step 0b returns `ok_library_doi` without downloading — uses `paper_store.find_paper(doi=...)` before any HTTP request; (2) hash post-check at step 1.6 after download but before metadata extraction — uses `paper_store.find_paper(pdf_hash=...)` to skip expensive S2/CrossRef lookups. Write-through at step 6 registers every novel acquisition via `paper_store.register_paper()` + `user_library.add_source()`. The `resolve_metadata` import was promoted to module-level to support clean test patching.

### Results
12 new tests, 1164 total (all green). Two API round-trips eliminated per duplicate acquire. `ok_library_doi` status gives explicit signal in CLI output: "(from library — download skipped)".