### PR TITLE
feat: dashboard redesign + source detail + AI pipeline (#191)

### DIFF
--- a/saas/dashboard/index.html
+++ b/saas/dashboard/index.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="ru">
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <meta name="description" content="AI-ассистент для академического письма. Загрузите PDF — получите фрагменты, покрытие и рекомендации.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=Source+Sans+3:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <title>LitResearch — AI-ассистент для академического письма</title>
   </head>
   <body>
     <div id="app"></div>

--- a/saas/dashboard/src/assets/main.css
+++ b/saas/dashboard/src/assets/main.css
@@ -1,1 +1,62 @@
 @import "tailwindcss";
+
+@theme {
+  /* Academic palette — warm, not clinical */
+  --color-ink: #1a1a2e;
+  --color-ink-light: #3d3d5c;
+  --color-ink-muted: #6b6b8a;
+  --color-paper: #faf9f7;
+  --color-paper-warm: #f5f3ef;
+  --color-paper-white: #ffffff;
+
+  /* Teal accent — scholarly, not corporate */
+  --color-accent: #0d7377;
+  --color-accent-light: #14919b;
+  --color-accent-pale: #e0f4f4;
+  --color-accent-deep: #065a5e;
+
+  /* Status */
+  --color-ok: #2d6a4f;
+  --color-ok-bg: #d8f3dc;
+  --color-warn: #b45309;
+  --color-warn-bg: #fef3c7;
+  --color-err: #991b1b;
+  --color-err-bg: #fee2e2;
+
+  /* Borders */
+  --color-rule: #e8e5df;
+  --color-rule-light: #f0ede8;
+
+  /* Fonts */
+  --font-display: 'Literata', 'Georgia', serif;
+  --font-body: 'Source Sans 3', 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+/* Base */
+body {
+  font-family: var(--font-body);
+  color: var(--color-ink);
+  background: var(--color-paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-rule); border-radius: 3px; }
+
+/* Subtle entry animation */
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-in {
+  animation: fade-up 0.4s ease-out both;
+}
+
+.animate-in-delay-1 { animation-delay: 0.08s; }
+.animate-in-delay-2 { animation-delay: 0.16s; }
+.animate-in-delay-3 { animation-delay: 0.24s; }
+.animate-in-delay-4 { animation-delay: 0.32s; }

--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -1,7 +1,20 @@
 <script setup lang="ts">
-import { RouterLink, RouterView, useRouter } from 'vue-router'
+import { RouterLink, useRouter, useRoute } from 'vue-router'
+import { ref, onMounted } from 'vue'
+import { auth } from '@/api/client'
 
 const router = useRouter()
+const route = useRoute()
+const userName = ref('')
+
+onMounted(async () => {
+  try {
+    const me = await auth.me()
+    userName.value = me.name ?? me.email.split('@')[0]
+  } catch {
+    /* ignore — header still works without name */
+  }
+})
 
 function logout() {
   localStorage.removeItem('access_token')
@@ -11,34 +24,58 @@ function logout() {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-50">
-    <header class="border-b border-gray-200 bg-white px-6 py-3">
-      <div class="mx-auto flex max-w-5xl items-center justify-between">
-        <div class="flex items-center gap-8">
-          <RouterLink to="/dashboard" class="text-lg font-semibold text-gray-900">CiteQ</RouterLink>
+  <div class="min-h-screen bg-[var(--color-paper)]">
+    <!-- Header -->
+    <header class="border-b border-[var(--color-rule)] bg-[var(--color-paper-white)]">
+      <div class="mx-auto flex max-w-6xl items-center justify-between px-8 py-4">
+        <!-- Logo + nav -->
+        <div class="flex items-center gap-10">
+          <RouterLink to="/dashboard" class="flex items-center gap-2.5 group">
+            <div class="flex h-8 w-8 items-center justify-center rounded-md bg-[var(--color-accent)] text-white font-[var(--font-display)] text-sm font-bold tracking-tight">
+              Lr
+            </div>
+            <span class="font-[var(--font-display)] text-lg font-semibold text-[var(--color-ink)] tracking-tight">
+              LitResearch
+            </span>
+          </RouterLink>
+
           <nav class="flex gap-1">
             <RouterLink
               to="/dashboard"
-              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
-              active-class="bg-gray-100 text-gray-900"
+              class="relative rounded-md px-3.5 py-2 text-sm font-medium transition-colors"
+              :class="route.path === '/dashboard'
+                ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
+                : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
             >
               Обзор
             </RouterLink>
             <RouterLink
               to="/library"
-              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
-              active-class="bg-gray-100 text-gray-900"
+              class="relative rounded-md px-3.5 py-2 text-sm font-medium transition-colors"
+              :class="route.path === '/library'
+                ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
+                : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
             >
               Библиотека
             </RouterLink>
           </nav>
         </div>
-        <button @click="logout" class="text-sm text-gray-400 hover:text-gray-600">
-          Выйти
-        </button>
+
+        <!-- User -->
+        <div class="flex items-center gap-4">
+          <span v-if="userName" class="text-sm text-[var(--color-ink-muted)]">{{ userName }}</span>
+          <button
+            @click="logout"
+            class="text-sm text-[var(--color-ink-muted)] hover:text-[var(--color-err)] transition-colors"
+          >
+            Выйти
+          </button>
+        </div>
       </div>
     </header>
-    <main class="mx-auto max-w-5xl px-6 py-8">
+
+    <!-- Content -->
+    <main class="mx-auto max-w-6xl px-8 py-8">
       <slot />
     </main>
   </div>

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -30,6 +30,12 @@ const router = createRouter({
       component: () => import('../views/LibraryView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/library/:citekey',
+      name: 'source',
+      component: () => import('../views/SourceView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/saas/dashboard/src/views/DashboardView.vue
+++ b/saas/dashboard/src/views/DashboardView.vue
@@ -1,20 +1,78 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
-import { analyze } from '@/api/client'
+import { analyze, library } from '@/api/client'
 import AppLayout from '@/components/AppLayout.vue'
 
 const router = useRouter()
+
 const status = ref<{
   sources: { total: number; completed: number; pending: number; failed: number }
   coverage: { section: string; source_count: number }[]
   total_fragments: number
 } | null>(null)
+
+const recentSources = ref<{ citekey: string; title: string; status: string; year: number | null }[]>([])
 const loading = ref(true)
+
+// Pipeline progress
+const pipelineSteps = computed(() => {
+  if (!status.value) return []
+  const s = status.value
+  const hasSources = s.sources.total > 0
+  const hasProcessed = s.sources.completed > 0
+  const hasCoverage = s.coverage.length > 0
+  return [
+    {
+      key: 'upload',
+      label: 'Загрузить',
+      desc: 'Добавьте PDF-статьи в библиотеку',
+      done: hasSources,
+      active: !hasSources,
+      count: s.sources.total,
+      unit: 'источников',
+    },
+    {
+      key: 'process',
+      label: 'Обработать',
+      desc: 'Извлеките фрагменты из статей',
+      done: hasProcessed && s.sources.pending === 0,
+      active: hasSources && !hasProcessed,
+      count: s.sources.completed,
+      unit: 'обработано',
+    },
+    {
+      key: 'map',
+      label: 'Разметить',
+      desc: 'Назначьте источники разделам диссертации',
+      done: hasCoverage,
+      active: hasProcessed && !hasCoverage,
+      count: s.coverage.length,
+      unit: 'разделов',
+    },
+    {
+      key: 'write',
+      label: 'Написать',
+      desc: 'Сгенерируйте обзор и черновики',
+      done: false,
+      active: hasCoverage,
+      count: 0,
+      unit: 'черновиков',
+    },
+  ]
+})
+
+// Coverage bar max
+const maxCoverage = computed(() => {
+  if (!status.value || status.value.coverage.length === 0) return 1
+  return Math.max(...status.value.coverage.map(c => c.source_count))
+})
 
 onMounted(async () => {
   try {
-    status.value = await analyze.status()
+    const [s, lib] = await Promise.all([analyze.status(), library.list()])
+    status.value = s
+    recentSources.value = lib.sources.slice(0, 5)
   } catch {
     router.push('/login')
   } finally {
@@ -25,62 +83,202 @@ onMounted(async () => {
 
 <template>
   <AppLayout>
-    <div v-if="loading" class="py-12 text-center text-gray-400">Загрузка...</div>
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-24">
+      <div class="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent"></div>
+    </div>
 
-    <div v-else-if="status" class="space-y-8">
-      <!-- Stats cards -->
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <div class="rounded-lg border border-gray-200 bg-white p-5">
-          <div class="text-2xl font-bold text-gray-900">{{ status.sources.total }}</div>
-          <div class="text-sm text-gray-500">Источников</div>
-        </div>
-        <div class="rounded-lg border border-gray-200 bg-white p-5">
-          <div class="text-2xl font-bold text-green-600">{{ status.sources.completed }}</div>
-          <div class="text-sm text-gray-500">Обработано</div>
-        </div>
-        <div class="rounded-lg border border-gray-200 bg-white p-5">
-          <div class="text-2xl font-bold text-yellow-600">{{ status.sources.pending }}</div>
-          <div class="text-sm text-gray-500">В очереди</div>
-        </div>
-        <div class="rounded-lg border border-gray-200 bg-white p-5">
-          <div class="text-2xl font-bold text-indigo-600">{{ status.total_fragments }}</div>
-          <div class="text-sm text-gray-500">Фрагментов</div>
-        </div>
+    <div v-else-if="status" class="space-y-10">
+      <!-- Page title -->
+      <div class="animate-in">
+        <h1 class="font-[var(--font-display)] text-2xl font-bold text-[var(--color-ink)] tracking-tight">
+          Обзор исследования
+        </h1>
+        <p class="mt-1 text-sm text-[var(--color-ink-muted)]">
+          Текущее состояние вашей работы
+        </p>
       </div>
 
-      <!-- Coverage -->
-      <div class="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 class="text-lg font-semibold text-gray-900">Покрытие по разделам</h2>
-        <div v-if="status.coverage.length === 0" class="mt-4 text-sm text-gray-400">
-          Нет назначенных разделов. Добавьте источники и назначьте их разделам.
-        </div>
-        <div v-else class="mt-4 space-y-2">
+      <!-- Pipeline steps -->
+      <div class="animate-in animate-in-delay-1">
+        <div class="grid grid-cols-4 gap-3">
           <div
-            v-for="item in status.coverage"
-            :key="item.section"
-            class="flex items-center justify-between rounded-md bg-gray-50 px-4 py-2"
+            v-for="(step, i) in pipelineSteps"
+            :key="step.key"
+            class="relative rounded-xl border p-5 transition-all duration-200"
+            :class="[
+              step.active
+                ? 'border-[var(--color-accent)] bg-[var(--color-accent-pale)] shadow-sm'
+                : step.done
+                  ? 'border-[var(--color-rule)] bg-[var(--color-paper-white)]'
+                  : 'border-[var(--color-rule-light)] bg-[var(--color-paper-warm)] opacity-60'
+            ]"
           >
-            <span class="text-sm font-medium text-gray-700">{{ item.section }}</span>
-            <span class="text-sm text-gray-500">{{ item.source_count }} источников</span>
+            <!-- Step number -->
+            <div class="flex items-center gap-3 mb-3">
+              <div
+                class="flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold"
+                :class="[
+                  step.done
+                    ? 'bg-[var(--color-ok)] text-white'
+                    : step.active
+                      ? 'bg-[var(--color-accent)] text-white'
+                      : 'bg-[var(--color-rule)] text-[var(--color-ink-muted)]'
+                ]"
+              >
+                <span v-if="step.done">&#10003;</span>
+                <span v-else>{{ i + 1 }}</span>
+              </div>
+              <span
+                class="text-sm font-semibold"
+                :class="step.active ? 'text-[var(--color-accent-deep)]' : 'text-[var(--color-ink)]'"
+              >
+                {{ step.label }}
+              </span>
+            </div>
+
+            <p class="text-xs text-[var(--color-ink-muted)] leading-relaxed">{{ step.desc }}</p>
+
+            <!-- Counter -->
+            <div v-if="step.count > 0" class="mt-3 pt-3 border-t border-[var(--color-rule-light)]">
+              <span class="font-[var(--font-mono)] text-lg font-medium text-[var(--color-ink)]">{{ step.count }}</span>
+              <span class="ml-1 text-xs text-[var(--color-ink-muted)]">{{ step.unit }}</span>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- Empty state CTA -->
+      <!-- Stats + Coverage row -->
+      <div class="grid grid-cols-3 gap-6 animate-in animate-in-delay-2">
+        <!-- Stats column -->
+        <div class="col-span-1 space-y-4">
+          <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider">
+            Статистика
+          </h2>
+
+          <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] divide-y divide-[var(--color-rule-light)]">
+            <div class="flex items-center justify-between px-5 py-4">
+              <span class="text-sm text-[var(--color-ink-muted)]">Источников</span>
+              <span class="font-[var(--font-mono)] text-xl font-medium text-[var(--color-ink)]">{{ status.sources.total }}</span>
+            </div>
+            <div class="flex items-center justify-between px-5 py-4">
+              <span class="text-sm text-[var(--color-ink-muted)]">Обработано</span>
+              <span class="font-[var(--font-mono)] text-xl font-medium text-[var(--color-ok)]">{{ status.sources.completed }}</span>
+            </div>
+            <div class="flex items-center justify-between px-5 py-4">
+              <span class="text-sm text-[var(--color-ink-muted)]">В очереди</span>
+              <span class="font-[var(--font-mono)] text-xl font-medium text-[var(--color-warn)]">{{ status.sources.pending }}</span>
+            </div>
+            <div class="flex items-center justify-between px-5 py-4">
+              <span class="text-sm text-[var(--color-ink-muted)]">Фрагментов</span>
+              <span class="font-[var(--font-mono)] text-xl font-medium text-[var(--color-accent)]">{{ status.total_fragments }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Coverage column -->
+        <div class="col-span-2 space-y-4">
+          <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider">
+            Покрытие по разделам
+          </h2>
+
+          <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-5">
+            <div v-if="status.coverage.length === 0" class="py-8 text-center">
+              <p class="text-sm text-[var(--color-ink-muted)]">
+                Нет назначенных разделов.
+              </p>
+              <p class="mt-1 text-xs text-[var(--color-ink-muted)]">
+                Обработайте источники и назначьте их разделам диссертации.
+              </p>
+            </div>
+
+            <div v-else class="space-y-3">
+              <div
+                v-for="item in status.coverage"
+                :key="item.section"
+                class="group"
+              >
+                <div class="flex items-center justify-between mb-1.5">
+                  <span class="text-sm font-medium text-[var(--color-ink)]">{{ item.section }}</span>
+                  <span class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)]">{{ item.source_count }}</span>
+                </div>
+                <div class="h-2 w-full rounded-full bg-[var(--color-rule-light)] overflow-hidden">
+                  <div
+                    class="h-full rounded-full bg-[var(--color-accent)] transition-all duration-500"
+                    :style="{ width: `${(item.source_count / maxCoverage) * 100}%` }"
+                  ></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recent sources -->
+      <div class="animate-in animate-in-delay-3" v-if="recentSources.length > 0">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider">
+            Недавние источники
+          </h2>
+          <RouterLink
+            to="/library"
+            class="text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-deep)] transition-colors"
+          >
+            Все источники &rarr;
+          </RouterLink>
+        </div>
+
+        <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] overflow-hidden">
+          <div
+            v-for="(src, i) in recentSources"
+            :key="src.citekey"
+            class="flex items-center justify-between px-5 py-3.5 hover:bg-[var(--color-paper-warm)] transition-colors"
+            :class="{ 'border-t border-[var(--color-rule-light)]': i > 0 }"
+          >
+            <div class="flex items-center gap-4 min-w-0">
+              <span class="font-[var(--font-mono)] text-xs text-[var(--color-accent)] shrink-0">{{ src.citekey }}</span>
+              <span class="text-sm text-[var(--color-ink)] truncate">{{ src.title || '—' }}</span>
+              <span v-if="src.year" class="text-xs text-[var(--color-ink-muted)] shrink-0">{{ src.year }}</span>
+            </div>
+            <span
+              class="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+              :class="{
+                'bg-[var(--color-ok-bg)] text-[var(--color-ok)]': src.status === 'completed',
+                'bg-[var(--color-warn-bg)] text-[var(--color-warn)]': src.status === 'pending',
+                'bg-[var(--color-err-bg)] text-[var(--color-err)]': src.status === 'failed',
+              }"
+            >
+              {{ src.status === 'completed' ? 'готово' : src.status === 'pending' ? 'ожидает' : 'ошибка' }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty state -->
       <div
         v-if="status.sources.total === 0"
-        class="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center"
+        class="animate-in animate-in-delay-2 rounded-xl border-2 border-dashed border-[var(--color-rule)] p-16 text-center"
       >
-        <div class="text-4xl">📄</div>
-        <h3 class="mt-3 text-lg font-semibold text-gray-900">Начните работу</h3>
-        <p class="mt-1 text-sm text-gray-500">
-          Добавьте первый источник, чтобы увидеть покрытие и фрагменты.
+        <div class="mx-auto w-16 h-16 rounded-2xl bg-[var(--color-accent-pale)] flex items-center justify-center mb-5">
+          <svg class="w-8 h-8 text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.331 0 4.512.89 6.148 2.354M12 6.042c1.985-1.392 4.37-2.292 7.025-2.292.944 0 1.857.14 2.725.4v14.25A9.001 9.001 0 0018 18c-2.331 0-4.512.89-6.148 2.354M12 6.042V20.354" />
+          </svg>
+        </div>
+        <h3 class="font-[var(--font-display)] text-xl font-semibold text-[var(--color-ink)]">
+          Начните исследование
+        </h3>
+        <p class="mt-2 text-sm text-[var(--color-ink-muted)] max-w-md mx-auto leading-relaxed">
+          Загрузите PDF-статьи в библиотеку. LitResearch извлечёт ключевые фрагменты,
+          оценит покрытие по разделам и поможет написать обзор литературы.
         </p>
         <RouterLink
           to="/library"
-          class="mt-4 inline-block rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+          class="mt-6 inline-flex items-center gap-2 rounded-lg bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[var(--color-accent-deep)] transition-colors shadow-sm"
         >
           Перейти в библиотеку
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+          </svg>
         </RouterLink>
       </div>
     </div>

--- a/saas/dashboard/src/views/LandingView.vue
+++ b/saas/dashboard/src/views/LandingView.vue
@@ -7,7 +7,7 @@ import { RouterLink } from 'vue-router'
     <!-- Hero -->
     <header class="mx-auto max-w-4xl px-6 py-24 text-center">
       <h1 class="text-5xl font-bold tracking-tight text-gray-900">
-        CiteQ
+        LitResearch
       </h1>
       <p class="mt-4 text-xl text-gray-600">
         AI-ассистент для академического письма
@@ -54,7 +54,7 @@ import { RouterLink } from 'vue-router'
 
     <!-- Footer -->
     <footer class="border-t border-gray-100 py-8 text-center text-sm text-gray-400">
-      CiteQ &copy; 2026. Powered by Klemma.
+      LitResearch &copy; 2026. Powered by Klemma.
     </footer>
   </div>
 </template>

--- a/saas/dashboard/src/views/LoginView.vue
+++ b/saas/dashboard/src/views/LoginView.vue
@@ -28,7 +28,7 @@ async function handleLogin() {
 <template>
   <div class="flex min-h-screen items-center justify-center bg-gray-50 px-4">
     <div class="w-full max-w-sm">
-      <h1 class="text-center text-2xl font-bold text-gray-900">Вход в CiteQ</h1>
+      <h1 class="text-center text-2xl font-bold text-gray-900">Вход в LitResearch</h1>
 
       <form class="mt-8 space-y-4" @submit.prevent="handleLogin">
         <div v-if="error" class="rounded-md bg-red-50 p-3 text-sm text-red-700">

--- a/saas/dashboard/src/views/RegisterView.vue
+++ b/saas/dashboard/src/views/RegisterView.vue
@@ -29,7 +29,7 @@ async function handleRegister() {
 <template>
   <div class="flex min-h-screen items-center justify-center bg-gray-50 px-4">
     <div class="w-full max-w-sm">
-      <h1 class="text-center text-2xl font-bold text-gray-900">Регистрация в CiteQ</h1>
+      <h1 class="text-center text-2xl font-bold text-gray-900">Регистрация в LitResearch</h1>
 
       <form class="mt-8 space-y-4" @submit.prevent="handleRegister">
         <div v-if="error" class="rounded-md bg-red-50 p-3 text-sm text-red-700">

--- a/saas/dashboard/src/views/SourceView.vue
+++ b/saas/dashboard/src/views/SourceView.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
+import { library, process, ApiError } from '@/api/client'
+import AppLayout from '@/components/AppLayout.vue'
+
+interface Fragment {
+  fragment_id: string
+  text: string
+  fragment_type: string
+  page_number: number | null
+  citation_intent: string | null
+}
+
+interface SourceDetail {
+  citekey: string
+  paper_id: string
+  status: string
+  title: string
+  authors: string
+  year: number | null
+  doi: string | null
+  abstract: string
+  fragments: Fragment[]
+}
+
+const route = useRoute()
+const router = useRouter()
+const citekey = route.params.citekey as string
+
+const source = ref<SourceDetail | null>(null)
+const loading = ref(true)
+const error = ref('')
+
+// Processing state
+const processing = ref(false)
+const jobId = ref<string | null>(null)
+const jobStatus = ref('')
+const jobError = ref('')
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+const intentLabel: Record<string, string> = {
+  background: 'фон',
+  method: 'метод',
+  result_comparison: 'результат',
+  extends: 'расширяет',
+  contrasts: 'контраст',
+  uses_data: 'данные',
+}
+
+const intentColor: Record<string, string> = {
+  background: 'bg-blue-100 text-blue-700',
+  method: 'bg-purple-100 text-purple-700',
+  result_comparison: 'bg-green-100 text-green-700',
+  extends: 'bg-teal-100 text-teal-700',
+  contrasts: 'bg-orange-100 text-orange-700',
+  uses_data: 'bg-yellow-100 text-yellow-700',
+}
+
+const typeLabel: Record<string, string> = {
+  key_idea: 'идея',
+  quote: 'цитата',
+  methodology: 'методология',
+  result: 'результат',
+  conclusion: 'вывод',
+  definition: 'определение',
+}
+
+const fragmentsByType = computed(() => {
+  if (!source.value) return {}
+  const groups: Record<string, Fragment[]> = {}
+  for (const f of source.value.fragments) {
+    const key = f.fragment_type || 'key_idea'
+    if (!groups[key]) groups[key] = []
+    groups[key].push(f)
+  }
+  return groups
+})
+
+async function loadSource() {
+  loading.value = true
+  error.value = ''
+  try {
+    source.value = await library.get(citekey)
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) {
+      error.value = 'Источник не найден'
+    } else {
+      error.value = 'Ошибка загрузки'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+async function startProcessing() {
+  processing.value = true
+  jobError.value = ''
+  jobStatus.value = 'queued'
+  try {
+    const resp = await process.submit(citekey)
+    jobId.value = resp.job_id
+    startPolling()
+  } catch (e) {
+    jobError.value = e instanceof ApiError ? e.message : 'Ошибка запуска обработки'
+    processing.value = false
+  }
+}
+
+function startPolling() {
+  if (pollTimer) clearInterval(pollTimer)
+  pollTimer = setInterval(async () => {
+    if (!jobId.value) return
+    try {
+      const resp = await process.jobStatus(jobId.value)
+      jobStatus.value = resp.status
+      if (resp.status === 'finished') {
+        stopPolling()
+        processing.value = false
+        await loadSource()
+      } else if (resp.status === 'failed') {
+        stopPolling()
+        processing.value = false
+        jobError.value = resp.result?.detail || 'Обработка завершилась с ошибкой'
+        await loadSource()
+      }
+    } catch {
+      // keep polling on transient errors
+    }
+  }, 3000)
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+onMounted(loadSource)
+onUnmounted(stopPolling)
+</script>
+
+<template>
+  <AppLayout>
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-24">
+      <div class="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent"></div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="py-12 text-center">
+      <p class="text-sm text-[var(--color-err)]">{{ error }}</p>
+      <RouterLink to="/library" class="mt-4 inline-block text-sm text-[var(--color-accent)]">
+        &larr; Вернуться в библиотеку
+      </RouterLink>
+    </div>
+
+    <!-- Source detail -->
+    <div v-else-if="source" class="space-y-8">
+      <!-- Breadcrumb -->
+      <div class="animate-in">
+        <RouterLink to="/library" class="text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-deep)] transition-colors">
+          &larr; Библиотека
+        </RouterLink>
+      </div>
+
+      <!-- Header -->
+      <div class="animate-in animate-in-delay-1">
+        <div class="flex items-start justify-between gap-6">
+          <div class="min-w-0">
+            <h1 class="font-[var(--font-display)] text-2xl font-bold text-[var(--color-ink)] tracking-tight leading-tight">
+              {{ source.title || source.citekey }}
+            </h1>
+            <div class="mt-2 flex flex-wrap items-center gap-3 text-sm text-[var(--color-ink-muted)]">
+              <span v-if="source.authors">{{ source.authors }}</span>
+              <span v-if="source.year" class="font-[var(--font-mono)]">{{ source.year }}</span>
+              <span class="font-[var(--font-mono)] text-xs text-[var(--color-accent)]">{{ source.citekey }}</span>
+              <a
+                v-if="source.doi"
+                :href="`https://doi.org/${source.doi}`"
+                target="_blank"
+                class="text-xs text-[var(--color-accent)] hover:underline"
+              >
+                DOI: {{ source.doi }}
+              </a>
+            </div>
+          </div>
+
+          <!-- Status + Process button -->
+          <div class="flex items-center gap-3 shrink-0">
+            <span
+              class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium"
+              :class="{
+                'bg-[var(--color-ok-bg)] text-[var(--color-ok)]': source.status === 'completed',
+                'bg-[var(--color-warn-bg)] text-[var(--color-warn)]': source.status === 'pending' || source.status === 'processing',
+                'bg-[var(--color-err-bg)] text-[var(--color-err)]': source.status === 'failed',
+              }"
+            >
+              {{ source.status === 'completed' ? 'готово' : source.status === 'pending' ? 'ожидает' : source.status === 'processing' ? 'обработка...' : 'ошибка' }}
+            </span>
+
+            <button
+              v-if="source.status === 'pending' || source.status === 'failed'"
+              @click="startProcessing"
+              :disabled="processing"
+              class="rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-semibold text-white hover:bg-[var(--color-accent-deep)] disabled:opacity-50 transition-colors"
+            >
+              {{ processing ? 'Обработка...' : 'Обработать' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Processing indicator -->
+      <div v-if="processing" class="animate-in rounded-xl border border-[var(--color-accent)] bg-[var(--color-accent-pale)] p-5">
+        <div class="flex items-center gap-3">
+          <div class="h-4 w-4 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent"></div>
+          <span class="text-sm font-medium text-[var(--color-accent-deep)]">
+            Извлекаем фрагменты из PDF...
+          </span>
+          <span class="text-xs text-[var(--color-ink-muted)]">{{ jobStatus }}</span>
+        </div>
+      </div>
+
+      <!-- Job error -->
+      <div v-if="jobError" class="rounded-xl border border-[var(--color-err)] bg-[var(--color-err-bg)] p-4">
+        <p class="text-sm text-[var(--color-err)]">{{ jobError }}</p>
+      </div>
+
+      <!-- Abstract -->
+      <div v-if="source.abstract" class="animate-in animate-in-delay-2 rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-6">
+        <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider mb-3">
+          Аннотация
+        </h2>
+        <p class="text-sm text-[var(--color-ink-light)] leading-relaxed">{{ source.abstract }}</p>
+      </div>
+
+      <!-- Fragments -->
+      <div v-if="source.fragments.length > 0" class="animate-in animate-in-delay-3 space-y-6">
+        <div class="flex items-center justify-between">
+          <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider">
+            Фрагменты
+          </h2>
+          <span class="font-[var(--font-mono)] text-sm text-[var(--color-ink-muted)]">
+            {{ source.fragments.length }}
+          </span>
+        </div>
+
+        <!-- Fragment groups by type -->
+        <div v-for="(frags, type) in fragmentsByType" :key="type" class="space-y-3">
+          <h3 class="text-xs font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider">
+            {{ typeLabel[type] || type }}
+          </h3>
+
+          <div class="space-y-2">
+            <div
+              v-for="f in frags"
+              :key="f.fragment_id"
+              class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-4 hover:border-[var(--color-rule)] transition-colors"
+            >
+              <p class="text-sm text-[var(--color-ink)] leading-relaxed">{{ f.text }}</p>
+              <div class="mt-3 flex flex-wrap items-center gap-2">
+                <span v-if="f.page_number" class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)]">
+                  стр. {{ f.page_number }}
+                </span>
+                <span
+                  v-if="f.citation_intent"
+                  class="rounded-full px-2 py-0.5 text-xs font-medium"
+                  :class="intentColor[f.citation_intent] || 'bg-gray-100 text-gray-600'"
+                >
+                  {{ intentLabel[f.citation_intent] || f.citation_intent }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- No fragments empty state -->
+      <div
+        v-else-if="source.status === 'completed'"
+        class="rounded-xl border-2 border-dashed border-[var(--color-rule)] p-12 text-center"
+      >
+        <p class="text-sm text-[var(--color-ink-muted)]">Фрагменты не найдены.</p>
+      </div>
+
+      <div
+        v-else-if="source.status === 'pending' && !processing"
+        class="rounded-xl border-2 border-dashed border-[var(--color-rule)] p-12 text-center"
+      >
+        <div class="mx-auto w-12 h-12 rounded-xl bg-[var(--color-accent-pale)] flex items-center justify-center mb-4">
+          <svg class="w-6 h-6 text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+          </svg>
+        </div>
+        <h3 class="font-[var(--font-display)] text-lg font-semibold text-[var(--color-ink)]">
+          Источник ещё не обработан
+        </h3>
+        <p class="mt-2 text-sm text-[var(--color-ink-muted)]">
+          Нажмите «Обработать», чтобы извлечь ключевые фрагменты из PDF.
+        </p>
+        <button
+          @click="startProcessing"
+          :disabled="processing"
+          class="mt-5 inline-flex items-center gap-2 rounded-lg bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[var(--color-accent-deep)] disabled:opacity-50 transition-colors"
+        >
+          Обработать
+        </button>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/saas/deploy/.env.example
+++ b/saas/deploy/.env.example
@@ -2,4 +2,9 @@
 KLEMMA_JWT_SECRET=change-me-to-a-random-64-char-hex-string
 
 # Optional — comma-separated allowed origins for CORS
-# KLEMMA_CORS_ORIGINS=https://app.klemma.ai
+# KLEMMA_CORS_ORIGINS=https://litresearch.ru
+
+# AI backend for fragment extraction (at least one required for processing)
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# KLEMMA_AI_MODEL=anthropic/claude-sonnet-4-20250514

--- a/saas/deploy/Caddyfile
+++ b/saas/deploy/Caddyfile
@@ -3,12 +3,23 @@
 }
 
 litresearch.ru {
-	reverse_proxy api:8000 {
-		header_up X-Real-IP {remote_host}
-		header_up X-Forwarded-For {remote_host}
-		header_up X-Forwarded-Proto {scheme}
+	# API proxy — strip /api prefix
+	handle_path /api/* {
+		reverse_proxy api:8000 {
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto {scheme}
+		}
 	}
 
+	# SPA static files
+	handle {
+		root * /srv/dashboard
+		try_files {path} /index.html
+		file_server
+	}
+
+	# Security headers
 	header {
 		X-Content-Type-Options nosniff
 		X-Frame-Options DENY

--- a/saas/deploy/docker-compose.yml
+++ b/saas/deploy/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     environment:
       - KLEMMA_DATA_DIR=/data/klemma
       - REDIS_URL=redis://redis:6379
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - KLEMMA_AI_MODEL=${KLEMMA_AI_MODEL:-anthropic/claude-sonnet-4-20250514}
     volumes:
       - klemma-data:/data/klemma
     depends_on:

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -8,9 +8,31 @@ or connections, since the worker runs in a separate process.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _create_ai_provider():
+    """Create an AI provider from environment variables.
+
+    Supports: ANTHROPIC_API_KEY, OPENAI_API_KEY via litellm backend.
+    Model: KLEMMA_AI_MODEL env var (default: anthropic/claude-sonnet-4-20250514).
+    """
+    from klemma.ai import create_ai
+    from klemma.config import AIConfig
+
+    model = os.getenv("KLEMMA_AI_MODEL", "anthropic/claude-sonnet-4-20250514")
+    api_keys = {}
+    if os.getenv("ANTHROPIC_API_KEY"):
+        api_keys["anthropic"] = os.environ["ANTHROPIC_API_KEY"]
+    if os.getenv("OPENAI_API_KEY"):
+        api_keys["openai"] = os.environ["OPENAI_API_KEY"]
+
+    config = AIConfig(backend="litellm", model=model)
+    config._resolved_api_keys = api_keys
+    return create_ai(config), config
 
 
 def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
@@ -19,8 +41,11 @@ def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
     This is the rq task equivalent of `klemma process <citekey>`.
     Runs in the worker process — initializes its own stores.
 
+    Pipeline: FileStore → PDFExtractor → AI extraction → PaperStore.
+
     Returns a dict with status and fragment count.
     """
+    from klemma.stores.file_store import LocalFileStore
     from klemma.stores.paper_store import LocalPaperStore
     from klemma.stores.user_library import LocalUserLibrary
 
@@ -28,10 +53,12 @@ def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
     library_db = data_path / "library.db"
     paper_store = LocalPaperStore(library_db)
     user_library = LocalUserLibrary(library_db)
+    file_store = LocalFileStore(data_path / "files")
 
     # Check paper exists
     paper = paper_store.get_paper_by_id(paper_id)
     if paper is None:
+        user_library.update_status(citekey, "failed")
         return {"status": "error", "detail": f"Paper {paper_id} not found"}
 
     # Check if already processed (has fragments)
@@ -47,31 +74,137 @@ def process_source(paper_id: str, citekey: str, data_dir: str) -> dict:
     # Mark as processing
     user_library.update_status(citekey, "processing")
 
-    # TODO: actual AI extraction will be wired here when the extraction
-    # pipeline is adapted for headless (no CLI) operation. For now, mark
-    # as pending — extraction requires PDF file access + AI backend config
-    # which aren't yet available in the SaaS context.
-    logger.info("process_source: %s (%s) — extraction not yet wired", citekey, paper_id)
-    user_library.update_status(citekey, "pending")
+    # Find PDF file in FileStore
+    paper_dir = file_store.get_paper_dir(paper_id)
+    pdf_files = list(paper_dir.glob("*.pdf")) if paper_dir.is_dir() else []
+    if not pdf_files:
+        user_library.update_status(citekey, "failed")
+        return {"status": "error", "detail": f"PDF not found for paper {paper_id}"}
 
-    return {
-        "status": "pending",
-        "citekey": citekey,
-        "detail": "Extraction pipeline not yet wired for SaaS",
-    }
+    # Extract PDF text
+    try:
+        from klemma.literature.pdf import PDFExtractor
+
+        pdf_path = pdf_files[0]
+
+        extractor = PDFExtractor()
+        pdf_text = extractor.extract(pdf_path)
+        if not pdf_text or len(pdf_text) < 500:
+            user_library.update_status(citekey, "failed")
+            return {"status": "error", "detail": "PDF text too short or extraction failed"}
+
+        logger.info("Extracted %d chars from PDF for %s", len(pdf_text), citekey)
+    except Exception as exc:
+        logger.error("PDF extraction failed for %s: %s", citekey, exc)
+        user_library.update_status(citekey, "failed")
+        return {"status": "error", "detail": f"PDF extraction failed: {exc}"}
+
+    # Check AI config
+    if not os.getenv("ANTHROPIC_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+        user_library.update_status(citekey, "pending")
+        return {
+            "status": "pending",
+            "citekey": citekey,
+            "detail": "No AI API key configured (set ANTHROPIC_API_KEY or OPENAI_API_KEY)",
+        }
+
+    # Create AI provider and extract fragments
+    try:
+        ai, ai_config = _create_ai_provider()
+
+        from klemma.hashing import compute_content_hash
+        from klemma.literature.models import ZoteroEntry
+        from klemma.models import FragmentRecord
+
+        # Build minimal entry from paper metadata
+        entry = ZoteroEntry(
+            id=citekey,
+            title=paper.title or citekey,
+            author=[{"family": a.strip()} for a in (paper.authors or "").split(",") if a.strip()],
+            issued={"date-parts": [[paper.year]]} if paper.year else None,
+            DOI=paper.doi,
+            abstract=paper.abstract or "",
+        )
+
+        # Render extraction prompt
+        prompt_path = Path(__file__).parent.parent.parent.parent / "prompts" / "extract.md"
+        if not prompt_path.exists():
+            # Installed package — prompts shipped alongside
+            import importlib.resources
+            prompt_path = Path(importlib.resources.files("klemma").parent.parent / "prompts" / "extract.md")
+
+        user_prompt = ai.render_prompt(
+            prompt_path,
+            title=entry.title or "Unknown",
+            authors=entry.authors_str,
+            year=entry.year or "Unknown",
+            journal=entry.container_title or "N/A",
+            doi=entry.DOI or "N/A",
+            abstract=entry.abstract or "Not available",
+            pdf_text=pdf_text[:50000],  # Cap at 50K chars
+            dissertation_context="",
+            available_tags="",
+            language="ru",
+            project_type="research",
+        )
+
+        system = (
+            "You are a research assistant extracting citation-worthy fragments from scientific papers. "
+            "Output only valid JSON with fragments array."
+        )
+
+        data = ai.call_json(system, user_prompt, max_tokens=4096)
+        if not data:
+            user_library.update_status(citekey, "failed")
+            return {"status": "error", "detail": "AI extraction returned no data"}
+
+        # Parse and save fragments
+        fragments = []
+        for f_data in data.get("fragments", []):
+            text = f_data.get("text", "").strip()
+            if not text:
+                continue
+            fragment_id = compute_content_hash(paper_id, text, f_data.get("page"))
+            fragments.append(FragmentRecord(
+                fragment_id=fragment_id,
+                paper_id=paper_id,
+                fragment_text=text,
+                fragment_type=f_data.get("type", "key_idea"),
+                page_number=f_data.get("page"),
+                citation_intent=f_data.get("citation_intent"),
+                content_hash=fragment_id,
+            ))
+
+        if not fragments:
+            user_library.update_status(citekey, "failed")
+            return {"status": "error", "detail": "No fragments extracted from PDF"}
+
+        # Save to paper store
+        prompt_hash = ""
+        model_name = ai_config.model
+        saved = paper_store.save_fragments(paper_id, fragments, prompt_hash, model_name)
+
+        user_library.update_status(citekey, "completed")
+        logger.info("Extracted %d fragments for %s (%s)", saved, citekey, paper_id)
+
+        return {
+            "status": "completed",
+            "citekey": citekey,
+            "fragment_count": saved,
+        }
+
+    except Exception as exc:
+        logger.error("AI extraction failed for %s: %s", citekey, exc, exc_info=True)
+        user_library.update_status(citekey, "failed")
+        return {"status": "error", "detail": f"Extraction failed: {type(exc).__name__}: {exc}"}
 
 
 def generate_research(section: str, data_dir: str) -> dict:
     """Generate a research briefing for a section.
 
-    This is the rq task equivalent of `klemma research -s <section>`.
-    Runs in the worker process — initializes its own stores.
-
     Returns a dict with status and content.
     """
     # TODO: wire to researcher.research_section() when adapted for headless mode.
-    # Requires: AI backend config, fragment RAG, outline context — none available
-    # in SaaS context yet.
     logger.info("generate_research: section %s — not yet wired", section)
     return {
         "status": "pending",
@@ -83,13 +216,9 @@ def generate_research(section: str, data_dir: str) -> dict:
 def generate_draft(section: str, data_dir: str) -> dict:
     """Generate a section draft.
 
-    This is the rq task equivalent of `klemma draft -s <section>`.
-    Runs in the worker process — initializes its own stores.
-
     Returns a dict with status and content.
     """
     # TODO: wire to drafter.generate_draft() when adapted for headless mode.
-    # Requires: AI backend config, research report, RAG fragments, outline context.
     logger.info("generate_draft: section %s — not yet wired", section)
     return {
         "status": "pending",


### PR DESCRIPTION
### **User description**
## Summary

- **Dashboard redesign**: editorial/academic design system with pipeline tracker, coverage bars, recent sources
- **Source detail view**: `/library/:citekey` with fragments, process button, job polling
- **AI pipeline wired**: `process_source` task now does real extraction (FileStore → PDFExtractor → LiteLLM → PaperStore)
- **LitResearch branding**: CiteQ → LitResearch across all views

Part of #191

## What's new

### Dashboard
- 4-step visual pipeline (Загрузить → Обработать → Разметить → Написать) with progress tracking
- Stats panel with color-coded counters
- Coverage bar chart (replaces flat list)
- Recent sources section
- Custom fonts: Literata (serif headings), Source Sans 3 (body), JetBrains Mono (data)
- Teal accent palette replacing generic indigo

### Source Detail (`/library/:citekey`)
- Full metadata display (title, authors, year, DOI link, abstract)
- Fragments grouped by type (идея, цитата, методология, результат, вывод)
- Citation intent badges (фон, метод, результат, расширяет, контраст, данные)
- "Обработать" button → submits rq job → polls every 3s → shows fragments on completion
- Processing indicator with spinner

### AI Pipeline (`tasks.py`)
- `process_source()` wired to real extraction pipeline
- Reads PDF from FileStore → extracts text with PyMuPDF → calls Claude via LiteLLM
- Saves FragmentRecord objects to PaperStore with content-addressable IDs
- Config via env vars: `ANTHROPIC_API_KEY`, `KLEMMA_AI_MODEL`
- Worker docker-compose updated with AI env vars

## Test plan

- [x] 1366 tests pass
- [x] Lint clean (ruff)
- [x] Frontend builds without errors
- [x] Deployed to VPS at http://82.146.38.192
- [ ] E2E: upload PDF → process → see fragments (requires ANTHROPIC_API_KEY on VPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Wire `process_source` to PDF+AI extraction

- Add source detail page with polling

- Redesign dashboard and app branding

- Configure SPA deploy and AI env vars


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sd["Source detail view"]
  rq["RQ processing job"]
  pdf["PDF text extraction"]
  ai["LiteLLM fragment extraction"]
  store["Stored fragments and statuses"]
  dash["Dashboard progress and recent sources"]
  sd -- "starts" --> rq
  rq -- "extracts" --> pdf
  pdf -- "sends to" --> ai
  ai -- "writes" --> store
  store -- "updates" --> dash
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>tasks.py</strong><dd><code>Wire background PDF extraction through AI pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-932e9e2fb59ba03031134ebed9bae0d96b7b3efed441e6f53a63f3f8870e5f93">+149/-20</a></td>

</tr>

<tr>
  <td><strong>AppLayout.vue</strong><dd><code>Add branded header and user display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-7f77523c4e69b0b8240cc9448d875bd609ac48af3d4c95c1aaac5bc66a160304">+51/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DashboardView.vue</strong><dd><code>Redesign dashboard with pipeline and coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-586d22843c80c731111681ddd5c3a314bf7cc409594068d72a9420d5fb20bbbb">+237/-39</a></td>

</tr>

<tr>
  <td><strong>SourceView.vue</strong><dd><code>Create source detail view with processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-16f2c93e588d6973c9b8b499f57f6ed3fbfd7eb35a36b7d432ee43cf97152d3f">+313/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Register authenticated source detail route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-3b6af757a270f4432becc6894cf423a124e63cf7ea095e6c8e8b9248197247c3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.css</strong><dd><code>Add academic theme tokens and animations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-0448074717139317a54fd0aad50ab592d43928f4b8e42b3f6b4daebc5e4f5515">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>LandingView.vue</strong><dd><code>Rename public landing page branding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-9217afa75d86c09fedf67862f62ac934e4cf042ccf44f6ee9b6ad57d38fa1e32">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LoginView.vue</strong><dd><code>Rename login screen to LitResearch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-4a48ab41b84ae3ddb7ce5aceaded890a6b6f2d2728fbdd7eb729b8ac36d0e95a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RegisterView.vue</strong><dd><code>Rename registration screen to LitResearch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-7f04cb98f65d96504d5fb2ebc6f0c9d06a5501a133286ca3c6289c97d21431a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>index.html</strong><dd><code>Set app metadata title and fonts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-d1c991ca67adbd512160f4c39241217966fdb5d9d4aa509c81a4261fa82e1792">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env.example</strong><dd><code>Document AI environment variables for workers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-c88bfc35c49a218ab64d7a183420106df7c42c32f9b84adc217b73b90a5b6118">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Caddyfile</strong><dd><code>Serve SPA and proxy API paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-6a600fa19113289c9c7ffe7ba1442eaffbdaf5314a64530219951d927fd5eb56">+15/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Pass AI credentials into worker service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/198/files#diff-85ce8da897101e404ac4cd1fcf08e2c4ab2eae485aaffb7f41c476b07dd40281">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

