### PR TITLE
feat: add Redis + rq async job infrastructure (#186)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ api = [
     "PyJWT[crypto]==2.10.1",
     "pydantic[email]>=2.0",
     "httpx>=0.27",
+    "redis==5.3.0",
+    "rq==2.3.2",
 ]
 recommended = ["litellm>=1.40"]
 all-ai = ["openai>=1.0", "litellm>=1.40"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ api = [
     "PyJWT[crypto]==2.10.1",
     "pydantic[email]>=2.0",
     "httpx>=0.27",
-    "redis==5.3.0",
-    "rq==2.3.2",
+    "redis>=5.0",
+    "rq>=2.0",
 ]
 recommended = ["litellm>=1.40"]
 all-ai = ["openai>=1.0", "litellm>=1.40"]

--- a/saas/deploy/docker-compose.yml
+++ b/saas/deploy/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - KLEMMA_DATA_DIR=/data/klemma
       - KLEMMA_JWT_SECRET=${KLEMMA_JWT_SECRET}
       - KLEMMA_CORS_ORIGINS=${KLEMMA_CORS_ORIGINS:-}
+      - REDIS_URL=redis://redis:6379
     volumes:
       - klemma-data:/data/klemma
     # No host port — only nginx reaches the API via Docker network
@@ -22,6 +23,21 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+
+  worker:
+    build:
+      context: ../..
+      dockerfile: saas/deploy/Dockerfile
+    command: ["python", "-m", "klemma.api.worker"]
+    environment:
+      - KLEMMA_DATA_DIR=/data/klemma
+      - REDIS_URL=redis://redis:6379
+    volumes:
+      - klemma-data:/data/klemma
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine

--- a/src/klemma/api/CLAUDE.md
+++ b/src/klemma/api/CLAUDE.md
@@ -19,6 +19,13 @@ Shared FastAPI dependencies for data store access.
 - `set_user_library(lib)` / `get_user_library()` — module-level `UserLibrary` singleton
 - Both set in `app.py` lifespan, used by route handlers via `Depends()`
 
+### tasks.py (~60 lines)
+Async task definitions for rq worker. Tasks receive primitive args (worker runs in separate process).
+- `process_source(paper_id, citekey, data_dir)` — extraction task stub (initializes own stores)
+
+### worker.py (~25 lines)
+RQ worker entry point: `python -m klemma.api.worker`
+
 ### routes/
 Route modules. See [routes/CLAUDE.md](routes/CLAUDE.md).
 
@@ -32,7 +39,7 @@ Route modules. See [routes/CLAUDE.md](routes/CLAUDE.md).
 
 Docker Compose stack in `saas/deploy/`:
 - `Dockerfile` — Python 3.12, installs `[api,recommended]`, uvicorn 2 workers
-- `docker-compose.yml` — 4 services: api, redis, nginx, certbot
+- `docker-compose.yml` — 5 services: api, worker, redis, nginx, certbot
 - `nginx/default.conf` — reverse proxy, security headers, XFF override
 - `.env.example` — required secrets (JWT secret)
 

--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -22,7 +22,7 @@ from klemma.stores.user_store import LocalUserStore
 
 from .auth.deps import set_user_store
 from .deps import set_paper_store, set_project_store, set_user_library
-from .routes import analyze, auth, health, library, projects
+from .routes import analyze, auth, health, library, process, projects
 
 
 @asynccontextmanager
@@ -80,7 +80,7 @@ def create_app() -> FastAPI:
     app.include_router(library.router, prefix="/library", tags=["library"])
     app.include_router(projects.router, prefix="/projects", tags=["projects"])
     app.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
-    # app.include_router(process.router, prefix="/process", tags=["process"])
+    app.include_router(process.router, prefix="/process", tags=["process"])
     # app.include_router(write.router, prefix="/write", tags=["write"])
 
     return app

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -31,6 +31,13 @@ Project endpoints — mounted with `prefix="/projects"`. All require Bearer auth
 - `POST /projects/sections/assign` → assign source to sections (validates source exists in library)
 - `GET /projects/sources/{citekey}/sections` → sections assigned to a source
 
+### process.py (~120 lines)
+Process endpoints — mounted with `prefix="/process"`. All require Bearer auth.
+- `POST /process/sources/{citekey}` → `JobSubmitResponse` (202) — enqueue async extraction job
+- `GET /process/jobs/{job_id}` → `JobStatusResponse` — poll job status (queued/started/finished/failed)
+- Requires Redis + rq; returns 503 if unavailable
+- Worker entry point: `python -m klemma.api.worker`
+
 ### analyze.py (~90 lines)
 Analyze endpoints — mounted with `prefix="/analyze"`. All require Bearer auth.
 - `GET /analyze/status` → `StatusResponse` — source counts (total/completed/pending/failed), coverage by section, total fragment count. SaaS equivalent of `klemma status`.

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -1,0 +1,124 @@
+"""Process endpoints: async job submission and status (ADR-009, #186)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from klemma.models import UserRecord
+
+from ..auth.deps import get_current_user
+from ..deps import get_user_library
+
+try:
+    from redis import Redis
+    from rq import Queue
+    from rq.job import Job
+
+    _RQ_AVAILABLE = True
+except ImportError:
+    _RQ_AVAILABLE = False
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class JobSubmitResponse(BaseModel):
+    """Response when a job is enqueued."""
+
+    job_id: str
+    status: str
+    citekey: str
+
+
+class JobStatusResponse(BaseModel):
+    """Job status check response."""
+
+    job_id: str
+    status: str  # queued, started, finished, failed, deferred
+    result: dict | None = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/sources/{citekey}",
+    response_model=JobSubmitResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_process_job(
+    citekey: str,
+    user: UserRecord = Depends(get_current_user),
+) -> JobSubmitResponse:
+    """Enqueue a source for async extraction processing.
+
+    Returns 202 with a job_id that can be polled via GET /process/jobs/{job_id}.
+    """
+    if not _RQ_AVAILABLE:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis/rq not available — install klemma[api]",
+        )
+
+    library = get_user_library()
+    src = library.get_source_by_citekey(citekey)
+    if src is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Source '{citekey}' not found in library",
+        )
+
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    redis_conn = Redis.from_url(redis_url)
+    q = Queue(connection=redis_conn)
+
+    from ..tasks import process_source
+
+    data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
+    job = q.enqueue(
+        process_source,
+        src.paper_id,
+        citekey,
+        data_dir,
+        job_timeout=300,
+    )
+    return JobSubmitResponse(job_id=job.id, status="queued", citekey=citekey)
+
+
+@router.get("/jobs/{job_id}", response_model=JobStatusResponse)
+async def get_job_status(
+    job_id: str,
+    user: UserRecord = Depends(get_current_user),
+) -> JobStatusResponse:
+    """Check the status of an async processing job."""
+    if not _RQ_AVAILABLE:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis/rq not available",
+        )
+
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+        redis_conn = Redis.from_url(redis_url)
+        job = Job.fetch(job_id, connection=redis_conn)
+
+        return JobStatusResponse(
+            job_id=job_id,
+            status=job.get_status(),
+            result=job.result if job.is_finished else None,
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job '{job_id}' not found",
+        )

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -78,21 +78,27 @@ async def submit_process_job(
             detail=f"Source '{citekey}' not found in library",
         )
 
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
-    redis_conn = Redis.from_url(redis_url)
-    q = Queue(connection=redis_conn)
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+        redis_conn = Redis.from_url(redis_url)
+        q = Queue(connection=redis_conn)
 
-    from ..tasks import process_source
+        from ..tasks import process_source
 
-    data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
-    job = q.enqueue(
-        process_source,
-        src.paper_id,
-        citekey,
-        data_dir,
-        job_timeout=300,
-    )
-    return JobSubmitResponse(job_id=job.id, status="queued", citekey=citekey)
+        data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
+        job = q.enqueue(
+            process_source,
+            src.paper_id,
+            citekey,
+            data_dir,
+            job_timeout=300,
+        )
+        return JobSubmitResponse(job_id=job.id, status="queued", citekey=citekey)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Redis unavailable: {type(exc).__name__}",
+        )
 
 
 @router.get("/jobs/{job_id}", response_model=JobStatusResponse)
@@ -107,6 +113,8 @@ async def get_job_status(
             detail="Redis/rq not available",
         )
 
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
     try:
         redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
         redis_conn = Redis.from_url(redis_url)
@@ -116,6 +124,11 @@ async def get_job_status(
             job_id=job_id,
             status=job.get_status(),
             result=job.result if job.is_finished else None,
+        )
+    except RedisConnectionError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis unavailable",
         )
     except Exception:
         raise HTTPException(

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -1,0 +1,61 @@
+"""Async task definitions for rq worker (ADR-009, #186).
+
+Tasks are enqueued by API endpoints and executed by the rq worker process.
+Each task receives primitive arguments (strings, dicts) — no store objects
+or connections, since the worker runs in a separate process.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
+    """Extract fragments from a paper's PDF.
+
+    This is the rq task equivalent of `klemma process <citekey>`.
+    Runs in the worker process — initializes its own stores.
+
+    Returns a dict with status and fragment count.
+    """
+    from klemma.stores.paper_store import LocalPaperStore
+    from klemma.stores.user_library import LocalUserLibrary
+
+    data_path = Path(data_dir)
+    library_db = data_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+
+    # Check paper exists
+    paper = paper_store.get_paper_by_id(paper_id)
+    if paper is None:
+        return {"status": "error", "detail": f"Paper {paper_id} not found"}
+
+    # Check if already processed (has fragments)
+    existing = paper_store.get_fragments(paper_id)
+    if existing:
+        user_library.update_status(citekey, "completed")
+        return {
+            "status": "already_processed",
+            "citekey": citekey,
+            "fragment_count": len(existing),
+        }
+
+    # Mark as processing
+    user_library.update_status(citekey, "processing")
+
+    # TODO: actual AI extraction will be wired here when the extraction
+    # pipeline is adapted for headless (no CLI) operation. For now, mark
+    # as pending — extraction requires PDF file access + AI backend config
+    # which aren't yet available in the SaaS context.
+    logger.info("process_source: %s (%s) — extraction not yet wired", citekey, paper_id)
+    user_library.update_status(citekey, "pending")
+
+    return {
+        "status": "pending",
+        "citekey": citekey,
+        "detail": "Extraction pipeline not yet wired for SaaS",
+    }

--- a/src/klemma/api/worker.py
+++ b/src/klemma/api/worker.py
@@ -1,0 +1,28 @@
+"""RQ worker entry point for async job processing (ADR-009, #186).
+
+Usage:
+    rq worker --url redis://localhost:6379
+
+Or via Docker Compose (saas/deploy/docker-compose.yml worker service).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    """Start the rq worker."""
+    from redis import Redis
+    from rq import Worker
+
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    redis_conn = Redis.from_url(redis_url)
+
+    worker = Worker(["default"], connection=redis_conn)
+    worker.work()
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -1,0 +1,154 @@
+"""Tests for process API endpoints (ADR-009, #186)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from klemma.api.app import create_app
+from klemma.api.auth.deps import set_user_store
+from klemma.api.deps import set_paper_store, set_project_store, set_user_library
+from klemma.api.rate_limit import reset_rate_limiter
+from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
+from klemma.stores.user_library import LocalUserLibrary
+from klemma.stores.user_store import LocalUserStore
+
+
+@pytest.fixture
+def stores(tmp_path):
+    user_store = LocalUserStore(tmp_path / "users.db")
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    project_store = LocalProjectStore(tmp_path / "project.db")
+    return user_store, paper_store, user_library, project_store
+
+
+@pytest.fixture
+def client(stores) -> TestClient:
+    user_store, paper_store, user_library, project_store = stores
+    app = create_app()
+    set_user_store(user_store)
+    set_paper_store(paper_store)
+    set_user_library(user_library)
+    set_project_store(project_store)
+    reset_rate_limiter()
+    return TestClient(app)
+
+
+def _auth_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/register",
+        json={"email": "proc@example.com", "password": "secret123"},
+    )
+    return resp.json()["access_token"]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _add_source(client, token, citekey="smithML2020"):
+    client.post(
+        "/library/sources",
+        json={"citekey": citekey, "title": f"Paper {citekey}"},
+        headers=_headers(token),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submit process job
+# ---------------------------------------------------------------------------
+
+
+def test_submit_process_source_not_found(client):
+    token = _auth_token(client)
+    resp = client.post("/process/sources/nonexistent", headers=_headers(token))
+    assert resp.status_code == 404
+
+
+def test_submit_process_enqueues_job(client, monkeypatch):
+    token = _auth_token(client)
+    _add_source(client, token)
+
+    mock_job = MagicMock()
+    mock_job.id = "test-job-123"
+    mock_queue_instance = MagicMock()
+    mock_queue_instance.enqueue.return_value = mock_job
+
+    # Patch the module-level imports in process.py
+    import klemma.api.routes.process as proc_mod
+
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(proc_mod, "Redis", MagicMock())
+    monkeypatch.setattr(proc_mod, "Queue", MagicMock(return_value=mock_queue_instance))
+
+    resp = client.post("/process/sources/smithML2020", headers=_headers(token))
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["job_id"] == "test-job-123"
+    assert data["status"] == "queued"
+    assert data["citekey"] == "smithML2020"
+
+
+# ---------------------------------------------------------------------------
+# Job status
+# ---------------------------------------------------------------------------
+
+
+def test_job_status_finished(client, monkeypatch):
+    token = _auth_token(client)
+
+    mock_job = MagicMock()
+    mock_job.get_status.return_value = "finished"
+    mock_job.is_finished = True
+    mock_job.result = {"status": "ok", "fragment_count": 5}
+
+    import klemma.api.routes.process as proc_mod
+
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(proc_mod, "Redis", MagicMock())
+    mock_job_cls = MagicMock()
+    mock_job_cls.fetch.return_value = mock_job
+    monkeypatch.setattr(proc_mod, "Job", mock_job_cls)
+
+    resp = client.get("/process/jobs/test-123", headers=_headers(token))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "finished"
+    assert data["result"]["fragment_count"] == 5
+
+
+def test_job_status_not_found(client, monkeypatch):
+    token = _auth_token(client)
+
+    import klemma.api.routes.process as proc_mod
+
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(proc_mod, "Redis", MagicMock())
+    mock_job_cls = MagicMock()
+    mock_job_cls.fetch.side_effect = Exception("No such job")
+    monkeypatch.setattr(proc_mod, "Job", mock_job_cls)
+
+    resp = client.get("/process/jobs/nonexistent", headers=_headers(token))
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+
+def test_process_requires_auth(client):
+    resp = client.post("/process/sources/anything")
+    assert resp.status_code == 403
+
+
+def test_job_status_requires_auth(client):
+    resp = client.get("/process/jobs/anything")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Async job processing infrastructure for the SaaS backend — enables long-running AI operations (30-120s) without blocking HTTP requests:

- `POST /process/sources/{citekey}` → enqueue extraction job, returns 202 with job_id
- `GET /process/jobs/{job_id}` → poll job status (queued/started/finished/failed/result)
- `api/tasks.py` — task definitions with process_source stub (wired to AI extraction later)
- `api/worker.py` — rq worker entry point (`python -m klemma.api.worker`)
- Docker Compose worker service with `REDIS_URL` wiring

### Design
- Redis + rq chosen per ADR-009 (minimal, Python-native, single-VPS appropriate)
- Tasks receive primitive args (strings) — worker initializes its own stores (separate process)
- Graceful degradation: returns 503 if Redis/rq not installed
- Tests mock rq via monkeypatch (no Redis in CI)

Closes #186 | Part of #99

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1329 passed (+6 new)
- [x] Submit: source not found → 404
- [x] Submit: enqueues job → 202 with job_id (mocked rq)
- [x] Status: finished job → result dict
- [x] Status: unknown job → 404
- [x] Auth required on both endpoints → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)