### PR TITLE
feat: add library management page (#191 Phase 1)

### DIFF
--- a/saas/dashboard/CLAUDE.md
+++ b/saas/dashboard/CLAUDE.md
@@ -13,11 +13,14 @@ saas/dashboard/
 ├── src/
 │   ├── api/client.ts      — typed API client, JWT management, token refresh
 │   ├── router/index.ts    — routes + auth guard
+│   ├── components/        — shared components
+│   │   └── AppLayout      — nav header (Обзор / Библиотека) + logout
 │   ├── views/             — page components
 │   │   ├── LandingView    — public landing page (Russian)
 │   │   ├── LoginView      — email/password login
 │   │   ├── RegisterView   — registration form
-│   │   └── DashboardView  — status cards + coverage
+│   │   ├── DashboardView  — status cards + coverage (uses AppLayout)
+│   │   └── LibraryView    — source table + add form + delete (uses AppLayout)
 │   └── assets/main.css    — Tailwind entry point
 ├── vite.config.ts         — Tailwind plugin + /api proxy
 └── package.json

--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { RouterLink, RouterView, useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function logout() {
+  localStorage.removeItem('access_token')
+  localStorage.removeItem('refresh_token')
+  router.push('/login')
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-50">
+    <header class="border-b border-gray-200 bg-white px-6 py-3">
+      <div class="mx-auto flex max-w-5xl items-center justify-between">
+        <div class="flex items-center gap-8">
+          <RouterLink to="/dashboard" class="text-lg font-semibold text-gray-900">CiteQ</RouterLink>
+          <nav class="flex gap-1">
+            <RouterLink
+              to="/dashboard"
+              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              active-class="bg-gray-100 text-gray-900"
+            >
+              Обзор
+            </RouterLink>
+            <RouterLink
+              to="/library"
+              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              active-class="bg-gray-100 text-gray-900"
+            >
+              Библиотека
+            </RouterLink>
+          </nav>
+        </div>
+        <button @click="logout" class="text-sm text-gray-400 hover:text-gray-600">
+          Выйти
+        </button>
+      </div>
+    </header>
+    <main class="mx-auto max-w-5xl px-6 py-8">
+      <slot />
+    </main>
+  </div>
+</template>

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -24,6 +24,12 @@ const router = createRouter({
       component: () => import('../views/DashboardView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/library',
+      name: 'library',
+      component: () => import('../views/LibraryView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/saas/dashboard/src/views/DashboardView.vue
+++ b/saas/dashboard/src/views/DashboardView.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { analyze, auth } from '@/api/client'
+import { useRouter, RouterLink } from 'vue-router'
+import { analyze } from '@/api/client'
+import AppLayout from '@/components/AppLayout.vue'
 
 const router = useRouter()
-const user = ref<{ email: string; name: string } | null>(null)
 const status = ref<{
   sources: { total: number; completed: number; pending: number; failed: number }
   coverage: { section: string; source_count: number }[]
@@ -14,96 +14,75 @@ const loading = ref(true)
 
 onMounted(async () => {
   try {
-    const [userData, statusData] = await Promise.all([auth.me(), analyze.status()])
-    user.value = userData
-    status.value = statusData
+    status.value = await analyze.status()
   } catch {
     router.push('/login')
   } finally {
     loading.value = false
   }
 })
-
-function logout() {
-  localStorage.removeItem('access_token')
-  localStorage.removeItem('refresh_token')
-  router.push('/login')
-}
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-50">
-    <!-- Header -->
-    <header class="border-b border-gray-200 bg-white px-6 py-4">
-      <div class="mx-auto flex max-w-5xl items-center justify-between">
-        <h1 class="text-lg font-semibold text-gray-900">CiteQ</h1>
-        <div class="flex items-center gap-4">
-          <span v-if="user" class="text-sm text-gray-500">{{ user.email }}</span>
-          <button
-            @click="logout"
-            class="text-sm text-gray-400 hover:text-gray-600"
+  <AppLayout>
+    <div v-if="loading" class="py-12 text-center text-gray-400">Загрузка...</div>
+
+    <div v-else-if="status" class="space-y-8">
+      <!-- Stats cards -->
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
+        <div class="rounded-lg border border-gray-200 bg-white p-5">
+          <div class="text-2xl font-bold text-gray-900">{{ status.sources.total }}</div>
+          <div class="text-sm text-gray-500">Источников</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-5">
+          <div class="text-2xl font-bold text-green-600">{{ status.sources.completed }}</div>
+          <div class="text-sm text-gray-500">Обработано</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-5">
+          <div class="text-2xl font-bold text-yellow-600">{{ status.sources.pending }}</div>
+          <div class="text-sm text-gray-500">В очереди</div>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-5">
+          <div class="text-2xl font-bold text-indigo-600">{{ status.total_fragments }}</div>
+          <div class="text-sm text-gray-500">Фрагментов</div>
+        </div>
+      </div>
+
+      <!-- Coverage -->
+      <div class="rounded-lg border border-gray-200 bg-white p-6">
+        <h2 class="text-lg font-semibold text-gray-900">Покрытие по разделам</h2>
+        <div v-if="status.coverage.length === 0" class="mt-4 text-sm text-gray-400">
+          Нет назначенных разделов. Добавьте источники и назначьте их разделам.
+        </div>
+        <div v-else class="mt-4 space-y-2">
+          <div
+            v-for="item in status.coverage"
+            :key="item.section"
+            class="flex items-center justify-between rounded-md bg-gray-50 px-4 py-2"
           >
-            Выйти
-          </button>
+            <span class="text-sm font-medium text-gray-700">{{ item.section }}</span>
+            <span class="text-sm text-gray-500">{{ item.source_count }} источников</span>
+          </div>
         </div>
       </div>
-    </header>
 
-    <!-- Content -->
-    <main class="mx-auto max-w-5xl px-6 py-8">
-      <div v-if="loading" class="text-center text-gray-400">Загрузка...</div>
-
-      <div v-else-if="status" class="space-y-8">
-        <!-- Stats cards -->
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
-          <div class="rounded-lg border border-gray-200 bg-white p-5">
-            <div class="text-2xl font-bold text-gray-900">{{ status.sources.total }}</div>
-            <div class="text-sm text-gray-500">Источников</div>
-          </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-5">
-            <div class="text-2xl font-bold text-green-600">{{ status.sources.completed }}</div>
-            <div class="text-sm text-gray-500">Обработано</div>
-          </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-5">
-            <div class="text-2xl font-bold text-yellow-600">{{ status.sources.pending }}</div>
-            <div class="text-sm text-gray-500">В очереди</div>
-          </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-5">
-            <div class="text-2xl font-bold text-indigo-600">{{ status.total_fragments }}</div>
-            <div class="text-sm text-gray-500">Фрагментов</div>
-          </div>
-        </div>
-
-        <!-- Coverage -->
-        <div class="rounded-lg border border-gray-200 bg-white p-6">
-          <h2 class="text-lg font-semibold text-gray-900">Покрытие по разделам</h2>
-          <div v-if="status.coverage.length === 0" class="mt-4 text-sm text-gray-400">
-            Нет назначенных разделов. Добавьте источники и назначьте их разделам.
-          </div>
-          <div v-else class="mt-4 space-y-2">
-            <div
-              v-for="item in status.coverage"
-              :key="item.section"
-              class="flex items-center justify-between rounded-md bg-gray-50 px-4 py-2"
-            >
-              <span class="text-sm font-medium text-gray-700">{{ item.section }}</span>
-              <span class="text-sm text-gray-500">{{ item.source_count }} источников</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Empty state CTA -->
-        <div
-          v-if="status.sources.total === 0"
-          class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center"
+      <!-- Empty state CTA -->
+      <div
+        v-if="status.sources.total === 0"
+        class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center"
+      >
+        <div class="text-4xl">📄</div>
+        <h3 class="mt-3 text-lg font-semibold text-gray-900">Начните работу</h3>
+        <p class="mt-1 text-sm text-gray-500">
+          Добавьте первый источник, чтобы увидеть покрытие и фрагменты.
+        </p>
+        <RouterLink
+          to="/library"
+          class="mt-4 inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
         >
-          <div class="text-4xl">📄</div>
-          <h3 class="mt-3 text-lg font-semibold text-gray-900">Начните работу</h3>
-          <p class="mt-1 text-sm text-gray-500">
-            Добавьте первый источник, чтобы увидеть покрытие и фрагменты.
-          </p>
-        </div>
+          Перейти в библиотеку
+        </RouterLink>
       </div>
-    </main>
-  </div>
+    </div>
+  </AppLayout>
 </template>

--- a/saas/dashboard/src/views/LibraryView.vue
+++ b/saas/dashboard/src/views/LibraryView.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { library, ApiError } from '@/api/client'
+import AppLayout from '@/components/AppLayout.vue'
+
+interface Source {
+  citekey: string
+  title: string
+  authors: string
+  year: number | null
+  status: string
+  doi: string
+}
+
+const sources = ref<Source[]>([])
+const loading = ref(true)
+const showAddForm = ref(false)
+const deleteConfirm = ref<string | null>(null)
+
+// Add form state
+const form = ref({ citekey: '', title: '', authors: '', year: '', doi: '' })
+const formError = ref('')
+const formLoading = ref(false)
+
+async function loadSources() {
+  loading.value = true
+  try {
+    const data = await library.list()
+    sources.value = data.sources
+  } catch {
+    sources.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function addSource() {
+  formError.value = ''
+  formLoading.value = true
+  try {
+    await library.add({
+      citekey: form.value.citekey,
+      title: form.value.title,
+      authors: form.value.authors || undefined,
+      year: form.value.year ? parseInt(form.value.year) : undefined,
+      doi: form.value.doi || undefined,
+    })
+    form.value = { citekey: '', title: '', authors: '', year: '', doi: '' }
+    showAddForm.value = false
+    await loadSources()
+  } catch (e) {
+    formError.value = e instanceof ApiError ? e.message : 'Ошибка добавления'
+  } finally {
+    formLoading.value = false
+  }
+}
+
+async function deleteSource(citekey: string) {
+  try {
+    await library.remove(citekey)
+    deleteConfirm.value = null
+    await loadSources()
+  } catch {
+    // silently fail — source may already be deleted
+  }
+}
+
+onMounted(loadSources)
+</script>
+
+<template>
+  <AppLayout>
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <h1 class="text-xl font-semibold text-gray-900">Библиотека</h1>
+      <button
+        @click="showAddForm = !showAddForm"
+        class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+      >
+        {{ showAddForm ? 'Отмена' : '+ Добавить источник' }}
+      </button>
+    </div>
+
+    <!-- Add form -->
+    <div v-if="showAddForm" class="mt-6 rounded-lg border border-gray-200 bg-white p-6">
+      <h2 class="text-sm font-semibold text-gray-700">Новый источник</h2>
+      <form class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2" @submit.prevent="addSource">
+        <div v-if="formError" class="col-span-full rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {{ formError }}
+        </div>
+        <input
+          v-model="form.citekey"
+          placeholder="Citekey (например: smithML2020)"
+          required
+          class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        <input
+          v-model="form.title"
+          placeholder="Название статьи"
+          required
+          class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        <input
+          v-model="form.authors"
+          placeholder="Авторы (необязательно)"
+          class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        <input
+          v-model="form.year"
+          type="number"
+          placeholder="Год"
+          min="1900"
+          max="2099"
+          class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        <input
+          v-model="form.doi"
+          placeholder="DOI (необязательно)"
+          class="col-span-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        <div class="col-span-full">
+          <button
+            type="submit"
+            :disabled="formLoading"
+            class="rounded-lg bg-indigo-600 px-6 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {{ formLoading ? 'Добавляем...' : 'Добавить' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Sources table -->
+    <div class="mt-6">
+      <div v-if="loading" class="py-12 text-center text-gray-400">Загрузка...</div>
+
+      <div v-else-if="sources.length === 0" class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center">
+        <div class="text-4xl">📚</div>
+        <h3 class="mt-3 text-lg font-semibold text-gray-900">Библиотека пуста</h3>
+        <p class="mt-1 text-sm text-gray-500">Добавьте первый источник, чтобы начать работу.</p>
+        <button
+          @click="showAddForm = true"
+          class="mt-4 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+        >
+          + Добавить источник
+        </button>
+      </div>
+
+      <div v-else class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Citekey</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Название</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Авторы</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Год</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Статус</th>
+              <th class="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="src in sources" :key="src.citekey" class="hover:bg-gray-50">
+              <td class="px-4 py-3 text-sm font-mono text-indigo-600">{{ src.citekey }}</td>
+              <td class="max-w-xs truncate px-4 py-3 text-sm text-gray-900">{{ src.title || '—' }}</td>
+              <td class="max-w-[150px] truncate px-4 py-3 text-sm text-gray-500">{{ src.authors || '—' }}</td>
+              <td class="px-4 py-3 text-sm text-gray-500">{{ src.year || '—' }}</td>
+              <td class="px-4 py-3">
+                <span
+                  class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+                  :class="{
+                    'bg-green-100 text-green-700': src.status === 'completed',
+                    'bg-yellow-100 text-yellow-700': src.status === 'pending',
+                    'bg-red-100 text-red-700': src.status === 'failed',
+                  }"
+                >
+                  {{ src.status }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-right">
+                <button
+                  v-if="deleteConfirm !== src.citekey"
+                  @click="deleteConfirm = src.citekey"
+                  class="text-sm text-gray-400 hover:text-red-500"
+                >
+                  Удалить
+                </button>
+                <span v-else class="flex items-center gap-2">
+                  <button
+                    @click="deleteSource(src.citekey)"
+                    class="text-sm font-medium text-red-600 hover:text-red-800"
+                  >
+                    Да
+                  </button>
+                  <button
+                    @click="deleteConfirm = null"
+                    class="text-sm text-gray-400 hover:text-gray-600"
+                  >
+                    Нет
+                  </button>
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </AppLayout>
+</template>


### PR DESCRIPTION
## Summary

Phase 1 of CiteQ MVP Frontend (#191) — library management, the first real data interaction:

**Library page** (`/library`):
- Source table with citekey, title, authors, year, status badge (color-coded)
- Add source form: inline expandable with citekey, title, authors, year, DOI
- Delete with two-click confirmation (prevents accidental deletion)
- Empty state with CTA to add first source

**Shared layout** (`AppLayout.vue`):
- Navigation header: Обзор (dashboard) / Библиотека tabs
- Logout button
- Refactored DashboardView to use shared layout (no more duplicate headers)
- Dashboard empty state now links to library page

### User flow
Register → Dashboard (empty) → "Перейти в библиотеку" → Add source → See it in table → Back to dashboard (total: 1)

Part of #191

## Test plan
- [x] `npm run build` — builds (1.16s, 36KB gzipped)
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1361 passed
- [ ] Manual: add source → see in table → delete → empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)