### PR TITLE
fix: replace python-jose with PyJWT (#169)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ api = [
     "fastapi==0.115.12",
     "uvicorn[standard]>=0.34",
     "argon2-cffi==23.1.0",
-    "python-jose[cryptography]==3.3.0",
+    "PyJWT[crypto]==2.10.1",
     "pydantic[email]>=2.0",
     "httpx>=0.27",
 ]

--- a/src/klemma/api/auth/CLAUDE.md
+++ b/src/klemma/api/auth/CLAUDE.md
@@ -1,6 +1,6 @@
 # Auth Package
 
-JWT + argon2 authentication layer for the Klemma SaaS backend (ADR-009).
+JWT + argon2 authentication layer for the Klemma SaaS backend (ADR-009). JWT via `PyJWT[crypto]` (replaced `python-jose` due to CVE-2024-33663/33664).
 
 ## Modules
 

--- a/src/klemma/api/auth/tokens.py
+++ b/src/klemma/api/auth/tokens.py
@@ -9,7 +9,8 @@ import hashlib
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from jose import JWTError, jwt
+import jwt
+from jwt.exceptions import PyJWTError
 
 from .config import auth_config
 
@@ -49,7 +50,7 @@ def decode_token(token: str) -> dict | None:
             token, auth_config.secret_key, algorithms=[auth_config.algorithm]
         )
         return payload
-    except JWTError:
+    except PyJWTError:
         return None
 
 


### PR DESCRIPTION
## Summary

- Replace unmaintained `python-jose[cryptography]==3.3.0` with actively maintained `PyJWT[crypto]==2.10.1`
- Addresses CVE-2024-33663 (algorithm confusion) and CVE-2024-33664 (ECDSA key validation bypass)
- Near drop-in replacement: 3 lines changed in `tokens.py`

Closes #169

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1290 passed
- [x] All auth tests pass (register, login, refresh, token rotation, reuse detection)
- [x] JWT encode/decode behavior identical (verified via existing test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)