### PR TITLE
feat: research/ask supplement fragments from library.db (#82)

### DIFF
--- a/src/klemma/skills/context_loader.py
+++ b/src/klemma/skills/context_loader.py
@@ -704,6 +704,7 @@ def supplement_fragments_from_library(
 
     Returns the number of fragments added.
     """
+    _max_per_source = 10  # cap per-source to avoid flooding the fragment list
     existing_texts = {f.get("fragment_text", "") for f in section_fragments}
     added = 0
     for src in section_sources:
@@ -720,7 +721,10 @@ def supplement_fragments_from_library(
                 "Library supplement lookup failed for %s", citekey, exc_info=True
             )
             continue
+        source_added = 0
         for frag in lib_frags:
+            if source_added >= _max_per_source:
+                break
             fid = frag.fragment_id
             ftext = frag.fragment_text
             if fid not in seen_ids and ftext not in existing_texts:
@@ -735,9 +739,11 @@ def supplement_fragments_from_library(
                         "relevance_score": 3,
                         "usage_hint": "",
                         "citation_intent": frag.citation_intent or "",
+                        "similarity": 0.0,  # library frags have no query similarity
                     }
                 )
                 seen_ids.add(fid)
                 existing_texts.add(ftext)
                 added += 1
+                source_added += 1
     return added

--- a/tests/test_library_db_path.py
+++ b/tests/test_library_db_path.py
@@ -138,6 +138,7 @@ class TestInitComponentsUsesLibraryDbPath:
         """Return context managers that stub out everything except the stores."""
         state_mock = MagicMock()
         state_mock.get_coverage_stats.return_value = {"total_sources": 0}
+        state_mock.get_stats.return_value = {"total": 0}
         state_cls_mock = MagicMock(return_value=state_mock)
         return (
             patch("klemma.cli.ensure_system_home", return_value=system_home),

--- a/tests/test_research_library_fallback.py
+++ b/tests/test_research_library_fallback.py
@@ -322,3 +322,68 @@ class TestBuildAgentContextLibrarySupplement:
             )
 
         paper_store.get_fragments.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# research_section() integration: library supplement invoked when < 10 frags
+# ---------------------------------------------------------------------------
+
+
+class TestResearchSectionLibraryIntegration:
+    """Verify research_section() calls supplement_fragments_from_library() when needed."""
+
+    def test_research_section_invokes_library_supplement(self, tmp_path):
+        """research_section() calls supplement when local fragment count < 10."""
+        from unittest.mock import patch
+
+        from klemma.config import KlemmaConfig
+        from klemma.skills.researcher import research_section
+
+        lib_frag = _make_fragment_record("libfrag1", "paper123", "Library text.")
+        paper_store = _make_paper_store({"paper123": [lib_frag]})
+        user_library = _make_user_library({"alpha2020": "paper123"})
+
+        state = MagicMock()
+        state.get_fragments.return_value = []
+        state.get_all_sources.return_value = []
+        state.get_by_section.return_value = [{"id": "alpha2020", "title": "Alpha", "authors": "A", "year": 2020, "chapter": 1}]
+        state.get_coverage_stats.return_value = {"total_sources": 1, "sections": {}, "by_section": {}}
+        state.get_gaps.return_value = []
+        state.get_fragment_stats.return_value = {"total": 0}
+        state.get_existing_source_ids.return_value = {"alpha2020"}
+        state.retrieve_similar_fragments.return_value = []
+
+        vault = MagicMock()
+        vault.read_note.return_value = None
+
+        ai = MagicMock()
+        ai.render_prompt.return_value = "test_prompt"
+        ai.call_json.return_value = {
+            "section_status": "ready",
+            "section_title": "Test",
+            "current_word_count": 0,
+            "target_word_count": 500,
+            "readiness_pct": 0,
+            "fragment_distribution": {},
+            "argument_blocks": [],
+            "citation_plan": [],
+            "missing_coverage": [],
+            "writing_suggestions": [],
+        }
+
+        cfg = KlemmaConfig()
+
+        with patch("klemma.skills.context_loader.supplement_fragments_from_library") as mock_supplement:
+            mock_supplement.return_value = 1
+            research_section(
+                section="1.1",
+                config=cfg,
+                state=state,
+                vault=vault,
+                ai=ai,
+                save_to_vault=False,
+                paper_store=paper_store,
+                user_library=user_library,
+            )
+
+        mock_supplement.assert_called_once()

--- a/tests/test_research_library_fallback.py
+++ b/tests/test_research_library_fallback.py
@@ -158,6 +158,39 @@ class TestSupplementFragmentsFromLibrary:
 
         assert added == 0
 
+    def test_per_source_cap_limits_fragments(self):
+        """No more than 10 fragments per source are added (unbounded load guard)."""
+        # Create 20 fragments for one source
+        frags = [_make_fragment_record(f"f{i}", "p1", f"Text number {i}.") for i in range(20)]
+        paper_store = _make_paper_store({"p1": frags})
+        user_library = _make_user_library({"alice2022": "p1"})
+
+        fragments: list[dict] = []
+        seen: set[str] = set()
+
+        added = supplement_fragments_from_library(
+            fragments, seen, [{"id": "alice2022"}], paper_store, user_library, "1.1"
+        )
+
+        assert added == 10  # capped at 10 per source
+        assert len(fragments) == 10
+
+    def test_added_fragments_have_similarity_field(self):
+        """Library-supplemented fragments include 'similarity' key for prompt rendering."""
+        frag = _make_fragment_record("f1", "p1", "Some text.")
+        paper_store = _make_paper_store({"p1": [frag]})
+        user_library = _make_user_library({"alice2022": "p1"})
+
+        fragments: list[dict] = []
+        seen: set[str] = set()
+
+        supplement_fragments_from_library(
+            fragments, seen, [{"id": "alice2022"}], paper_store, user_library, "1.1"
+        )
+
+        assert "similarity" in fragments[0]
+        assert fragments[0]["similarity"] == 0.0
+
 
 # ---------------------------------------------------------------------------
 # research_section(): library supplement integration


### PR DESCRIPTION
## Summary

- Adds `supplement_fragments_from_library()` helper in `skills/context_loader.py` that bridges library.db → local fragment format (same dict shape as `state.get_fragments()`)
- `research_section()` calls the supplement after the fallback pass when local fragments < 10 and `paper_store`/`user_library` are available
- `build_agent_context()` (`klemma ask`) calls the supplement when RAG returns < 5 fragments
- Both call sites in `commands/research.py` updated to pass `kctx.paper_store` and `kctx.user_library`
- 11 new unit tests: `supplement_fragments_from_library` behaviour (dedup, skips, multi-source) + guard conditions for both researcher and agent paths

Part of #82

## Test plan

- [x] `pytest tests/test_research_library_fallback.py -v` — 11/11 pass
- [x] `pytest tests/ -q` — 1163 pass, 0 fail
- [x] `ruff check src/ tests/` — clean

## Release Note

### Problem
`klemma research -s <section>` in a new project (project B) returned empty fragments even when library.db already contained fragments for the same papers extracted in project A. The cross-project fragment sharing promised by the three-tier architecture was not wired into the research/ask commands.

### Academic Foundation
The three-tier Global Corpus model follows the shared-repository principle from Pautasso's (2013) software composition literature: components should read from the shared corpus before rebuilding locally. The supplement pattern (read shared first, fall back to local) is consistent with Fielding's (2000) cache constraint in REST — don't re-fetch what the corpus already has.

### Implementation
`supplement_fragments_from_library(section_fragments, seen_ids, section_sources, paper_store, user_library, section)` in `src/klemma/skills/context_loader.py`:
- Maps each section source's citekey → paper_id via `user_library.resolve_paper_id()`
- Fetches `FragmentRecord` objects from `paper_store.get_fragments(paper_id)`
- Converts to the `state.get_fragments()` dict shape (with `section`, `relevance_score=3` defaults)
- Deduplicates via `seen_ids` set
- Guard condition: only fires when `paper_store` and `user_library` are both provided AND local fragment count < threshold (10 for research, 5 for ask)
- Fully backward-compatible: old installations without three-tier stores pass `None` and the guard short-circuits

Both `research_section()` (`src/klemma/skills/researcher.py`) and `build_agent_context()` (`src/klemma/skills/agent.py`) received `paper_store=None, user_library=None` optional kwargs. Call sites in `src/klemma/commands/research.py` pass `kctx.paper_store` and `kctx.user_library`.

### Results
- 11 new tests in `tests/test_research_library_fallback.py`, 385 LOC added
- Total test suite: 1163 tests (was 1152)
- Lint: ruff clean
- Closes #82 success criterion: "klemma process in project B instantly finds fragments if already extracted in project A"