### PR TITLE
fix: security quick wins from periodic audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[dev]"
+      - run: pip install -e ".[dev,api]"
       - run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,17 @@ exports/
 *.swo
 .claude/settings.local.json
 
+# Project data (SQLite DBs, user content)
+.klemma/
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.cert
+credentials.json
+
 # User-specific files (use config.example.yaml as template)
 config.yaml
 .klemmarc*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ api = [
     "argon2-cffi==23.1.0",
     "python-jose[cryptography]==3.3.0",
     "pydantic[email]>=2.0",
+    "httpx>=0.27",
 ]
 recommended = ["litellm>=1.40"]
 all-ai = ["openai>=1.0", "litellm>=1.40"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Jinja2==3.1.6",
     "PyYAML==6.0.2",
     "rich==13.9.4",
-    "requests>=2.31.0",
+    "requests==2.32.3",
 ]
 
 [project.optional-dependencies]

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -167,9 +167,9 @@ SQLite backends implementing the three-tier library protocols.
 
 #### stores/user_store.py (~210 lines)
 `LocalUserStore` — SQLite-backed `UserStore` at `~/.klemma/users.db` (separate from library.db). User accounts and refresh token storage for the SaaS auth layer (ADR-009).
-- `__init__(db_path)` — creates dirs, runs `_migrate_schema()` (schema version 1)
-- `create_user(email, password_hash, name?) -> UserRecord` — raises `ValueError` on duplicate email
-- `get_user_by_email(email) -> UserRecord | None`
+- `__init__(db_path)` — creates dirs, runs `_migrate_schema()` (schema version 2)
+- `create_user(email, password_hash, name?) -> UserRecord` — normalizes email to lowercase; raises `ValueError` on duplicate
+- `get_user_by_email(email) -> UserRecord | None` — normalizes email to lowercase before lookup
 - `get_user_by_id(user_id) -> UserRecord | None`
 - `update_email_verified(user_id) -> None`
 - `save_refresh_token(user_id, token_hash, expires_at) -> None`

--- a/src/klemma/api/auth/CLAUDE.md
+++ b/src/klemma/api/auth/CLAUDE.md
@@ -25,6 +25,9 @@ JWT creation and verification.
 
 ### schemas.py (45 lines)
 Pydantic request/response models: `UserCreate`, `UserLogin`, `TokenResponse`, `RefreshRequest`, `UserResponse`.
+- `UserCreate.password`: min 8, max 128 characters
+- `UserCreate.name`: max 255 characters
+- `UserLogin.password`: min 1, max 128 characters
 
 ### deps.py (60 lines)
 FastAPI dependency injection.

--- a/src/klemma/api/auth/deps.py
+++ b/src/klemma/api/auth/deps.py
@@ -54,7 +54,9 @@ async def get_current_user(
     user = store.get_user_by_id(user_id)
     if user is None:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired access token",
+            headers={"WWW-Authenticate": "Bearer"},
         )
 
     return user

--- a/src/klemma/api/auth/schemas.py
+++ b/src/klemma/api/auth/schemas.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class UserCreate(BaseModel):
     """Registration request."""
 
     email: EmailStr
-    password: str
-    name: str = ""
+    password: str = Field(min_length=8, max_length=128)
+    name: str = Field(default="", max_length=255)
 
 
 class UserLogin(BaseModel):
     """Login request."""
 
     email: EmailStr
-    password: str
+    password: str = Field(min_length=1, max_length=128)
 
 
 class TokenResponse(BaseModel):

--- a/src/klemma/stores/user_store.py
+++ b/src/klemma/stores/user_store.py
@@ -93,15 +93,16 @@ class LocalUserStore:
         """Create a new user. Raises ValueError if email already exists."""
         user_id = uuid.uuid4().hex
         now = datetime.now(timezone.utc).isoformat()
+        email_normalized = email.strip().lower()
         with self._conn() as conn:
             try:
                 conn.execute(
                     """INSERT INTO users (user_id, email, password_hash, name, created_at)
                        VALUES (?, ?, ?, ?, ?)""",
-                    (user_id, email, password_hash, name, now),
+                    (user_id, email_normalized, password_hash, name, now),
                 )
             except sqlite3.IntegrityError:
-                raise ValueError(f"User with email {email!r} already exists")
+                raise ValueError(f"User with email {email_normalized!r} already exists")
         return UserRecord(
             user_id=user_id,
             email=email,
@@ -115,7 +116,7 @@ class LocalUserStore:
         """Look up a user by email. Returns None if not found."""
         with self._conn() as conn:
             row = conn.execute(
-                "SELECT * FROM users WHERE email = ?", (email,)
+                "SELECT * FROM users WHERE email = ?", (email.strip().lower(),)
             ).fetchone()
         if not row:
             return None

--- a/src/klemma/stores/user_store.py
+++ b/src/klemma/stores/user_store.py
@@ -15,18 +15,18 @@ from typing import Generator, Optional
 
 from ..models import UserRecord
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 
 _CREATE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS users (
     user_id         TEXT PRIMARY KEY,
-    email           TEXT NOT NULL UNIQUE,
+    email           TEXT NOT NULL UNIQUE COLLATE NOCASE,
     password_hash   TEXT NOT NULL,
     name            TEXT DEFAULT '',
     email_verified  INTEGER DEFAULT 0,
     created_at      TEXT DEFAULT (datetime('now'))
 );
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email COLLATE NOCASE);
 
 CREATE TABLE IF NOT EXISTS refresh_tokens (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -75,8 +75,12 @@ class LocalUserStore:
 
     def _migrate_schema(self, conn: sqlite3.Connection) -> None:
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        if version < _SCHEMA_VERSION:
+        if version < 1:
             conn.executescript(_CREATE_SCHEMA)
+        if version < 2:
+            # Normalize existing emails to lowercase
+            conn.execute("UPDATE users SET email = LOWER(TRIM(email))")
+        if version < _SCHEMA_VERSION:
             conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
     # ------------------------------------------------------------------ #

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -47,7 +47,7 @@ def test_register_duplicate_email(client):
     )
     resp = client.post(
         "/auth/register",
-        json={"email": "alice@example.com", "password": "other"},
+        json={"email": "alice@example.com", "password": "othersecret"},
     )
     assert resp.status_code == 409
     assert "already registered" in resp.json()["detail"]
@@ -61,6 +61,26 @@ def test_register_invalid_email(client):
     assert resp.status_code == 422
 
 
+def test_register_password_too_short(client):
+    resp = client.post(
+        "/auth/register",
+        json={"email": "short@example.com", "password": "abc"},
+    )
+    assert resp.status_code == 422
+
+
+def test_register_email_case_insensitive(client):
+    client.post(
+        "/auth/register",
+        json={"email": "Alice@Example.COM", "password": "secret123"},
+    )
+    resp = client.post(
+        "/auth/register",
+        json={"email": "alice@example.com", "password": "othersecret"},
+    )
+    assert resp.status_code == 409
+
+
 # ---------------------------------------------------------------------------
 # Login
 # ---------------------------------------------------------------------------
@@ -69,11 +89,11 @@ def test_register_invalid_email(client):
 def test_login_success(client):
     client.post(
         "/auth/register",
-        json={"email": "bob@example.com", "password": "pass123"},
+        json={"email": "bob@example.com", "password": "pass1234"},
     )
     resp = client.post(
         "/auth/login",
-        json={"email": "bob@example.com", "password": "pass123"},
+        json={"email": "bob@example.com", "password": "pass1234"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -84,11 +104,11 @@ def test_login_success(client):
 def test_login_wrong_password(client):
     client.post(
         "/auth/register",
-        json={"email": "bob@example.com", "password": "pass123"},
+        json={"email": "bob@example.com", "password": "pass1234"},
     )
     resp = client.post(
         "/auth/login",
-        json={"email": "bob@example.com", "password": "wrong"},
+        json={"email": "bob@example.com", "password": "wrongpass"},
     )
     assert resp.status_code == 401
 
@@ -96,7 +116,7 @@ def test_login_wrong_password(client):
 def test_login_nonexistent_user(client):
     resp = client.post(
         "/auth/login",
-        json={"email": "nobody@example.com", "password": "pass"},
+        json={"email": "nobody@example.com", "password": "password"},
     )
     assert resp.status_code == 401
 
@@ -109,7 +129,7 @@ def test_login_nonexistent_user(client):
 def test_me_authenticated(client):
     reg = client.post(
         "/auth/register",
-        json={"email": "carol@example.com", "password": "p", "name": "Carol"},
+        json={"email": "carol@example.com", "password": "carolpass", "name": "Carol"},
     )
     token = reg.json()["access_token"]
     resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
@@ -140,7 +160,7 @@ def test_me_invalid_token(client):
 def test_refresh_success(client):
     reg = client.post(
         "/auth/register",
-        json={"email": "dan@example.com", "password": "p"},
+        json={"email": "dan@example.com", "password": "danpass12"},
     )
     refresh_token = reg.json()["refresh_token"]
     resp = client.post("/auth/refresh", json={"refresh_token": refresh_token})
@@ -155,7 +175,7 @@ def test_refresh_success(client):
 def test_refresh_reuse_revokes_all(client):
     reg = client.post(
         "/auth/register",
-        json={"email": "eve@example.com", "password": "p"},
+        json={"email": "eve@example.com", "password": "evepass12"},
     )
     old_refresh = reg.json()["refresh_token"]
     # First refresh — succeeds

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -21,13 +21,13 @@ def store(tmp_path) -> LocalUserStore:
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_1(tmp_path):
+def test_schema_version_is_2(tmp_path):
     db_path = tmp_path / "users.db"
     LocalUserStore(db_path)
     conn = sqlite3.connect(str(db_path))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version == 1
+    assert version == 2
 
 
 def test_creates_db_file(tmp_path):


### PR DESCRIPTION
## Summary

Address low-hanging security findings from periodic security review:

- **`.gitignore`**: add `.klemma/` directory, `*.pem`, `*.key`, `*.p12`, `credentials.json` exclusions
- **Password validation**: `min_length=8`, `max_length=128` on registration; `max_length=255` on name field
- **Email normalization**: `lowercase + strip` in `user_store.py` (create and lookup) — prevents duplicate accounts via case variants
- **Error message unification**: `deps.py` returns generic "Invalid or expired access token" instead of "User not found" (prevents account deletion info leakage)
- **Pin `requests==2.32.3`**: was `>=2.31.0`, inconsistent with all other core deps being exact-pinned
- **Tests**: update all test passwords to meet 8-char minimum, add `test_register_password_too_short` and `test_register_email_case_insensitive`

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1292 passed (+2 new tests)
- [x] New test: password under 8 chars → 422
- [x] New test: `Alice@Example.COM` then `alice@example.com` → 409 duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)