### PR TITLE
feat: add projects API endpoints — coverage and section assignments (#99)

### DIFF
--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -29,14 +29,17 @@ from .routes import auth, health, library, projects
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown hooks."""
     # Startup: initialize stores
+    # SaaS Phase 1: SQLite backends via Protocol interfaces.
+    # Phase 2 swaps to PostgreSQL — same Protocols, different implementations.
+    # project.db lives in KLEMMA_DATA_DIR (not per-directory) because the SaaS
+    # API has no concept of filesystem project directories — one project per user.
     data_dir = Path(os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma")))
     user_store = LocalUserStore(data_dir / "users.db")
     set_user_store(user_store)
     library_db = data_dir / "library.db"
     set_paper_store(LocalPaperStore(library_db))
     set_user_library(LocalUserLibrary(library_db))
-    project_db = data_dir / "project.db"
-    set_project_store(LocalProjectStore(project_db))
+    set_project_store(LocalProjectStore(data_dir / "project.db"))
     yield
     # Shutdown: close connections, flush caches
 

--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -16,12 +16,13 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from klemma import __version__
 from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
 from klemma.stores.user_library import LocalUserLibrary
 from klemma.stores.user_store import LocalUserStore
 
 from .auth.deps import set_user_store
-from .deps import set_paper_store, set_user_library
-from .routes import auth, health, library
+from .deps import set_paper_store, set_project_store, set_user_library
+from .routes import auth, health, library, projects
 
 
 @asynccontextmanager
@@ -34,6 +35,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     library_db = data_dir / "library.db"
     set_paper_store(LocalPaperStore(library_db))
     set_user_library(LocalUserLibrary(library_db))
+    project_db = data_dir / "project.db"
+    set_project_store(LocalProjectStore(project_db))
     yield
     # Shutdown: close connections, flush caches
 
@@ -72,7 +75,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="/health")
     app.include_router(auth.router, prefix="/auth", tags=["auth"])
     app.include_router(library.router, prefix="/library", tags=["library"])
-    # app.include_router(projects.router, prefix="/projects", tags=["projects"])
+    app.include_router(projects.router, prefix="/projects", tags=["projects"])
     # app.include_router(process.router, prefix="/process", tags=["process"])
     # app.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
     # app.include_router(write.router, prefix="/write", tags=["write"])

--- a/src/klemma/api/deps.py
+++ b/src/klemma/api/deps.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from klemma.protocols import PaperStore, UserLibrary
+    from klemma.protocols import PaperStore, ProjectStore, UserLibrary
 
 # Module-level store references, set during app startup via lifespan.
 _paper_store: PaperStore | None = None
 _user_library: UserLibrary | None = None
+_project_store: ProjectStore | None = None
 
 
 def set_paper_store(store: PaperStore) -> None:
@@ -36,3 +37,16 @@ def get_user_library() -> UserLibrary:
     if _user_library is None:
         raise RuntimeError("UserLibrary not configured — call set_user_library() at startup")
     return _user_library
+
+
+def set_project_store(store: ProjectStore) -> None:
+    """Set the ProjectStore instance."""
+    global _project_store  # noqa: PLW0603
+    _project_store = store
+
+
+def get_project_store() -> ProjectStore:
+    """Return the configured ProjectStore, or raise if not set."""
+    if _project_store is None:
+        raise RuntimeError("ProjectStore not configured — call set_project_store() at startup")
+    return _project_store

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -24,6 +24,13 @@ Library CRUD endpoints — mounted with `prefix="/library"`. All require Bearer 
 - `DELETE /library/sources/{citekey}` → 204 — remove from user library (keeps global corpus)
 - Schemas: `SourceResponse`, `SourceListResponse`, `SourceCreateRequest`, `FragmentResponse`, `SourceDetailResponse`
 
+### projects.py (~110 lines)
+Project endpoints — mounted with `prefix="/projects"`. All require Bearer auth.
+- `GET /projects/coverage` → `CoverageStatsResponse` — total sources, per-section/chapter counts
+- `GET /projects/sections/{section}/sources` → `SectionSourcesResponse` — citekeys assigned to a section
+- `POST /projects/sections/assign` → assign source to sections (validates source exists in library)
+- `GET /projects/sources/{citekey}/sections` → sections assigned to a source
+
 ## Adding a new router
 
 1. Create `<domain>.py` with `router = APIRouter(tags=["<domain>"])` and route handlers.

--- a/src/klemma/api/routes/projects.py
+++ b/src/klemma/api/routes/projects.py
@@ -1,0 +1,110 @@
+"""Project endpoints: coverage stats and section assignments (ADR-009, #99)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from klemma.models import UserRecord
+
+from ..auth.deps import get_current_user
+from ..deps import get_project_store, get_user_library
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CoverageStatsResponse(BaseModel):
+    """Coverage statistics for the project."""
+
+    total_sources: int
+    sections: dict[str, int]
+    chapters: dict[str, int]
+
+
+class SectionSourcesResponse(BaseModel):
+    """Sources assigned to a section."""
+
+    section: str
+    citekeys: list[str]
+    count: int
+
+
+class AssignSectionRequest(BaseModel):
+    """Assign a source to sections."""
+
+    citekey: str
+    sections: list[str]
+    chapters: list[int] = []
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/coverage", response_model=CoverageStatsResponse)
+async def get_coverage(
+    user: UserRecord = Depends(get_current_user),
+) -> CoverageStatsResponse:
+    """Get coverage statistics for the project."""
+    store = get_project_store()
+    stats = store.get_coverage_stats()
+    return CoverageStatsResponse(
+        total_sources=stats["total_sources"],
+        sections={str(k): v for k, v in stats.get("sections", {}).items()},
+        chapters={str(k): v for k, v in stats.get("chapters", {}).items()},
+    )
+
+
+@router.get("/sections/{section}/sources", response_model=SectionSourcesResponse)
+async def get_section_sources(
+    section: str,
+    user: UserRecord = Depends(get_current_user),
+) -> SectionSourcesResponse:
+    """List sources assigned to a specific section."""
+    store = get_project_store()
+    citekeys = store.get_sources_by_section(section)
+    return SectionSourcesResponse(
+        section=section,
+        citekeys=citekeys,
+        count=len(citekeys),
+    )
+
+
+@router.post("/sections/assign", status_code=status.HTTP_200_OK)
+async def assign_source_sections(
+    body: AssignSectionRequest,
+    user: UserRecord = Depends(get_current_user),
+) -> dict:
+    """Assign a source to sections in the project."""
+    store = get_project_store()
+    library = get_user_library()
+
+    # Verify source exists in user's library
+    src = library.get_source_by_citekey(body.citekey)
+    if src is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Source '{body.citekey}' not found in library",
+        )
+
+    store.set_source_sections(
+        body.citekey, src.paper_id, body.sections, body.chapters
+    )
+    return {"citekey": body.citekey, "sections": body.sections}
+
+
+@router.get("/sources/{citekey}/sections")
+async def get_source_sections(
+    citekey: str,
+    user: UserRecord = Depends(get_current_user),
+) -> dict:
+    """Get sections assigned to a source in the project."""
+    store = get_project_store()
+    sections = store.get_source_sections(citekey)
+    return {"citekey": citekey, "sections": sections}

--- a/src/klemma/protocols.py
+++ b/src/klemma/protocols.py
@@ -107,6 +107,14 @@ class ProjectStore(Protocol):
 
     def get_coverage_stats(self) -> dict: ...
 
+    def get_sources_by_section(self, section: str) -> list[str]:
+        """Return citekeys assigned to a section."""
+        ...
+
+    def get_source_sections(self, citekey: str) -> list[str]:
+        """Return section list for a citekey."""
+        ...
+
     def get_reference_gaps(self, **kwargs: object) -> list[dict]: ...
 
 

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -1,0 +1,179 @@
+"""Tests for projects API endpoints (ADR-009, #99)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from klemma.api.app import create_app
+from klemma.api.auth.deps import set_user_store
+from klemma.api.deps import set_paper_store, set_project_store, set_user_library
+from klemma.api.rate_limit import reset_rate_limiter
+from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
+from klemma.stores.user_library import LocalUserLibrary
+from klemma.stores.user_store import LocalUserStore
+
+
+@pytest.fixture
+def stores(tmp_path):
+    user_store = LocalUserStore(tmp_path / "users.db")
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    project_store = LocalProjectStore(tmp_path / "project.db")
+    return user_store, paper_store, user_library, project_store
+
+
+@pytest.fixture
+def client(stores) -> TestClient:
+    user_store, paper_store, user_library, project_store = stores
+    app = create_app()
+    set_user_store(user_store)
+    set_paper_store(paper_store)
+    set_user_library(user_library)
+    set_project_store(project_store)
+    reset_rate_limiter()
+    return TestClient(app)
+
+
+def _auth_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/register",
+        json={"email": "proj@example.com", "password": "secret123"},
+    )
+    return resp.json()["access_token"]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _add_source(client, token, citekey="smithML2020"):
+    """Add a source to the library for section assignment."""
+    client.post(
+        "/library/sources",
+        json={"citekey": citekey, "title": f"Paper {citekey}", "authors": "Test"},
+        headers=_headers(token),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage stats
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_empty(client):
+    token = _auth_token(client)
+    resp = client.get("/projects/coverage", headers=_headers(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_sources"] == 0
+    assert data["sections"] == {}
+    assert data["chapters"] == {}
+
+
+def test_coverage_after_assignment(client):
+    token = _auth_token(client)
+    _add_source(client, token, "smithML2020")
+    client.post(
+        "/projects/sections/assign",
+        json={"citekey": "smithML2020", "sections": ["2.1", "2.3"], "chapters": [2, 2]},
+        headers=_headers(token),
+    )
+    resp = client.get("/projects/coverage", headers=_headers(token))
+    data = resp.json()
+    assert data["total_sources"] == 1
+    assert data["sections"]["2.1"] == 1
+    assert data["sections"]["2.3"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Section sources
+# ---------------------------------------------------------------------------
+
+
+def test_section_sources_empty(client):
+    token = _auth_token(client)
+    resp = client.get("/projects/sections/1.1/sources", headers=_headers(token))
+    assert resp.status_code == 200
+    assert resp.json()["citekeys"] == []
+    assert resp.json()["count"] == 0
+
+
+def test_section_sources_after_assignment(client):
+    token = _auth_token(client)
+    _add_source(client, token)
+    client.post(
+        "/projects/sections/assign",
+        json={"citekey": "smithML2020", "sections": ["1.3"], "chapters": [1]},
+        headers=_headers(token),
+    )
+    resp = client.get("/projects/sections/1.3/sources", headers=_headers(token))
+    data = resp.json()
+    assert "smithML2020" in data["citekeys"]
+    assert data["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Assign sections
+# ---------------------------------------------------------------------------
+
+
+def test_assign_sections(client):
+    token = _auth_token(client)
+    _add_source(client, token)
+    resp = client.post(
+        "/projects/sections/assign",
+        json={"citekey": "smithML2020", "sections": ["2.1"], "chapters": [2]},
+        headers=_headers(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["sections"] == ["2.1"]
+
+
+def test_assign_sections_source_not_in_library(client):
+    token = _auth_token(client)
+    resp = client.post(
+        "/projects/sections/assign",
+        json={"citekey": "nonexistent", "sections": ["1.1"], "chapters": [1]},
+        headers=_headers(token),
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Source sections
+# ---------------------------------------------------------------------------
+
+
+def test_get_source_sections(client):
+    token = _auth_token(client)
+    _add_source(client, token)
+    client.post(
+        "/projects/sections/assign",
+        json={"citekey": "smithML2020", "sections": ["1.1", "2.3"], "chapters": [1, 2]},
+        headers=_headers(token),
+    )
+    resp = client.get("/projects/sources/smithML2020/sections", headers=_headers(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "1.1" in data["sections"]
+    assert "2.3" in data["sections"]
+
+
+def test_get_source_sections_unassigned(client):
+    token = _auth_token(client)
+    resp = client.get("/projects/sources/nobody/sections", headers=_headers(token))
+    assert resp.status_code == 200
+    assert resp.json()["sections"] == []
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_requires_auth(client):
+    resp = client.get("/projects/coverage")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Second domain API for the SaaS backend — exposes the Map step (section assignments and coverage) over HTTP:

- `GET /projects/coverage` — total sources, per-section and per-chapter source counts
- `GET /projects/sections/{section}/sources` — list citekeys assigned to a section
- `POST /projects/sections/assign` — assign a source to sections (validates source exists in library first)
- `GET /projects/sources/{citekey}/sections` — list sections assigned to a source

All endpoints require Bearer authentication. Built on `LocalProjectStore` (ADR-014).

### Supporting changes
- `api/deps.py` — added `ProjectStore` dependency (set/get)
- `app.py` — initialize `LocalProjectStore` in lifespan, mount projects router
- `routes/CLAUDE.md` — documented new endpoints

Part of #99

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1319 passed (+9 new)
- [x] Coverage stats: empty → 0; after assignment → correct counts
- [x] Section sources: empty list; after assignment → correct citekeys
- [x] Assign: validates source in library; 404 if not found
- [x] Source sections: returns assigned sections; empty for unassigned
- [x] Auth required → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)