### PR TITLE
feat: add GitHub Actions deploy workflow (#99)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "production"
+        type: choice
+        options:
+          - production
+          - staging
+
+# Only one deploy at a time
+concurrency:
+  group: deploy-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            -t klemma-api:${{ github.sha }} \
+            -t klemma-api:latest \
+            -f saas/deploy/Dockerfile \
+            .
+
+      - name: Save Docker image
+        run: docker save klemma-api:latest | gzip > klemma-api.tar.gz
+
+      - name: Deploy to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          # Setup SSH
+          mkdir -p ~/.ssh
+          echo "$VPS_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          SSH_OPTS="-i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new"
+
+          # Transfer image
+          scp $SSH_OPTS klemma-api.tar.gz "${VPS_USER}@${VPS_HOST}:/tmp/"
+
+          # Transfer compose files
+          scp $SSH_OPTS -r saas/deploy/ "${VPS_USER}@${VPS_HOST}:/opt/klemma/"
+
+          # Deploy on VPS
+          ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" << 'DEPLOY_SCRIPT'
+            set -e
+            cd /opt/klemma/deploy
+
+            # Load new image
+            docker load < /tmp/klemma-api.tar.gz
+            rm /tmp/klemma-api.tar.gz
+
+            # Pull latest Redis/nginx images
+            docker compose pull redis nginx
+
+            # Restart with new image (zero-downtime: nginx healthcheck waits)
+            docker compose up -d --force-recreate api
+            docker compose up -d
+
+            # Verify health
+            sleep 5
+            curl -sf http://localhost:8000/health || exit 1
+            echo "Deploy successful"
+          DEPLOY_SCRIPT
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary

Manual-trigger GitHub Actions workflow for deploying the Klemma API to a FirstVDS VPS:

1. Builds Docker image from `saas/deploy/Dockerfile`
2. Transfers image to VPS via SCP
3. Deploys with `docker compose up -d --force-recreate`
4. Verifies health endpoint

### Design decisions
- **Manual trigger** (`workflow_dispatch`) — not auto-deploy on merge. Solopreneur needs control over when deploys happen.
- **Image transfer via SCP** — no container registry needed. Simpler ops for single-VPS setup.
- **Concurrency control** — only one deploy per environment at a time.
- **Environment support** — `production` and `staging` selectable at trigger time.

### Required setup (one-time)
1. Create GitHub environment `production` in repo settings
2. Add secrets: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`
3. On VPS: `mkdir -p /opt/klemma/deploy && cp .env.example .env` (edit with real JWT secret)

Part of #99

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1301 passed
- [x] Workflow YAML validates (GitHub Actions syntax)
- [ ] Manual: trigger workflow after VPS is provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)