### PR TITLE
feat: add CORS middleware to FastAPI app (#171)

### DIFF
--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from klemma import __version__
 from klemma.stores.user_store import LocalUserStore
@@ -42,6 +43,23 @@ def create_app() -> FastAPI:
         docs_url=None if is_production else "/docs",
         redoc_url=None if is_production else "/redoc",
         openapi_url=None if is_production else "/openapi.json",
+    )
+
+    # CORS — explicit origins from env, deny-all default in production
+    cors_origins_raw = os.getenv("KLEMMA_CORS_ORIGINS", "")
+    is_production = os.getenv("KLEMMA_ENV") == "production"
+    if cors_origins_raw:
+        allowed_origins = [o.strip() for o in cors_origins_raw.split(",") if o.strip()]
+    elif is_production:
+        allowed_origins = []
+    else:
+        allowed_origins = ["http://localhost:3000", "http://localhost:5173"]
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
 
     # Mount routers

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -272,3 +272,32 @@ def test_docs_disabled_in_production(tmp_path, monkeypatch):
     prod_client = TestClient(app)
     resp = prod_client.get("/docs")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+
+def test_cors_allows_configured_origin(client):
+    """Dev origins should get CORS headers."""
+    resp = client.options(
+        "/auth/login",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_blocks_unknown_origin(client):
+    """Unknown origins should not get CORS allow headers."""
+    resp = client.options(
+        "/auth/login",
+        headers={
+            "Origin": "https://evil.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert "access-control-allow-origin" not in resp.headers


### PR DESCRIPTION
## Summary

- Add `CORSMiddleware` with explicit origin configuration
- `KLEMMA_CORS_ORIGINS` env var: comma-separated allowed origins (e.g. `https://app.klemma.ai`)
- Production default (`KLEMMA_ENV=production`): deny all cross-origin requests
- Development default: allow `localhost:3000` and `localhost:5173`
- Zero new dependencies (CORSMiddleware is built into FastAPI/Starlette)

Closes #171

This is the last security item from the periodic audit. All 6 findings (#169–#174) now have PRs.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1292 passed (+2 new)
- [x] New test: configured origin (`localhost:3000`) gets CORS allow header
- [x] New test: unknown origin (`evil.com`) gets no CORS allow header

🤖 Generated with [Claude Code](https://claude.com/claude-code)