### PR TITLE
fix: warn on bare chapter section assignments (#148)

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -324,6 +324,14 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
         if not sections_list and primary_section_str:
             sections_list = [primary_section_str]
 
+        # Warn on bare chapter assignments (e.g. sections: [1] instead of 1.1)
+        for _sec in sections_list:
+            if str(_sec).isdigit():
+                console.print(
+                    f"[yellow]Warning:[/yellow] @{citekey} assigned to bare chapter "
+                    f"'{_sec}' — did you mean a subsection (e.g. {_sec}.1)?"
+                )
+
         vault_data.append(
             {
                 "citekey": citekey,

--- a/tests/test_bare_section_warning.py
+++ b/tests/test_bare_section_warning.py
@@ -1,0 +1,95 @@
+"""Tests for bare chapter section warning in _sync_sections (issue #148)."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from klemma.cli import main as klemma_cli
+from klemma.state import StateManager
+
+
+def _make_ctx(tmp_path, vault_notes: dict):
+    """Build a mock KlemmaContext with a real StateManager and fake vault."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+
+    mock_vault = MagicMock()
+    mock_vault.list_notes.return_value = list(vault_notes.keys())
+    mock_vault.get_properties.side_effect = lambda name: vault_notes.get(name, {})
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.vault = mock_vault
+    mock_ctx.config = MagicMock()
+    mock_ctx.config.obsidian.notes_folder = ""
+    mock_ctx.library = None
+    mock_ctx.project = None
+    mock_ctx.project_store = None
+    mock_ctx.user_library = None
+    mock_ctx.embeddings = None
+    return mock_ctx
+
+
+def test_bare_section_emits_warning(tmp_path):
+    """vault note with sections: [1] triggers a yellow warning during sync."""
+    mock_ctx = _make_ctx(tmp_path, {
+        "@paper1": {"sections": [1]},
+    })
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["status"])
+
+    assert "bare chapter" in result.output or "Warning" in result.output, result.output
+    assert "'1'" in result.output, result.output
+
+
+def test_subsection_no_warning(tmp_path):
+    """Proper subsection assignment (e.g. 1.1) produces no warning."""
+    mock_ctx = _make_ctx(tmp_path, {
+        "@paper1": {"sections": ["1.1"]},
+    })
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["status"])
+
+    assert "bare chapter" not in result.output
+
+
+def test_mixed_sections_warns_only_bare(tmp_path):
+    """Mixed sections list: only bare integers trigger a warning."""
+    mock_ctx = _make_ctx(tmp_path, {
+        "@paper1": {"sections": ["1.1", "2"]},  # 2 is bare, 1.1 is fine
+    })
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["status"])
+
+    assert "'2'" in result.output
+    assert "'1.1'" not in result.output
+
+
+def test_multiple_sources_each_warned(tmp_path):
+    """Two sources with bare chapter assignments each get a warning line."""
+    mock_ctx = _make_ctx(tmp_path, {
+        "@alpha": {"sections": ["3"]},
+        "@beta": {"sections": ["3"]},
+    })
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["status"])
+
+    # Both sources should appear in warnings
+    assert result.output.count("Warning") >= 2 or result.output.count("bare chapter") >= 2


### PR DESCRIPTION
## Summary

- Adds a yellow warning in `_sync_sections` when a vault note has `sections: [1]` (bare integer, no decimal point)
- Uses `str.isdigit()` — no regex import needed
- Assignment is NOT blocked — user sees the warning and can fix their vault frontmatter
- 4 tests covering: bare triggers warning, subsection no warning, mixed list, multiple sources

## Test plan

- [x] 4 new tests in `tests/test_bare_section_warning.py`
- [x] Full suite: 1156 tests pass
- [x] `ruff check` clean

Closes #148

## Release Note

### Problem
`klemma status` showed confusing table rows like `1 │ │ 1` when a vault note had `sections: [1]` instead of `sections: [1.1]`. Users had no indication anything was wrong — the bare chapter number was silently accepted as a valid section.

### Academic Foundation
Defensive UX: fail loudly on likely user errors rather than silently accepting invalid input (Nielsen's error prevention heuristic).

### Implementation
5-line addition to `_sync_sections()` in `cli.py`: after building `sections_list` from vault frontmatter, iterate and check `str(sec).isdigit()`. On match, print a yellow warning with a suggested fix (e.g. "did you mean 1.1?"). Assignment proceeds — no data is blocked.

### Results
4 new tests, 1156 total. Zero regressions. Warning visible on all commands that call `_sync_sections`: `status`, `research`, `library`, `coach`.