### PR TITLE
feat: add /write/* API endpoints — research and draft generation (#99)

### DIFF
--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -22,7 +22,7 @@ from klemma.stores.user_store import LocalUserStore
 
 from .auth.deps import set_user_store
 from .deps import set_paper_store, set_project_store, set_user_library
-from .routes import analyze, auth, health, library, process, projects
+from .routes import analyze, auth, health, library, process, projects, write
 
 
 @asynccontextmanager
@@ -81,6 +81,6 @@ def create_app() -> FastAPI:
     app.include_router(projects.router, prefix="/projects", tags=["projects"])
     app.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
     app.include_router(process.router, prefix="/process", tags=["process"])
-    # app.include_router(write.router, prefix="/write", tags=["write"])
+    app.include_router(write.router, prefix="/write", tags=["write"])
 
     return app

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -42,6 +42,13 @@ Process endpoints — mounted with `prefix="/process"`. All require Bearer auth.
 Analyze endpoints — mounted with `prefix="/analyze"`. All require Bearer auth.
 - `GET /analyze/status` → `StatusResponse` — source counts (total/completed/pending/failed), coverage by section, total fragment count. SaaS equivalent of `klemma status`.
 
+### write.py (~110 lines)
+Write endpoints — mounted with `prefix="/write"`. All require Bearer auth.
+- `POST /write/research` → `WriteJobResponse` (202) — enqueue research briefing job
+- `POST /write/draft` → `WriteJobResponse` (202) — enqueue section draft job
+- Jobs polled via shared `GET /process/jobs/{job_id}`
+- Task stubs in `api/tasks.py` (AI pipeline not yet wired for headless SaaS)
+
 ## Adding a new router
 
 1. Create `<domain>.py` with `router = APIRouter(tags=["<domain>"])` and route handlers.

--- a/src/klemma/api/routes/write.py
+++ b/src/klemma/api/routes/write.py
@@ -1,0 +1,114 @@
+"""Write endpoints: research briefings and draft generation (ADR-009, #99)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from klemma.models import UserRecord
+
+from ..auth.deps import get_current_user
+
+try:
+    from redis import Redis
+    from rq import Queue
+
+    _RQ_AVAILABLE = True
+except ImportError:
+    _RQ_AVAILABLE = False
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class WriteJobRequest(BaseModel):
+    """Request to generate research briefing or draft for a section."""
+
+    section: str
+
+
+class WriteJobResponse(BaseModel):
+    """Response when a write job is enqueued."""
+
+    job_id: str
+    status: str
+    section: str
+    task_type: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/research",
+    response_model=WriteJobResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_research_job(
+    body: WriteJobRequest,
+    user: UserRecord = Depends(get_current_user),
+) -> WriteJobResponse:
+    """Enqueue a research briefing generation for a section.
+
+    Returns 202 with a job_id. Poll status via GET /process/jobs/{job_id}.
+    """
+    return _enqueue_write_task("generate_research", body.section)
+
+
+@router.post(
+    "/draft",
+    response_model=WriteJobResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def submit_draft_job(
+    body: WriteJobRequest,
+    user: UserRecord = Depends(get_current_user),
+) -> WriteJobResponse:
+    """Enqueue a section draft generation.
+
+    Returns 202 with a job_id. Poll status via GET /process/jobs/{job_id}.
+    """
+    return _enqueue_write_task("generate_draft", body.section)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _enqueue_write_task(task_name: str, section: str) -> WriteJobResponse:
+    """Enqueue a write task (research or draft) via rq."""
+    if not _RQ_AVAILABLE:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis/rq not available — install klemma[api]",
+        )
+
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+        redis_conn = Redis.from_url(redis_url)
+        q = Queue(connection=redis_conn)
+
+        from ..tasks import generate_draft, generate_research
+
+        task_fn = generate_research if task_name == "generate_research" else generate_draft
+        data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
+
+        job = q.enqueue(task_fn, section, data_dir, job_timeout=600)
+        return WriteJobResponse(
+            job_id=job.id, status="queued", section=section, task_type=task_name
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Redis unavailable: {type(exc).__name__}",
+        )

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -59,3 +59,40 @@ def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
         "citekey": citekey,
         "detail": "Extraction pipeline not yet wired for SaaS",
     }
+
+
+def generate_research(section: str, data_dir: str) -> dict:
+    """Generate a research briefing for a section.
+
+    This is the rq task equivalent of `klemma research -s <section>`.
+    Runs in the worker process — initializes its own stores.
+
+    Returns a dict with status and content.
+    """
+    # TODO: wire to researcher.research_section() when adapted for headless mode.
+    # Requires: AI backend config, fragment RAG, outline context — none available
+    # in SaaS context yet.
+    logger.info("generate_research: section %s — not yet wired", section)
+    return {
+        "status": "pending",
+        "section": section,
+        "detail": "Research pipeline not yet wired for SaaS",
+    }
+
+
+def generate_draft(section: str, data_dir: str) -> dict:
+    """Generate a section draft.
+
+    This is the rq task equivalent of `klemma draft -s <section>`.
+    Runs in the worker process — initializes its own stores.
+
+    Returns a dict with status and content.
+    """
+    # TODO: wire to drafter.generate_draft() when adapted for headless mode.
+    # Requires: AI backend config, research report, RAG fragments, outline context.
+    logger.info("generate_draft: section %s — not yet wired", section)
+    return {
+        "status": "pending",
+        "section": section,
+        "detail": "Draft pipeline not yet wired for SaaS",
+    }

--- a/tests/test_write_api.py
+++ b/tests/test_write_api.py
@@ -1,0 +1,128 @@
+"""Tests for write API endpoints (ADR-009, #99)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from klemma.api.app import create_app
+from klemma.api.auth.deps import set_user_store
+from klemma.api.deps import set_paper_store, set_project_store, set_user_library
+from klemma.api.rate_limit import reset_rate_limiter
+from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
+from klemma.stores.user_library import LocalUserLibrary
+from klemma.stores.user_store import LocalUserStore
+
+
+@pytest.fixture
+def stores(tmp_path):
+    user_store = LocalUserStore(tmp_path / "users.db")
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    project_store = LocalProjectStore(tmp_path / "project.db")
+    return user_store, paper_store, user_library, project_store
+
+
+@pytest.fixture
+def client(stores) -> TestClient:
+    user_store, paper_store, user_library, project_store = stores
+    app = create_app()
+    set_user_store(user_store)
+    set_paper_store(paper_store)
+    set_user_library(user_library)
+    set_project_store(project_store)
+    reset_rate_limiter()
+    return TestClient(app)
+
+
+def _auth_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/register",
+        json={"email": "write@example.com", "password": "secret123"},
+    )
+    return resp.json()["access_token"]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Research
+# ---------------------------------------------------------------------------
+
+
+def test_submit_research_job(client, monkeypatch):
+    token = _auth_token(client)
+
+    mock_job = MagicMock()
+    mock_job.id = "research-job-1"
+    mock_queue = MagicMock()
+    mock_queue.enqueue.return_value = mock_job
+
+    import klemma.api.routes.write as write_mod
+
+    monkeypatch.setattr(write_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(write_mod, "Redis", MagicMock())
+    monkeypatch.setattr(write_mod, "Queue", MagicMock(return_value=mock_queue))
+
+    resp = client.post(
+        "/write/research",
+        json={"section": "2.3"},
+        headers=_headers(token),
+    )
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["job_id"] == "research-job-1"
+    assert data["section"] == "2.3"
+    assert data["task_type"] == "generate_research"
+
+
+# ---------------------------------------------------------------------------
+# Draft
+# ---------------------------------------------------------------------------
+
+
+def test_submit_draft_job(client, monkeypatch):
+    token = _auth_token(client)
+
+    mock_job = MagicMock()
+    mock_job.id = "draft-job-1"
+    mock_queue = MagicMock()
+    mock_queue.enqueue.return_value = mock_job
+
+    import klemma.api.routes.write as write_mod
+
+    monkeypatch.setattr(write_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(write_mod, "Redis", MagicMock())
+    monkeypatch.setattr(write_mod, "Queue", MagicMock(return_value=mock_queue))
+
+    resp = client.post(
+        "/write/draft",
+        json={"section": "1.3.2"},
+        headers=_headers(token),
+    )
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["job_id"] == "draft-job-1"
+    assert data["section"] == "1.3.2"
+    assert data["task_type"] == "generate_draft"
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+
+def test_research_requires_auth(client):
+    resp = client.post("/write/research", json={"section": "1.1"})
+    assert resp.status_code == 403
+
+
+def test_draft_requires_auth(client):
+    resp = client.post("/write/draft", json={"section": "1.1"})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Complete the core loop over HTTP with async write endpoints:

- `POST /write/research` → enqueue research briefing for a section (202 + job_id)
- `POST /write/draft` → enqueue section draft generation (202 + job_id)
- Poll results via shared `GET /process/jobs/{job_id}`

Task stubs in `tasks.py` — the AI pipeline (researcher, drafter) isn't adapted for headless SaaS yet, but the API surface and async job flow are fully functional.

Part of #99 — **this completes all 5 core loop steps over HTTP:**

| Step | Endpoint | Status |
|---|---|---|
| Acquire | `POST /library/sources` | Merged |
| Process | `POST /process/sources/{citekey}` | Merged |
| Map | `POST /projects/sections/assign` | Merged |
| Analyze | `GET /analyze/status` | Merged |
| Write | `POST /write/research`, `POST /write/draft` | This PR |

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1333 passed (+4 new)
- [x] Research job enqueued → 202 with job_id and task_type
- [x] Draft job enqueued → 202 with job_id and task_type
- [x] Auth required on both → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)