### PR TITLE
fix: add JWT claims (iat/iss/aud) and disable OpenAPI docs in production (#174)

### DIFF
--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -33,13 +33,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 def create_app() -> FastAPI:
     """Application factory — creates and configures the FastAPI app."""
+    is_production = os.getenv("KLEMMA_ENV") == "production"
     app = FastAPI(
         title="Klemma API",
         description="AI-powered academic research assistant — SaaS backend",
         version=__version__,
         lifespan=lifespan,
-        docs_url="/docs",
-        redoc_url="/redoc",
+        docs_url=None if is_production else "/docs",
+        redoc_url=None if is_production else "/redoc",
+        openapi_url=None if is_production else "/openapi.json",
     )
 
     # Mount routers

--- a/src/klemma/api/auth/tokens.py
+++ b/src/klemma/api/auth/tokens.py
@@ -20,10 +20,14 @@ def create_access_token(user_id: str, email: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(
         minutes=auth_config.access_token_expire_minutes
     )
+    now = datetime.now(timezone.utc)
     payload = {
         "sub": user_id,
         "email": email,
         "exp": expire,
+        "iat": now,
+        "iss": "klemma-api",
+        "aud": "klemma",
         "type": "access",
     }
     return jwt.encode(payload, auth_config.secret_key, algorithm=auth_config.algorithm)
@@ -31,12 +35,14 @@ def create_access_token(user_id: str, email: str) -> str:
 
 def create_refresh_token(user_id: str) -> str:
     """Create a long-lived refresh token."""
-    expire = datetime.now(timezone.utc) + timedelta(
-        days=auth_config.refresh_token_expire_days
-    )
+    now = datetime.now(timezone.utc)
+    expire = now + timedelta(days=auth_config.refresh_token_expire_days)
     payload = {
         "sub": user_id,
         "exp": expire,
+        "iat": now,
+        "iss": "klemma-api",
+        "aud": "klemma",
         "type": "refresh",
         "jti": uuid.uuid4().hex,
     }
@@ -47,7 +53,11 @@ def decode_token(token: str) -> dict | None:
     """Decode and validate a JWT token. Returns payload or None if invalid."""
     try:
         payload = jwt.decode(
-            token, auth_config.secret_key, algorithms=[auth_config.algorithm]
+            token,
+            auth_config.secret_key,
+            algorithms=[auth_config.algorithm],
+            audience="klemma",
+            issuer="klemma-api",
         )
         return payload
     except PyJWTError:

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -226,3 +226,49 @@ def test_login_rate_limit(client):
         json={"email": "nobody5@example.com", "password": "secret123"},
     )
     assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# JWT claims
+# ---------------------------------------------------------------------------
+
+
+def test_access_token_contains_standard_claims(client):
+    """Access tokens must include iat, iss, aud claims."""
+    from klemma.api.auth.tokens import decode_token
+
+    reg = client.post(
+        "/auth/register",
+        json={"email": "claims@example.com", "password": "secret123"},
+    )
+    token = reg.json()["access_token"]
+    payload = decode_token(token)
+    assert payload is not None
+    assert "iat" in payload
+    assert payload["iss"] == "klemma-api"
+    assert payload["aud"] == "klemma"
+    assert payload["type"] == "access"
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI docs gating
+# ---------------------------------------------------------------------------
+
+
+def test_docs_available_in_development(client):
+    """OpenAPI docs should be available when KLEMMA_ENV is not 'production'."""
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+def test_docs_disabled_in_production(tmp_path, monkeypatch):
+    """OpenAPI docs should return 404 when KLEMMA_ENV=production."""
+    monkeypatch.setenv("KLEMMA_ENV", "production")
+    from klemma.stores.user_store import LocalUserStore
+
+    store = LocalUserStore(tmp_path / "users.db")
+    app = create_app()
+    set_user_store(store)
+    prod_client = TestClient(app)
+    resp = prod_client.get("/docs")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **JWT claims**: add `iat`, `iss: "klemma-api"`, `aud: "klemma"` to access and refresh tokens; validate `iss` and `aud` in `decode_token()` — tokens from other contexts are now rejected
- **OpenAPI docs gating**: `/docs`, `/redoc`, `/openapi.json` disabled when `KLEMMA_ENV=production` — prevents API schema reconnaissance

Closes #174

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1293 passed (+3 new)
- [x] New test: access token payload contains `iat`, `iss`, `aud` claims
- [x] New test: `/docs` returns 200 in development
- [x] New test: `/docs` returns 404 when `KLEMMA_ENV=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)