### PR TITLE
feat: add rate limiting to auth API endpoints (#170)

### DIFF
--- a/src/klemma/api/rate_limit.py
+++ b/src/klemma/api/rate_limit.py
@@ -1,0 +1,69 @@
+"""In-memory per-IP rate limiting for the Klemma API (#170).
+
+Simple token-bucket rate limiter implemented as FastAPI dependencies.
+Suitable for single-process deployment (FirstVDS VPS, ADR-009).
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Callable
+
+from fastapi import HTTPException, Request, status
+
+
+class _RateLimiter:
+    """Token-bucket rate limiter keyed by client IP."""
+
+    def __init__(self) -> None:
+        # {ip: [(timestamp, ...), ...]} — sliding window
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def check(self, ip: str, max_requests: int, window_seconds: int) -> None:
+        """Raise 429 if the IP has exceeded max_requests in the last window_seconds."""
+        now = time.monotonic()
+        cutoff = now - window_seconds
+        # Prune old entries
+        self._requests[ip] = [t for t in self._requests[ip] if t > cutoff]
+        if len(self._requests[ip]) >= max_requests:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many requests. Please try again later.",
+                headers={"Retry-After": str(window_seconds)},
+            )
+        self._requests[ip].append(now)
+
+
+_limiter = _RateLimiter()
+
+
+def reset_rate_limiter() -> None:
+    """Clear all rate limit state. Used in tests."""
+    _limiter._requests.clear()
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract client IP from request (respects X-Forwarded-For behind proxy)."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def rate_limit(max_requests: int, window_seconds: int = 60) -> Callable:
+    """Create a FastAPI dependency that enforces rate limiting.
+
+    Usage::
+
+        @router.post("/login")
+        async def login(
+            body: UserLogin,
+            _rate=Depends(rate_limit(5, 60)),  # 5 req/min
+        ):
+    """
+
+    async def dependency(request: Request) -> None:
+        _limiter.check(_get_client_ip(request), max_requests, window_seconds)
+
+    return dependency

--- a/src/klemma/api/routes/auth.py
+++ b/src/klemma/api/routes/auth.py
@@ -22,12 +22,16 @@ from ..auth.tokens import (
     hash_token,
     refresh_token_expires_at,
 )
+from ..rate_limit import rate_limit
 
 router = APIRouter()
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
-async def register(body: UserCreate) -> TokenResponse:
+async def register(
+    body: UserCreate,
+    _rate=Depends(rate_limit(3, 60)),
+) -> TokenResponse:
     """Create a new user account and return token pair."""
     store = get_user_store()
     pw_hash = hash_password(body.password)
@@ -47,7 +51,10 @@ async def register(body: UserCreate) -> TokenResponse:
 
 
 @router.post("/login", response_model=TokenResponse)
-async def login(body: UserLogin) -> TokenResponse:
+async def login(
+    body: UserLogin,
+    _rate=Depends(rate_limit(5, 60)),
+) -> TokenResponse:
     """Authenticate with email/password and return token pair."""
     store = get_user_store()
     user = store.get_user_by_email(body.email)
@@ -65,7 +72,10 @@ async def login(body: UserLogin) -> TokenResponse:
 
 
 @router.post("/refresh", response_model=TokenResponse)
-async def refresh(body: RefreshRequest) -> TokenResponse:
+async def refresh(
+    body: RefreshRequest,
+    _rate=Depends(rate_limit(10, 60)),
+) -> TokenResponse:
     """Exchange a valid refresh token for a new token pair (rotation)."""
     payload = decode_token(body.refresh_token)
     if payload is None or payload.get("type") != "refresh":

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from klemma.api.app import create_app
 from klemma.api.auth.deps import set_user_store
+from klemma.api.rate_limit import reset_rate_limiter
 from klemma.stores.user_store import LocalUserStore
 
 
@@ -20,6 +21,7 @@ def client(user_store) -> TestClient:
     app = create_app()
     # Override the lifespan-set store with our test store
     set_user_store(user_store)
+    reset_rate_limiter()
     return TestClient(app)
 
 
@@ -188,3 +190,39 @@ def test_refresh_reuse_revokes_all(client):
 def test_refresh_invalid_token(client):
     resp = client.post("/auth/refresh", json={"refresh_token": "garbage"})
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+def test_register_rate_limit(client):
+    """Registration is limited to 3 requests per minute per IP."""
+    for i in range(3):
+        client.post(
+            "/auth/register",
+            json={"email": f"rate{i}@example.com", "password": "secret123"},
+        )
+    # 4th request should be throttled
+    resp = client.post(
+        "/auth/register",
+        json={"email": "rate3@example.com", "password": "secret123"},
+    )
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+
+
+def test_login_rate_limit(client):
+    """Login is limited to 5 requests per minute per IP."""
+    for i in range(5):
+        client.post(
+            "/auth/login",
+            json={"email": f"nobody{i}@example.com", "password": "secret123"},
+        )
+    # 6th request should be throttled
+    resp = client.post(
+        "/auth/login",
+        json={"email": "nobody5@example.com", "password": "secret123"},
+    )
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary

- Add per-IP sliding-window rate limiting to auth endpoints
- `/auth/register`: 3 req/min, `/auth/login`: 5 req/min, `/auth/refresh`: 10 req/min
- Returns 429 Too Many Requests with `Retry-After` header when exceeded
- Zero new dependencies — in-memory token-bucket as FastAPI dependency (no slowapi needed)
- Supports `X-Forwarded-For` for nginx reverse proxy (ADR-009 deployment)

Closes #170

### Design decisions
- **FastAPI Depends() over decorators**: slowapi's decorators corrupt FastAPI's parameter parsing with `APIRouter`. Dependency injection is cleaner and idiomatic.
- **In-memory over Redis**: suitable for single-process VPS deployment. If multi-worker is needed later, swap to Redis-backed limiter.
- **Separate module**: `api/rate_limit.py` — reusable for future endpoints.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1292 passed (+2 new: rate limit enforcement for register and login)
- [x] 4th register request → 429 with Retry-After header
- [x] 6th login request → 429
- [x] Rate limiter state resets between tests (no cross-test contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)