### PR TITLE
fix: use Jinja2 SandboxedEnvironment for prompt rendering (#173)

### DIFF
--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -244,11 +244,12 @@ class AIProviderBase:
         )
 
     def render_prompt(self, template_path: Path, **kwargs) -> str:
-        """Load a prompt template and render with Jinja2."""
-        from jinja2 import Template
+        """Load a prompt template and render with Jinja2 (sandboxed)."""
+        from jinja2.sandbox import SandboxedEnvironment
 
         raw = template_path.read_text(encoding="utf-8")
-        return Template(raw).render(**kwargs)
+        env = SandboxedEnvironment()
+        return env.from_string(raw).render(**kwargs)
 
     @property
     def interactive_available(self) -> bool:

--- a/src/klemma/skills/agent.py
+++ b/src/klemma/skills/agent.py
@@ -6,7 +6,7 @@ from datetime import date
 from pathlib import Path
 from typing import Optional
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from ..config import KlemmaConfig, ProjectConfig, resolve_prompt
 from ..state import StateManager
@@ -284,7 +284,7 @@ def build_agent_context(
         else Path(__file__).parent.parent.parent.parent / "prompts" / "agent.md"
     )
     raw = prompt_path.read_text(encoding="utf-8")
-    context = Template(raw).render(
+    context = SandboxedEnvironment().from_string(raw).render(
         parent_context=parent_context,
         project_context=project_context,
         chapters=chapters,


### PR DESCRIPTION
## Summary

Switch prompt template rendering from bare `jinja2.Template()` to `SandboxedEnvironment().from_string()` in two files:
- `ai.py:render_prompt()` — used by every AI command (research, ask, draft, process, outline, library)
- `skills/agent.py:build_agent_context()` — used by `klemma ask`

Prevents template injection via poisoned source metadata (e.g., a compromised Semantic Scholar API response injecting `{{config.__class__.__init__.__globals__}}` into a paper title). `SandboxedEnvironment` restricts template access to safe attribute/method access only.

Zero new dependencies — `jinja2.sandbox` is built into Jinja2.

Closes #173

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1290 passed
- [x] `test_prompts.py` — all 25 prompt template rendering tests pass (validates sandbox doesn't break existing templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)