### PR TITLE
feat: add PDF upload endpoint with dedup (#191)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ api = [
     "PyJWT[crypto]==2.10.1",
     "pydantic[email]>=2.0",
     "httpx>=0.27",
+    "python-multipart>=0.0.9",
     "redis>=5.0",
     "rq>=2.0",
 ]

--- a/src/klemma/api/CLAUDE.md
+++ b/src/klemma/api/CLAUDE.md
@@ -13,11 +13,13 @@ Application factory — creates and configures the FastAPI app.
 - `create_app() -> FastAPI` — mounts all routers, sets title/version/lifespan
 - `lifespan(app)` — async context manager: startup (DB init, config checks) + shutdown (close connections)
 
-### deps.py (38 lines)
+### deps.py (~65 lines)
 Shared FastAPI dependencies for data store access.
-- `set_paper_store(store)` / `get_paper_store()` — module-level `PaperStore` singleton
-- `set_user_library(lib)` / `get_user_library()` — module-level `UserLibrary` singleton
-- Both set in `app.py` lifespan, used by route handlers via `Depends()`
+- `set/get_paper_store()` — `PaperStore` singleton
+- `set/get_user_library()` — `UserLibrary` singleton
+- `set/get_project_store()` — `ProjectStore` singleton
+- `set/get_file_store()` — `FileStore` singleton
+- All set in `app.py` lifespan, used by route handlers via `Depends()`
 
 ### tasks.py (~60 lines)
 Async task definitions for rq worker. Tasks receive primitive args (worker runs in separate process).

--- a/src/klemma/api/app.py
+++ b/src/klemma/api/app.py
@@ -15,13 +15,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from klemma import __version__
+from klemma.stores.file_store import LocalFileStore
 from klemma.stores.paper_store import LocalPaperStore
 from klemma.stores.project_store import LocalProjectStore
 from klemma.stores.user_library import LocalUserLibrary
 from klemma.stores.user_store import LocalUserStore
 
 from .auth.deps import set_user_store
-from .deps import set_paper_store, set_project_store, set_user_library
+from .deps import set_file_store, set_paper_store, set_project_store, set_user_library
 from .routes import analyze, auth, health, library, process, projects, write
 
 
@@ -40,6 +41,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     set_paper_store(LocalPaperStore(library_db))
     set_user_library(LocalUserLibrary(library_db))
     set_project_store(LocalProjectStore(data_dir / "project.db"))
+    set_file_store(LocalFileStore(data_dir / "files"))
     yield
     # Shutdown: close connections, flush caches
 

--- a/src/klemma/api/deps.py
+++ b/src/klemma/api/deps.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from klemma.protocols import PaperStore, ProjectStore, UserLibrary
+    from klemma.protocols import FileStore, PaperStore, ProjectStore, UserLibrary
 
 # Module-level store references, set during app startup via lifespan.
 _paper_store: PaperStore | None = None
 _user_library: UserLibrary | None = None
 _project_store: ProjectStore | None = None
+_file_store: FileStore | None = None
 
 
 def set_paper_store(store: PaperStore) -> None:
@@ -50,3 +51,16 @@ def get_project_store() -> ProjectStore:
     if _project_store is None:
         raise RuntimeError("ProjectStore not configured — call set_project_store() at startup")
     return _project_store
+
+
+def set_file_store(store: FileStore) -> None:
+    """Set the FileStore instance."""
+    global _file_store  # noqa: PLW0603
+    _file_store = store
+
+
+def get_file_store() -> FileStore:
+    """Return the configured FileStore, or raise if not set."""
+    if _file_store is None:
+        raise RuntimeError("FileStore not configured — call set_file_store() at startup")
+    return _file_store

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -22,7 +22,8 @@ Library CRUD endpoints — mounted with `prefix="/library"`. All require Bearer 
 - `GET /library/sources/{citekey}` → `SourceDetailResponse` — source details + fragments
 - `POST /library/sources` → `SourceResponse` (201) — add source by metadata (DOI dedup)
 - `DELETE /library/sources/{citekey}` → 204 — remove from user library (keeps global corpus)
-- Schemas: `SourceResponse`, `SourceListResponse`, `SourceCreateRequest`, `FragmentResponse`, `SourceDetailResponse`
+- `POST /library/upload` → `UploadResponse` (201) — upload PDF file with content-addressable dedup (pdf_hash)
+- Schemas: `SourceResponse`, `SourceListResponse`, `SourceCreateRequest`, `FragmentResponse`, `SourceDetailResponse`, `UploadResponse`
 
 ### projects.py (~110 lines)
 Project endpoints — mounted with `prefix="/projects"`. All require Bearer auth.

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -290,7 +290,12 @@ async def upload_pdf(
         title=file.filename.rsplit(".", 1)[0],
         pdf_hash=pdf_hash,
     )
-    file_store.save(paper_id, data, file.filename)
+    # Sanitize filename for storage (FileStore validates, but give a clean 400)
+    safe_filename = re.sub(r"[^\w.\-]", "_", file.filename)
+    try:
+        file_store.save(paper_id, data, safe_filename)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     library.add_source(paper_id, citekey, status="pending")
 
     return UploadResponse(

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import hashlib
+import re
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
 from klemma.models import UserRecord
 
 from ..auth.deps import get_current_user
-from ..deps import get_paper_store, get_user_library
+from ..deps import get_file_store, get_paper_store, get_user_library
 
 router = APIRouter()
 
@@ -213,5 +216,107 @@ async def delete_source(
         )
 
     library.remove_source(citekey)
+
+
+class UploadResponse(BaseModel):
+    """Response from PDF upload."""
+
+    citekey: str
+    paper_id: str
+    pdf_hash: str
+    status: str
+    deduplicated: bool = False
+
+
+MAX_PDF_BYTES = 50 * 1024 * 1024  # 50 MB
+
+
+@router.post("/upload", response_model=UploadResponse, status_code=status.HTTP_201_CREATED)
+async def upload_pdf(
+    file: UploadFile,
+    user: UserRecord = Depends(get_current_user),
+) -> UploadResponse:
+    """Upload a PDF and register it in the library.
+
+    Deduplicates by pdf_hash: if the same PDF already exists in the global
+    corpus, reuses the existing paper_id (no re-extraction needed).
+    Generates a citekey from the filename.
+    """
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only PDF files are accepted",
+        )
+
+    data = await file.read()
+    if len(data) < 1024:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File too small to be a valid PDF",
+        )
+    if len(data) > MAX_PDF_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File exceeds {MAX_PDF_BYTES // (1024 * 1024)} MB limit",
+        )
+
+    pdf_hash = hashlib.sha256(data).hexdigest()
+    paper_store = get_paper_store()
+    file_store = get_file_store()
+    library = get_user_library()
+
+    # Dedup: check if this PDF already exists in the global corpus
+    existing = paper_store.find_paper(pdf_hash=pdf_hash)
+    if existing:
+        citekey = _citekey_from_filename(file.filename)
+        # Check citekey conflict
+        if library.get_source_by_citekey(citekey):
+            citekey = f"{citekey}_{pdf_hash[:6]}"
+        library.add_source(existing.paper_id, citekey, status="completed")
+        return UploadResponse(
+            citekey=citekey,
+            paper_id=existing.paper_id,
+            pdf_hash=pdf_hash,
+            status="completed",
+            deduplicated=True,
+        )
+
+    # New paper: register + store file
+    citekey = _citekey_from_filename(file.filename)
+    if library.get_source_by_citekey(citekey):
+        citekey = f"{citekey}_{pdf_hash[:6]}"
+
+    paper_id = paper_store.register_paper(
+        title=file.filename.rsplit(".", 1)[0],
+        pdf_hash=pdf_hash,
+    )
+    file_store.save(paper_id, data, file.filename)
+    library.add_source(paper_id, citekey, status="pending")
+
+    return UploadResponse(
+        citekey=citekey,
+        paper_id=paper_id,
+        pdf_hash=pdf_hash,
+        status="pending",
+    )
+
+
+def _citekey_from_filename(filename: str) -> str:
+    """Generate a citekey from a PDF filename.
+
+    'Smith_2020_Machine_Learning.pdf' → 'smith2020machineLearning'
+    """
+    name = filename.rsplit(".", 1)[0]  # remove .pdf
+    # Split on common separators
+    parts = re.split(r"[_\-\s]+", name)
+    if not parts:
+        return "unknown"
+    # lowercase first part, camelCase rest
+    result = parts[0].lower()
+    for p in parts[1:]:
+        if p:
+            result += p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper()
+    # Remove non-alphanumeric
+    return re.sub(r"[^a-zA-Z0-9]", "", result) or "unknown"
 
 

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -7,9 +7,11 @@ from fastapi.testclient import TestClient
 
 from klemma.api.app import create_app
 from klemma.api.auth.deps import set_user_store
-from klemma.api.deps import set_paper_store, set_user_library
+from klemma.api.deps import set_file_store, set_paper_store, set_project_store, set_user_library
 from klemma.api.rate_limit import reset_rate_limiter
+from klemma.stores.file_store import LocalFileStore
 from klemma.stores.paper_store import LocalPaperStore
+from klemma.stores.project_store import LocalProjectStore
 from klemma.stores.user_library import LocalUserLibrary
 from klemma.stores.user_store import LocalUserStore
 
@@ -20,16 +22,20 @@ def stores(tmp_path):
     library_db = tmp_path / "library.db"
     paper_store = LocalPaperStore(library_db)
     user_library = LocalUserLibrary(library_db)
-    return user_store, paper_store, user_library
+    project_store = LocalProjectStore(tmp_path / "project.db")
+    file_store = LocalFileStore(tmp_path / "files")
+    return user_store, paper_store, user_library, project_store, file_store
 
 
 @pytest.fixture
 def client(stores) -> TestClient:
-    user_store, paper_store, user_library = stores
+    user_store, paper_store, user_library, project_store, file_store = stores
     app = create_app()
     set_user_store(user_store)
     set_paper_store(paper_store)
     set_user_library(user_library)
+    set_project_store(project_store)
+    set_file_store(file_store)
     reset_rate_limiter()
     return TestClient(app)
 
@@ -174,3 +180,77 @@ def test_delete_source_not_found(client):
     token = _register_and_get_token(client)
     resp = client.delete("/library/sources/nonexistent", headers=_auth_headers(token))
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PDF Upload
+# ---------------------------------------------------------------------------
+
+
+def _fake_pdf(size: int = 2048) -> bytes:
+    """Create minimal bytes that pass the size check."""
+    return b"%PDF-1.4 " + b"x" * (size - 9)
+
+
+def test_upload_pdf(client):
+    token = _register_and_get_token(client)
+    resp = client.post(
+        "/library/upload",
+        files={"file": ("smith2020_ml.pdf", _fake_pdf(), "application/pdf")},
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["citekey"]  # generated from filename
+    assert data["paper_id"]
+    assert data["pdf_hash"]
+    assert data["status"] == "pending"
+    assert data["deduplicated"] is False
+
+
+def test_upload_dedup(client):
+    token = _register_and_get_token(client)
+    pdf = _fake_pdf()
+    r1 = client.post(
+        "/library/upload",
+        files={"file": ("paper_a.pdf", pdf, "application/pdf")},
+        headers=_auth_headers(token),
+    )
+    r2 = client.post(
+        "/library/upload",
+        files={"file": ("paper_b.pdf", pdf, "application/pdf")},
+        headers=_auth_headers(token),
+    )
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    # Same PDF → same paper_id
+    assert r1.json()["paper_id"] == r2.json()["paper_id"]
+    assert r2.json()["deduplicated"] is True
+
+
+def test_upload_rejects_non_pdf(client):
+    token = _register_and_get_token(client)
+    resp = client.post(
+        "/library/upload",
+        files={"file": ("readme.txt", b"hello world", "text/plain")},
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_rejects_tiny_file(client):
+    token = _register_and_get_token(client)
+    resp = client.post(
+        "/library/upload",
+        files={"file": ("tiny.pdf", b"%PDF", "application/pdf")},
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_requires_auth(client):
+    resp = client.post(
+        "/library/upload",
+        files={"file": ("test.pdf", _fake_pdf(), "application/pdf")},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

New `POST /library/upload` endpoint — upload a PDF and register it in the library:

- **Validation**: file type (.pdf), size (1KB–50MB)
- **Dedup**: SHA256 hash → if same PDF exists in global corpus, reuses paper_id (instant, no re-extraction)
- **Storage**: new PDFs saved via `FileStore` (content-addressed `files/{prefix}/{paper_id}/`)
- **Citekey**: auto-generated from filename in camelCase convention
- **Conflict handling**: appends hash suffix if citekey already taken

### Supporting changes
- `deps.py`: `FileStore` dependency (set/get)
- `app.py`: `LocalFileStore` initialized in lifespan at `KLEMMA_DATA_DIR/files/`
- Test fixtures updated to include all stores (FileStore, ProjectStore)

Part of #191 — enables Phase 2 frontend PDF upload

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1366 passed (+5 new)
- [x] Upload PDF → 201, returns citekey + paper_id + pdf_hash
- [x] Upload same PDF twice → second returns deduplicated=true, same paper_id
- [x] Upload non-PDF → 400
- [x] Upload tiny file → 400
- [x] Auth required → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)