### PR TITLE
feat: add bibliography reference parser (#76)

### DIFF
--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -44,6 +44,12 @@ Vault note creation pipeline — largest module in the package:
 4. `create_vault_note()` — renders structured note with frontmatter + sections
 5. Reference gap extraction — bibliography cross-check against library
 
+### reference_parser.py (~140 lines)
+Parse bibliography strings into structured `ParsedReference` dataclass. Pure string processing, no AI, no external deps. Foundation for CiteQ `--from-draft` onboarding (#76).
+- `ParsedReference` — dataclass: raw, authors, year, title, journal, doi, url
+- `parse_reference(raw) -> ParsedReference` — parse single entry (APA, numbered, DOI/URL extraction)
+- `parse_references(text) -> list[ParsedReference]` — split bibliography section into entries, filter short
+
 ## Data flows
 
 ### PDF finding (3-tier)

--- a/src/klemma/literature/reference_parser.py
+++ b/src/klemma/literature/reference_parser.py
@@ -1,0 +1,170 @@
+"""Parse bibliography strings into structured references (#76).
+
+Pure string processing — no AI, no external deps. Handles common
+academic citation formats (APA, numbered, inline). Used by the
+CiteQ onboarding pipeline to extract references from draft PDFs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class ParsedReference:
+    """A structured reference parsed from a bibliography string."""
+
+    raw: str
+    authors: str = ""
+    year: int | None = None
+    title: str = ""
+    journal: str = ""
+    doi: str = ""
+    url: str = ""
+
+
+# DOI pattern: 10.XXXX/... (standard DOI format)
+_DOI_RE = re.compile(r"10\.\d{4,}/[^\s,;}\]]+")
+
+# URL pattern
+_URL_RE = re.compile(r"https?://[^\s,;}\]]+")
+
+# Year pattern: 4-digit year in parentheses or standalone, 1900-2099
+_YEAR_RE = re.compile(r"\b((?:19|20)\d{2})\b")
+
+# Numbered reference prefix: [1], 1., 1)
+_NUMBERED_PREFIX_RE = re.compile(r"^\s*\[?\d+[.\])]\s*")
+
+
+def parse_reference(raw: str) -> ParsedReference:
+    """Parse a single bibliography string into structured fields.
+
+    Handles:
+    - APA: "Smith, J., & Jones, K. (2020). Title. Journal, 1(2), 3-4."
+    - Numbered: "[1] Smith J. Title. Journal. 2020;1:3-4."
+    - Inline DOI: "... https://doi.org/10.1234/test"
+
+    Returns ParsedReference with best-effort extraction. Empty fields
+    when parsing fails — never raises.
+    """
+    ref = ParsedReference(raw=raw.strip())
+
+    # Extract DOI
+    doi_match = _DOI_RE.search(raw)
+    if doi_match:
+        ref.doi = doi_match.group().rstrip(".")
+
+    # Extract URL (prefer non-DOI URL if both present)
+    url_match = _URL_RE.search(raw)
+    if url_match:
+        url = url_match.group().rstrip(".")
+        if "doi.org" not in url:
+            ref.url = url
+        elif not ref.doi:
+            ref.doi = _DOI_RE.search(url).group() if _DOI_RE.search(url) else ""
+            ref.url = url
+
+    # Strip numbered prefix
+    text = _NUMBERED_PREFIX_RE.sub("", raw).strip()
+
+    # Extract year
+    year_match = _YEAR_RE.search(text)
+    if year_match:
+        ref.year = int(year_match.group(1))
+
+    # Try APA-style parsing: "Authors (Year). Title. Journal..."
+    apa = _try_apa(text)
+    if apa:
+        ref.authors = apa["authors"]
+        ref.title = apa["title"]
+        ref.journal = apa["journal"]
+        if not ref.year and apa.get("year"):
+            ref.year = apa["year"]
+        return ref
+
+    # Fallback: split on periods, heuristic assignment
+    ref.authors, ref.title, ref.journal = _split_heuristic(text, ref.year)
+
+    return ref
+
+
+def parse_references(text: str) -> list[ParsedReference]:
+    """Parse a bibliography section into individual references.
+
+    Splits on numbered prefixes ([1], 1., etc.) or double newlines.
+    Filters out empty/too-short entries.
+    """
+    # Try splitting on numbered references first
+    numbered = re.split(r"\n\s*\[?\d+[.\])]\s+", "\n" + text)
+    if len(numbered) > 2:
+        entries = [e.strip() for e in numbered if e.strip()]
+    else:
+        # Fall back to double-newline or single-newline splitting
+        entries = [e.strip() for e in re.split(r"\n\n+|\n(?=[A-Z])", text) if e.strip()]
+
+    results = []
+    for entry in entries:
+        # Skip entries that are too short to be real references
+        if len(entry) < 20:
+            continue
+        ref = parse_reference(entry)
+        results.append(ref)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal parsers
+# ---------------------------------------------------------------------------
+
+
+def _try_apa(text: str) -> dict | None:
+    """Try to parse APA-style: "Authors (Year). Title. Journal, vol(issue), pages."
+
+    Returns dict with authors/year/title/journal or None if doesn't match.
+    """
+    # Pattern: "text (YYYY)" or "text, YYYY"
+    m = re.match(
+        r"^(.+?)\s*\((\d{4})\)\.\s*(.+)",
+        text,
+    )
+    if not m:
+        return None
+
+    authors = m.group(1).strip().rstrip(",")
+    year = int(m.group(2))
+    rest = m.group(3).strip()
+
+    # Split remaining on first period to get title vs journal
+    parts = rest.split(". ", 1)
+    title = parts[0].strip().rstrip(".")
+    journal = parts[1].strip().rstrip(".") if len(parts) > 1 else ""
+
+    # Clean up journal — remove volume/pages info
+    if journal:
+        journal = re.split(r",\s*\d+", journal)[0].strip()
+
+    return {"authors": authors, "year": year, "title": title, "journal": journal}
+
+
+def _split_heuristic(text: str, year: int | None) -> tuple[str, str, str]:
+    """Fallback parser: split on periods, assign by position.
+
+    Returns (authors, title, journal).
+    """
+    # Remove year in parens for cleaner splitting
+    cleaned = text
+    if year:
+        cleaned = re.sub(rf"\({year}\)", "", cleaned)
+        cleaned = re.sub(rf"\b{year}\b", "", cleaned, count=1)
+
+    parts = [p.strip() for p in cleaned.split(".") if p.strip()]
+
+    if len(parts) >= 3:
+        return parts[0], parts[1], parts[2]
+    elif len(parts) == 2:
+        return parts[0], parts[1], ""
+    elif len(parts) == 1:
+        return "", parts[0], ""
+    return "", "", ""

--- a/tests/test_reference_parser.py
+++ b/tests/test_reference_parser.py
@@ -1,0 +1,150 @@
+"""Tests for reference_parser.py (#76 CiteQ onboarding)."""
+
+from __future__ import annotations
+
+from klemma.literature.reference_parser import ParsedReference, parse_reference, parse_references
+
+# ---------------------------------------------------------------------------
+# APA-style references
+# ---------------------------------------------------------------------------
+
+
+def test_apa_basic():
+    ref = parse_reference(
+        "Smith, J., & Jones, K. (2020). Machine Learning for NLP. Nature, 123, 45-67."
+    )
+    assert ref.authors == "Smith, J., & Jones, K."
+    assert ref.year == 2020
+    assert ref.title == "Machine Learning for NLP"
+    assert ref.journal == "Nature"
+
+
+def test_apa_with_doi():
+    ref = parse_reference(
+        "Cohan, A. (2019). SPECTER: Document-Level Representation. ACL. https://doi.org/10.18653/v1/2020.acl-main.207"
+    )
+    assert ref.year == 2019
+    assert ref.title == "SPECTER: Document-Level Representation"
+    assert "10.18653" in ref.doi
+
+
+def test_apa_single_author():
+    ref = parse_reference(
+        "Pautasso, M. (2013). Ten simple rules for writing a literature review. PLoS Computational Biology, 9(7)."
+    )
+    assert ref.authors == "Pautasso, M."
+    assert ref.year == 2013
+    assert "literature review" in ref.title.lower()
+    assert "PLoS" in ref.journal
+
+
+# ---------------------------------------------------------------------------
+# Numbered references
+# ---------------------------------------------------------------------------
+
+
+def test_numbered_bracket():
+    ref = parse_reference(
+        "[1] Wagner, P.M. Sea ice information and forecast needs. Cold Regions Sci. 2020;140:103–108."
+    )
+    assert ref.year == 2020
+    assert "Wagner" in ref.authors or "Wagner" in ref.title
+
+
+def test_numbered_dot():
+    ref = parse_reference(
+        "3. Bidenko S. Neural network approaches for ice prediction. J. Marine Systems. 2019."
+    )
+    assert ref.year == 2019
+
+
+# ---------------------------------------------------------------------------
+# DOI and URL extraction
+# ---------------------------------------------------------------------------
+
+
+def test_doi_extraction():
+    ref = parse_reference(
+        "Smith (2020). Title. Journal. doi:10.1234/test.5678"
+    )
+    assert ref.doi == "10.1234/test.5678"
+
+
+def test_url_extraction():
+    ref = parse_reference(
+        "Smith (2020). Title. Available at https://arxiv.org/abs/2101.12345"
+    )
+    assert ref.url == "https://arxiv.org/abs/2101.12345"
+
+
+def test_doi_url_extraction():
+    ref = parse_reference(
+        "Smith (2020). Title. https://doi.org/10.1234/test"
+    )
+    assert "10.1234/test" in ref.doi
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string():
+    ref = parse_reference("")
+    assert ref.raw == ""
+    assert ref.year is None
+    assert ref.title == ""
+
+
+def test_minimal_reference():
+    ref = parse_reference("Some random text without structure")
+    assert ref.raw == "Some random text without structure"
+
+
+def test_year_extraction_from_middle():
+    ref = parse_reference("A method published in 2018 for ice forecasting.")
+    assert ref.year == 2018
+
+
+def test_no_year():
+    ref = parse_reference("Smith J. A paper about methods. Some Journal.")
+    assert ref.year is None
+
+
+# ---------------------------------------------------------------------------
+# Batch parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_references_numbered():
+    text = """[1] Smith, J. (2020). First paper. Nature.
+[2] Jones, K. (2019). Second paper. Science.
+[3] Lee, M. (2021). Third paper. PNAS."""
+    refs = parse_references(text)
+    assert len(refs) == 3
+    assert refs[0].year == 2020
+    assert refs[1].year == 2019
+    assert refs[2].year == 2021
+
+
+def test_parse_references_paragraph():
+    text = """Smith, J. (2020). First paper. Nature, 1, 2-3.
+
+Jones, K. (2019). Second paper. Science, 4(5), 67-89."""
+    refs = parse_references(text)
+    assert len(refs) == 2
+
+
+def test_parse_references_filters_short():
+    text = """[1] Smith, J. (2020). A real reference with enough content. Nature.
+[2] Too short.
+[3] Jones, K. (2019). Another real reference. Science, 123."""
+    refs = parse_references(text)
+    assert len(refs) == 2  # "Too short." filtered out
+
+
+def test_parsed_reference_dataclass():
+    ref = ParsedReference(raw="test", authors="A", year=2020, title="T")
+    assert ref.raw == "test"
+    assert ref.journal == ""
+    assert ref.doi == ""


### PR DESCRIPTION
## Summary

Pure string-processing parser for bibliography entries — first component of CiteQ onboarding (#76):

- `parse_reference(raw)` → `ParsedReference` with authors, year, title, journal, DOI, URL
- `parse_references(text)` → split bibliography sections into individual entries
- Handles APA style, numbered references, DOI/URL extraction
- Best-effort — never raises on malformed input

Zero dependencies, zero AI calls, additive (no existing code modified).

Part of #76

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1349 passed (+16 new)
- [x] APA parsing: basic, with DOI, single author
- [x] Numbered: bracket `[1]`, dot `3.`
- [x] DOI/URL extraction from various positions
- [x] Edge cases: empty, no year, minimal text
- [x] Batch: numbered split, paragraph split, short-entry filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)