### PR TITLE
feat: add /analyze/status endpoint (#99)

### DIFF
--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -22,7 +22,7 @@ from klemma.stores.user_store import LocalUserStore
 
 from .auth.deps import set_user_store
 from .deps import set_paper_store, set_project_store, set_user_library
-from .routes import auth, health, library, projects
+from .routes import analyze, auth, health, library, projects
 
 
 @asynccontextmanager
@@ -79,8 +79,8 @@ def create_app() -> FastAPI:
     app.include_router(auth.router, prefix="/auth", tags=["auth"])
     app.include_router(library.router, prefix="/library", tags=["library"])
     app.include_router(projects.router, prefix="/projects", tags=["projects"])
+    app.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
     # app.include_router(process.router, prefix="/process", tags=["process"])
-    # app.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
     # app.include_router(write.router, prefix="/write", tags=["write"])
 
     return app

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -31,6 +31,10 @@ Project endpoints — mounted with `prefix="/projects"`. All require Bearer auth
 - `POST /projects/sections/assign` → assign source to sections (validates source exists in library)
 - `GET /projects/sources/{citekey}/sections` → sections assigned to a source
 
+### analyze.py (~90 lines)
+Analyze endpoints — mounted with `prefix="/analyze"`. All require Bearer auth.
+- `GET /analyze/status` → `StatusResponse` — source counts (total/completed/pending/failed), coverage by section, total fragment count. SaaS equivalent of `klemma status`.
+
 ## Adding a new router
 
 1. Create `<domain>.py` with `router = APIRouter(tags=["<domain>"])` and route handlers.

--- a/src/klemma/api/routes/analyze.py
+++ b/src/klemma/api/routes/analyze.py
@@ -1,0 +1,92 @@
+"""Analyze endpoints: status, coverage, gaps (ADR-009, #99)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from klemma.models import UserRecord
+
+from ..auth.deps import get_current_user
+from ..deps import get_paper_store, get_project_store, get_user_library
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class SourceStats(BaseModel):
+    """Summary statistics for the user's sources."""
+
+    total: int
+    completed: int
+    pending: int
+    failed: int
+
+
+class SectionCoverage(BaseModel):
+    """Coverage data for a single section."""
+
+    section: str
+    source_count: int
+
+
+class StatusResponse(BaseModel):
+    """Full project status — the SaaS equivalent of `klemma status`."""
+
+    sources: SourceStats
+    coverage: list[SectionCoverage]
+    total_fragments: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/status", response_model=StatusResponse)
+async def get_status(
+    user: UserRecord = Depends(get_current_user),
+) -> StatusResponse:
+    """Get project status: source counts, coverage by section, fragment count.
+
+    This is the SaaS equivalent of `klemma status` — the most-used CLI command.
+    Composes data from UserLibrary (source counts) and ProjectStore (coverage).
+    """
+    library = get_user_library()
+    project_store = get_project_store()
+    paper_store = get_paper_store()
+
+    # Source counts by status
+    all_sources = library.get_all_sources()
+    completed = sum(1 for s in all_sources if s.status == "completed")
+    pending = sum(1 for s in all_sources if s.status == "pending")
+    failed = sum(1 for s in all_sources if s.status == "failed")
+
+    # Coverage by section from ProjectStore
+    stats = project_store.get_coverage_stats()
+    sections = stats.get("sections", {})
+    coverage = [
+        SectionCoverage(section=str(sec), source_count=cnt)
+        for sec, cnt in sorted(sections.items())
+    ]
+
+    # Total fragments across all sources
+    total_fragments = 0
+    for src in all_sources:
+        frags = paper_store.get_fragments(src.paper_id)
+        total_fragments += len(frags)
+
+    return StatusResponse(
+        sources=SourceStats(
+            total=len(all_sources),
+            completed=completed,
+            pending=pending,
+            failed=failed,
+        ),
+        coverage=coverage,
+        total_fragments=total_fragments,
+    )

--- a/tests/test_analyze_api.py
+++ b/tests/test_analyze_api.py
@@ -1,0 +1,105 @@
+"""Tests for analyze API endpoints (ADR-009, #99)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from klemma.api.app import create_app
+from klemma.api.auth.deps import set_user_store
+from klemma.api.deps import set_paper_store, set_project_store, set_user_library
+from klemma.api.rate_limit import reset_rate_limiter
+from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
+from klemma.stores.user_library import LocalUserLibrary
+from klemma.stores.user_store import LocalUserStore
+
+
+@pytest.fixture
+def stores(tmp_path):
+    user_store = LocalUserStore(tmp_path / "users.db")
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    project_store = LocalProjectStore(tmp_path / "project.db")
+    return user_store, paper_store, user_library, project_store
+
+
+@pytest.fixture
+def client(stores) -> TestClient:
+    user_store, paper_store, user_library, project_store = stores
+    app = create_app()
+    set_user_store(user_store)
+    set_paper_store(paper_store)
+    set_user_library(user_library)
+    set_project_store(project_store)
+    reset_rate_limiter()
+    return TestClient(app)
+
+
+def _auth_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/register",
+        json={"email": "analyze@example.com", "password": "secret123"},
+    )
+    return resp.json()["access_token"]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+def test_status_empty(client):
+    token = _auth_token(client)
+    resp = client.get("/analyze/status", headers=_headers(token))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sources"]["total"] == 0
+    assert data["sources"]["completed"] == 0
+    assert data["sources"]["pending"] == 0
+    assert data["coverage"] == []
+    assert data["total_fragments"] == 0
+
+
+def test_status_with_sources(client):
+    token = _auth_token(client)
+    # Add a source via library API
+    client.post(
+        "/library/sources",
+        json={"citekey": "smithML2020", "title": "ML Paper", "authors": "Smith"},
+        headers=_headers(token),
+    )
+    resp = client.get("/analyze/status", headers=_headers(token))
+    data = resp.json()
+    assert data["sources"]["total"] == 1
+    assert data["sources"]["pending"] == 1  # default status
+
+
+def test_status_with_coverage(client):
+    token = _auth_token(client)
+    # Add source + assign to section
+    client.post(
+        "/library/sources",
+        json={"citekey": "jonesNLP2019", "title": "NLP Paper"},
+        headers=_headers(token),
+    )
+    client.post(
+        "/projects/sections/assign",
+        json={"citekey": "jonesNLP2019", "sections": ["2.1"], "chapters": [2]},
+        headers=_headers(token),
+    )
+    resp = client.get("/analyze/status", headers=_headers(token))
+    data = resp.json()
+    assert len(data["coverage"]) == 1
+    assert data["coverage"][0]["section"] == "2.1"
+    assert data["coverage"][0]["source_count"] == 1
+
+
+def test_status_requires_auth(client):
+    resp = client.get("/analyze/status")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

SaaS equivalent of `klemma status` — the most-used CLI command:

- `GET /analyze/status` → source counts (total/completed/pending/failed), coverage by section, total fragment count

Composes data from all three tiers: UserLibrary (source status) + ProjectStore (section coverage) + PaperStore (fragment counts). No AI calls, no async jobs — pure data aggregation.

Part of #99

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1323 passed (+4 new)
- [x] Empty status → all zeros
- [x] After adding source → total=1, pending=1
- [x] After section assignment → coverage includes section
- [x] Auth required → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)