### PR TITLE
fix: add SSRF protection to fetch_url_text() (#172)

### DIFF
--- a/src/klemma/literature/url_safety.py
+++ b/src/klemma/literature/url_safety.py
@@ -1,0 +1,43 @@
+"""URL safety validation — SSRF protection for all HTTP requests (#172).
+
+Shared by acquirer.py (PDF downloads) and web.py (URL text fetching).
+Blocks requests to private IPs, localhost, link-local, multicast, and
+reserved addresses.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+
+def is_safe_url(url: str) -> bool:
+    """Allow only safe external HTTP(S) URLs.
+
+    Rejects:
+    - Non-HTTP(S) schemes (ftp://, file://, etc.)
+    - localhost, *.local hostnames
+    - Private, loopback, link-local, multicast, reserved, unspecified IPs
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+
+    host = (parsed.hostname or "").lower()
+    if not host or host == "localhost" or host.endswith(".local"):
+        return False
+
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return True
+
+    blocked = (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+    return not blocked

--- a/src/klemma/literature/web.py
+++ b/src/klemma/literature/web.py
@@ -7,6 +7,8 @@ import logging
 import re
 from html.parser import HTMLParser
 
+from .url_safety import is_safe_url
+
 logger = logging.getLogger(__name__)
 
 _USER_AGENT = "Mozilla/5.0 (compatible; Klemma/1.0; +https://github.com/klemma-ai/klemma)"
@@ -85,6 +87,10 @@ def fetch_url_text(url: str, max_chars: int = 200_000) -> str:
     Handles gzip-encoded responses transparently (requests does this).
     """
     import requests
+
+    if not is_safe_url(url):
+        logger.warning("fetch_url_text: blocked unsafe URL '%s'", url[:60])
+        return ""
 
     try:
         resp = requests.get(

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -1,6 +1,5 @@
 """Acquire papers: download PDF → generate citekey → register in klemma."""
 
-import ipaddress
 import json
 import logging
 import re
@@ -15,6 +14,7 @@ import requests
 
 from ..hashing import compute_pdf_hash
 from ..literature.metadata import resolve_metadata
+from ..literature.url_safety import is_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -51,25 +51,11 @@ class AcquireResult:
 
 
 def _is_allowed_download_url(url: str) -> bool:
-    """Allow only safe external HTTP(S) URLs."""
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return False
+    """Allow only safe external HTTP(S) URLs.
 
-    host = (parsed.hostname or "").lower()
-    if not host or host == "localhost" or host.endswith(".local"):
-        return False
-
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return True
-
-    blocked = (
-        ip.is_private or ip.is_loopback or ip.is_link_local
-        or ip.is_multicast or ip.is_reserved or ip.is_unspecified
-    )
-    return not blocked
+    Delegates to shared ``is_safe_url`` (literature/url_safety.py).
+    """
+    return is_safe_url(url)
 
 
 def download_pdf(

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from klemma.literature.url_safety import is_safe_url
+from klemma.literature.web import fetch_url_text
 from klemma.skills import acquirer
 from klemma.stores.file_store import LocalFileStore
 from klemma.vault import VaultAdapter
@@ -54,6 +56,31 @@ def test_vault_create_note_allows_valid_path(tmp_path: Path):
     assert path.exists()
     assert path.read_text(encoding="utf-8") == "ok"
     assert path.parent == (tmp_path / "vault" / "Notes").resolve()
+
+
+def test_is_safe_url_blocks_private_ips():
+    assert not is_safe_url("http://localhost/data")
+    assert not is_safe_url("http://127.0.0.1/data")
+    assert not is_safe_url("http://192.168.1.1/data")
+    assert not is_safe_url("http://10.0.0.1/data")
+    assert not is_safe_url("ftp://example.com/data")
+    assert not is_safe_url("file:///etc/passwd")
+    assert is_safe_url("https://example.com/data")
+    assert is_safe_url("https://arxiv.org/pdf/2101.12345.pdf")
+
+
+def test_fetch_url_text_rejects_unsafe_url(monkeypatch):
+    """fetch_url_text must block SSRF-prone URLs without making a request."""
+    import requests as requests_mod
+
+    def _never_called(*args, **kwargs):
+        raise AssertionError("requests.get must not be called for blocked URL")
+
+    monkeypatch.setattr(requests_mod, "get", _never_called)
+    assert fetch_url_text("http://localhost/secret") == ""
+    assert fetch_url_text("http://127.0.0.1/secret") == ""
+    assert fetch_url_text("http://192.168.1.1/internal") == ""
+    assert fetch_url_text("ftp://example.com/file") == ""
 
 
 def test_download_pdf_rejects_unsafe_url(monkeypatch):


### PR DESCRIPTION
## Summary

- Extract URL safety validation from `acquirer.py` into shared `literature/url_safety.py`
- Apply SSRF check to `web.py:fetch_url_text()` — previously unprotected
- Both HTTP call sites in the codebase now block: private IPs, localhost, `*.local`, link-local, multicast, reserved, non-HTTP schemes
- `acquirer.py:_is_allowed_download_url()` now delegates to shared `is_safe_url()`

Closes #172

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1292 passed (+2 new)
- [x] New test: `is_safe_url` blocks localhost, private IPs, ftp; allows https
- [x] New test: `fetch_url_text` returns `""` for unsafe URLs without making HTTP requests
- [x] Existing test: `download_pdf` still rejects unsafe URLs (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)