### PR TITLE
feat: coverage map + section assignment (Phase 2 complete) (#191)

### DIFF
--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -52,11 +52,20 @@ function logout() {
             <RouterLink
               to="/library"
               class="relative rounded-md px-3.5 py-2 text-sm font-medium transition-colors"
-              :class="route.path === '/library'
+              :class="route.path.startsWith('/library')
                 ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
                 : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
             >
               Библиотека
+            </RouterLink>
+            <RouterLink
+              to="/coverage"
+              class="relative rounded-md px-3.5 py-2 text-sm font-medium transition-colors"
+              :class="route.path === '/coverage'
+                ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
+                : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
+            >
+              Покрытие
             </RouterLink>
           </nav>
         </div>

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -36,6 +36,12 @@ const router = createRouter({
       component: () => import('../views/SourceView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/coverage',
+      name: 'coverage',
+      component: () => import('../views/CoverageView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/saas/dashboard/src/views/CoverageView.vue
+++ b/saas/dashboard/src/views/CoverageView.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, RouterLink } from 'vue-router'
+import { projects, library } from '@/api/client'
+import AppLayout from '@/components/AppLayout.vue'
+
+const router = useRouter()
+
+const coverage = ref<{ total_sources: number; sections: Record<string, number>; chapters: Record<string, number> } | null>(null)
+const sectionSources = ref<Record<string, string[]>>({})
+const expandedSection = ref<string | null>(null)
+const loading = ref(true)
+const allSources = ref<{ citekey: string; title: string; status: string }[]>([])
+
+const sortedSections = computed(() => {
+  if (!coverage.value) return []
+  return Object.entries(coverage.value.sections)
+    .sort(([a], [b]) => {
+      const aParts = a.split('.').map(Number)
+      const bParts = b.split('.').map(Number)
+      for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+        const diff = (aParts[i] || 0) - (bParts[i] || 0)
+        if (diff !== 0) return diff
+      }
+      return 0
+    })
+})
+
+const maxCount = computed(() => {
+  if (!coverage.value) return 1
+  const vals = Object.values(coverage.value.sections)
+  return Math.max(...vals, 1)
+})
+
+const unassignedCount = computed(() => {
+  if (!coverage.value) return 0
+  const assignedKeys = new Set(Object.values(sectionSources.value).flat())
+  return allSources.value.filter(s => !assignedKeys.has(s.citekey)).length
+})
+
+async function toggleSection(section: string) {
+  if (expandedSection.value === section) {
+    expandedSection.value = null
+    return
+  }
+  expandedSection.value = section
+  if (!sectionSources.value[section]) {
+    try {
+      const resp = await projects.sectionSources(section)
+      sectionSources.value[section] = resp.citekeys
+    } catch {
+      sectionSources.value[section] = []
+    }
+  }
+}
+
+onMounted(async () => {
+  try {
+    const [cov, lib] = await Promise.all([projects.coverage(), library.list()])
+    coverage.value = cov
+    allSources.value = lib.sources
+  } catch {
+    router.push('/login')
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <AppLayout>
+    <div v-if="loading" class="flex items-center justify-center py-24">
+      <div class="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent"></div>
+    </div>
+
+    <div v-else-if="coverage" class="space-y-8">
+      <!-- Header -->
+      <div class="animate-in">
+        <h1 class="font-[var(--font-display)] text-2xl font-bold text-[var(--color-ink)] tracking-tight">
+          Карта покрытия
+        </h1>
+        <p class="mt-1 text-sm text-[var(--color-ink-muted)]">
+          Распределение источников по разделам диссертации
+        </p>
+      </div>
+
+      <!-- Summary cards -->
+      <div class="grid grid-cols-3 gap-4 animate-in animate-in-delay-1">
+        <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-5">
+          <div class="font-[var(--font-mono)] text-2xl font-medium text-[var(--color-ink)]">{{ coverage.total_sources }}</div>
+          <div class="text-sm text-[var(--color-ink-muted)]">Назначено источников</div>
+        </div>
+        <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-5">
+          <div class="font-[var(--font-mono)] text-2xl font-medium text-[var(--color-accent)]">{{ sortedSections.length }}</div>
+          <div class="text-sm text-[var(--color-ink-muted)]">Разделов с источниками</div>
+        </div>
+        <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-5">
+          <div class="font-[var(--font-mono)] text-2xl font-medium" :class="unassignedCount > 0 ? 'text-[var(--color-warn)]' : 'text-[var(--color-ok)]'">
+            {{ unassignedCount }}
+          </div>
+          <div class="text-sm text-[var(--color-ink-muted)]">Без раздела</div>
+        </div>
+      </div>
+
+      <!-- Coverage map -->
+      <div class="animate-in animate-in-delay-2">
+        <!-- Empty state -->
+        <div v-if="sortedSections.length === 0" class="rounded-xl border-2 border-dashed border-[var(--color-rule)] p-16 text-center">
+          <div class="mx-auto w-12 h-12 rounded-xl bg-[var(--color-accent-pale)] flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+            </svg>
+          </div>
+          <h3 class="font-[var(--font-display)] text-lg font-semibold text-[var(--color-ink)]">Нет назначенных разделов</h3>
+          <p class="mt-2 text-sm text-[var(--color-ink-muted)] max-w-md mx-auto">
+            Откройте источник в библиотеке и назначьте его разделам диссертации.
+          </p>
+          <RouterLink
+            to="/library"
+            class="mt-5 inline-flex items-center gap-2 rounded-lg bg-[var(--color-accent)] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[var(--color-accent-deep)] transition-colors"
+          >
+            Перейти в библиотеку
+          </RouterLink>
+        </div>
+
+        <!-- Sections list -->
+        <div v-else class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] overflow-hidden">
+          <div
+            v-for="([section, count], i) in sortedSections"
+            :key="section"
+            :class="{ 'border-t border-[var(--color-rule-light)]': i > 0 }"
+          >
+            <!-- Section row -->
+            <button
+              @click="toggleSection(section)"
+              class="w-full flex items-center gap-4 px-5 py-4 hover:bg-[var(--color-paper-warm)] transition-colors text-left"
+            >
+              <!-- Section number -->
+              <span class="font-[var(--font-mono)] text-sm font-medium text-[var(--color-accent)] w-16 shrink-0">
+                {{ section }}
+              </span>
+
+              <!-- Bar -->
+              <div class="flex-1">
+                <div class="h-3 w-full rounded-full bg-[var(--color-rule-light)] overflow-hidden">
+                  <div
+                    class="h-full rounded-full transition-all duration-500"
+                    :class="count >= 10 ? 'bg-[var(--color-ok)]' : count >= 5 ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-warn)]'"
+                    :style="{ width: `${(count / maxCount) * 100}%` }"
+                  ></div>
+                </div>
+              </div>
+
+              <!-- Count -->
+              <span class="font-[var(--font-mono)] text-sm text-[var(--color-ink-muted)] w-8 text-right shrink-0">
+                {{ count }}
+              </span>
+
+              <!-- Expand indicator -->
+              <svg
+                class="w-4 h-4 text-[var(--color-ink-muted)] transition-transform shrink-0"
+                :class="{ 'rotate-180': expandedSection === section }"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+              </svg>
+            </button>
+
+            <!-- Expanded: sources in this section -->
+            <div v-if="expandedSection === section" class="bg-[var(--color-paper-warm)] px-5 py-3 border-t border-[var(--color-rule-light)]">
+              <div v-if="!sectionSources[section]" class="text-sm text-[var(--color-ink-muted)]">Загрузка...</div>
+              <div v-else-if="sectionSources[section].length === 0" class="text-sm text-[var(--color-ink-muted)]">Нет источников</div>
+              <div v-else class="space-y-1">
+                <RouterLink
+                  v-for="ck in sectionSources[section]"
+                  :key="ck"
+                  :to="`/library/${ck}`"
+                  class="block font-[var(--font-mono)] text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-deep)] hover:underline transition-colors py-0.5"
+                >
+                  {{ ck }}
+                </RouterLink>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/saas/dashboard/src/views/SourceView.vue
+++ b/saas/dashboard/src/views/SourceView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import { library, process, ApiError } from '@/api/client'
+import { library, process, projects, ApiError } from '@/api/client'
 import AppLayout from '@/components/AppLayout.vue'
 
 interface Fragment {
@@ -77,6 +77,51 @@ const fragmentsByType = computed(() => {
   return groups
 })
 
+// Section assignment state
+const assignedSections = ref<string[]>([])
+const newSection = ref('')
+const assignLoading = ref(false)
+const assignError = ref('')
+
+async function loadSections() {
+  try {
+    const resp = await projects.sourceSections(citekey)
+    assignedSections.value = resp.sections
+  } catch {
+    assignedSections.value = []
+  }
+}
+
+async function addSection() {
+  const section = newSection.value.trim()
+  if (!section || assignedSections.value.includes(section)) return
+  assignLoading.value = true
+  assignError.value = ''
+  try {
+    const updated = [...assignedSections.value, section]
+    await projects.assignSections(citekey, updated)
+    assignedSections.value = updated
+    newSection.value = ''
+  } catch (e) {
+    assignError.value = e instanceof ApiError ? e.message : 'Ошибка назначения'
+  } finally {
+    assignLoading.value = false
+  }
+}
+
+async function removeSection(section: string) {
+  assignLoading.value = true
+  try {
+    const updated = assignedSections.value.filter(s => s !== section)
+    await projects.assignSections(citekey, updated)
+    assignedSections.value = updated
+  } catch {
+    // ignore
+  } finally {
+    assignLoading.value = false
+  }
+}
+
 async function loadSource() {
   loading.value = true
   error.value = ''
@@ -137,7 +182,10 @@ function stopPolling() {
   }
 }
 
-onMounted(loadSource)
+onMounted(() => {
+  loadSource()
+  loadSections()
+})
 onUnmounted(stopPolling)
 </script>
 
@@ -234,6 +282,51 @@ onUnmounted(stopPolling)
           Аннотация
         </h2>
         <p class="text-sm text-[var(--color-ink-light)] leading-relaxed">{{ source.abstract }}</p>
+      </div>
+
+      <!-- Section assignment -->
+      <div class="animate-in animate-in-delay-3 rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] p-6">
+        <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider mb-4">
+          Разделы диссертации
+        </h2>
+
+        <!-- Assigned sections -->
+        <div v-if="assignedSections.length > 0" class="flex flex-wrap gap-2 mb-4">
+          <span
+            v-for="section in assignedSections"
+            :key="section"
+            class="inline-flex items-center gap-1.5 rounded-full bg-[var(--color-accent-pale)] px-3 py-1 text-sm font-medium text-[var(--color-accent-deep)]"
+          >
+            {{ section }}
+            <button
+              @click="removeSection(section)"
+              class="text-[var(--color-accent)] hover:text-[var(--color-err)] transition-colors"
+              :disabled="assignLoading"
+            >
+              &times;
+            </button>
+          </span>
+        </div>
+        <p v-else class="text-sm text-[var(--color-ink-muted)] mb-4">
+          Не назначен ни одному разделу.
+        </p>
+
+        <!-- Add section form -->
+        <form @submit.prevent="addSection" class="flex items-center gap-2">
+          <input
+            v-model="newSection"
+            placeholder="Номер раздела (например: 1.2.3)"
+            class="flex-1 rounded-lg border border-[var(--color-rule)] bg-[var(--color-paper)] px-3 py-2 text-sm text-[var(--color-ink)] placeholder-[var(--color-ink-muted)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+          />
+          <button
+            type="submit"
+            :disabled="assignLoading || !newSection.trim()"
+            class="rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-semibold text-white hover:bg-[var(--color-accent-deep)] disabled:opacity-50 transition-colors"
+          >
+            Назначить
+          </button>
+        </form>
+        <div v-if="assignError" class="mt-2 text-sm text-[var(--color-err)]">{{ assignError }}</div>
       </div>
 
       <!-- Fragments -->


### PR DESCRIPTION
### **User description**
## Summary

Completes **Phase 2** of the MVP Frontend epic (#191):
- **Coverage map** (`/coverage`): expandable section bars, click to see assigned sources
- **Section assignment**: add/remove section tags on source detail page
- **Nav update**: "Покрытие" tab in header

## Phase 2 checklist — all done

- [x] PDF upload (PR #195)
- [x] Processing trigger (PR #198)
- [x] Job status polling (PR #198)
- [x] Source detail view with fragments (PR #198)
- [x] Section assignment UI ← this PR
- [x] Coverage map ← this PR
- [x] Coverage detail ← this PR

## Test plan

- [x] Lint clean
- [x] Build succeeds
- [x] Deployed to VPS

Part of #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `coverage` page with section drilldown

- Enable source section assignment management

- Add `coverage` route and navigation tab

- Keep library nav active on detail


___

### Diagram Walkthrough


```mermaid
flowchart LR
  source["Source detail page"]
  assign["Section assignment API calls"]
  coverage["Coverage page"]
  details["Expanded section source lists"]
  nav["Updated app navigation"]
  source -- "assigns sections via" --> assign
  assign -- "updates data shown in" --> coverage
  coverage -- "reveals" --> details
  nav -- "links users to" --> coverage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AppLayout.vue</strong><dd><code>Add coverage nav and improve active states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/components/AppLayout.vue

<ul><li>Keep <code>Библиотека</code> highlighted for child routes<br> <li> Add <code>Покрытие</code> navigation link<br> <li> Highlight the new coverage page when active</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/200/files#diff-7f77523c4e69b0b8240cc9448d875bd609ac48af3d4c95c1aaac5bc66a160304">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CoverageView.vue</strong><dd><code>Create coverage map with expandable sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/CoverageView.vue

<ul><li>Add new authenticated coverage overview page<br> <li> Load coverage stats and library sources<br> <li> Sort dissertation sections numerically<br> <li> Expand sections to fetch linked source <code>citekeys</code></ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/200/files#diff-1fc2548e817c87f3eb46d4a62fe5a6fcbffe5b5eed2712bf20ea8fd6533527f0">+189/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SourceView.vue</strong><dd><code>Add section assignment to source detail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/SourceView.vue

<ul><li>Load assigned sections for the current source<br> <li> Add form to assign dissertation sections<br> <li> Allow removing assigned section chips<br> <li> Show assignment errors and loading state</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/200/files#diff-16f2c93e588d6973c9b8b499f57f6ed3fbfd7eb35a36b7d432ee43cf97152d3f">+95/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Register authenticated coverage page route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/router/index.ts

<ul><li>Register new <code>/coverage</code> protected route<br> <li> Lazy-load <code>CoverageView</code> for authenticated users</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/200/files#diff-3b6af757a270f4432becc6894cf423a124e63cf7ea095e6c8e8b9248197247c3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

