### PR TITLE
feat: show reference gaps in library view (#208)

### DIFF
--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -140,6 +140,9 @@ export const library = {
       job_id: string | null
     }>
   },
+
+  gaps: () =>
+    request<{ gaps: { title: string; authors: string | null; year: number | null; cited_by_count: number; intents: string | null }[]; total: number; detail?: string }>('/library/gaps'),
 }
 
 // User projects (CRUD)

--- a/saas/dashboard/src/views/LibraryView.vue
+++ b/saas/dashboard/src/views/LibraryView.vue
@@ -30,6 +30,27 @@ const dragOver = ref(false)
 // Processing state per source
 const processingJobs = ref<Record<string, string>>({})
 
+// Reference gaps
+interface Gap {
+  title: string
+  authors: string | null
+  year: number | null
+  cited_by_count: number
+  intents: string | null
+}
+const gaps = ref<Gap[]>([])
+const gapsDetail = ref('')
+
+async function loadGaps() {
+  try {
+    const data = await library.gaps()
+    gaps.value = data.gaps
+    gapsDetail.value = data.detail ?? ''
+  } catch {
+    gaps.value = []
+  }
+}
+
 async function loadSources() {
   loading.value = true
   try {
@@ -134,8 +155,8 @@ function onFileInput(e: Event) {
   input.value = ''
 }
 
-onMounted(loadSources)
-watch(() => projectStore.activeProjectId, loadSources)
+onMounted(() => { loadSources(); loadGaps() })
+watch(() => projectStore.activeProjectId, () => { loadSources(); loadGaps() })
 </script>
 
 <template>
@@ -279,6 +300,41 @@ watch(() => projectStore.activeProjectId, loadSources)
           </tbody>
         </table>
       </div>
+    </div>
+
+    <!-- Reference gaps -->
+    <div v-if="gaps.length > 0" class="mt-8 animate-in animate-in-delay-3">
+      <h2 class="font-[var(--font-display)] text-sm font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider mb-3">
+        Рекомендуемая литература
+      </h2>
+      <p class="text-xs text-[var(--color-ink-muted)] mb-4">
+        Источники, которые часто цитируются вашими статьями, но отсутствуют в библиотеке.
+      </p>
+
+      <div class="rounded-xl border border-[var(--color-rule)] bg-[var(--color-paper-white)] divide-y divide-[var(--color-rule-light)]">
+        <div
+          v-for="(gap, i) in gaps"
+          :key="i"
+          class="px-5 py-3.5"
+        >
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-[var(--color-ink)]">{{ gap.title }}</p>
+              <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--color-ink-muted)]">
+                <span v-if="gap.authors">{{ gap.authors }}</span>
+                <span v-if="gap.year" class="font-[var(--font-mono)]">{{ gap.year }}</span>
+              </div>
+            </div>
+            <span class="shrink-0 inline-flex items-center rounded-full bg-[var(--color-warn-bg)] text-[var(--color-warn)] px-2.5 py-0.5 text-xs font-medium">
+              {{ gap.cited_by_count }} цит.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="gapsDetail && sources.length >= 3" class="mt-8">
+      <p class="text-xs text-[var(--color-ink-muted)]">{{ gapsDetail }}</p>
     </div>
   </AppLayout>
 </template>

--- a/saas/dashboard/src/views/LibraryView.vue
+++ b/saas/dashboard/src/views/LibraryView.vue
@@ -42,6 +42,8 @@ const gaps = ref<Gap[]>([])
 const gapsDetail = ref('')
 
 async function loadGaps() {
+  gaps.value = []
+  gapsDetail.value = ''
   try {
     const data = await library.gaps()
     gaps.value = data.gaps
@@ -333,8 +335,8 @@ watch(() => projectStore.activeProjectId, () => { loadSources(); loadGaps() })
       </div>
     </div>
 
-    <div v-else-if="gapsDetail && sources.length >= 3" class="mt-8">
-      <p class="text-xs text-[var(--color-ink-muted)]">{{ gapsDetail }}</p>
+    <div v-else-if="gapsDetail" class="mt-8">
+      <p class="text-sm text-[var(--color-ink-muted)]">{{ gapsDetail }}</p>
     </div>
   </AppLayout>
 </template>

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -326,6 +326,22 @@ async def upload_pdf(
     )
 
 
+@router.get("/gaps")
+async def list_reference_gaps(
+    user: UserRecord = Depends(get_current_user),
+) -> dict:
+    """Return reference gaps — papers cited by library sources but not in the library."""
+    paper_store = get_paper_store()
+    library = get_user_library()
+
+    source_count = library.count()
+    if source_count < 3:
+        return {"gaps": [], "total": 0, "detail": "Загрузите больше источников (минимум 3) для анализа пробелов"}
+
+    gaps = paper_store.get_reference_gaps(limit=30)
+    return {"gaps": gaps, "total": len(gaps)}
+
+
 def _enqueue_processing(paper_id: str, citekey: str, user_id: str, project_id: str | None = None) -> str | None:
     """Enqueue a process_source job. Returns job_id or None if Redis unavailable."""
     if not _RQ_AVAILABLE:

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -294,6 +294,35 @@ class LocalPaperStore:
         return inserted
 
     # ------------------------------------------------------------------ #
+    # Citation graph — reference gaps                                      #
+    # ------------------------------------------------------------------ #
+
+    def get_reference_gaps(self, limit: int = 50) -> list[dict]:
+        """Return cited papers not in the library, sorted by citation frequency.
+
+        A "gap" is a paper referenced by sources in the library but not itself
+        present as a paper. Identified by cited_title_hash not matching any
+        paper's title hash.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                """SELECT
+                     cg.cited_title as title,
+                     cg.cited_authors as authors,
+                     cg.cited_year as year,
+                     COUNT(DISTINCT cg.citing_paper_id) as cited_by_count,
+                     GROUP_CONCAT(DISTINCT cg.citation_intent) as intents
+                   FROM citation_graph cg
+                   LEFT JOIN papers p ON cg.cited_title_hash = p.paper_id
+                   WHERE p.paper_id IS NULL
+                   GROUP BY cg.cited_title_hash
+                   ORDER BY cited_by_count DESC
+                   LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------ #
     # Paper-level embeddings                                               #
     # ------------------------------------------------------------------ #
 

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -300,9 +300,8 @@ class LocalPaperStore:
     def get_reference_gaps(self, limit: int = 50) -> list[dict]:
         """Return cited papers not in the library, sorted by citation frequency.
 
-        A "gap" is a paper referenced by sources in the library but not itself
-        present as a paper. Identified by cited_title_hash not matching any
-        paper's title hash.
+        A "gap" is a paper referenced in citation_graph but whose normalized
+        title doesn't match any paper in the library.
         """
         with self._conn() as conn:
             rows = conn.execute(
@@ -313,8 +312,10 @@ class LocalPaperStore:
                      COUNT(DISTINCT cg.citing_paper_id) as cited_by_count,
                      GROUP_CONCAT(DISTINCT cg.citation_intent) as intents
                    FROM citation_graph cg
-                   LEFT JOIN papers p ON cg.cited_title_hash = p.paper_id
-                   WHERE p.paper_id IS NULL
+                   WHERE NOT EXISTS (
+                     SELECT 1 FROM papers p
+                     WHERE LOWER(TRIM(p.title)) = LOWER(TRIM(cg.cited_title))
+                   )
                    GROUP BY cg.cited_title_hash
                    ORDER BY cited_by_count DESC
                    LIMIT ?""",


### PR DESCRIPTION
### **User description**
## Summary

- Backend: `paper_store.get_reference_gaps()` queries citation_graph for papers cited by library sources but not in the library
- API: `GET /library/gaps` — returns gaps sorted by citation frequency (requires min 3 completed sources)
- Frontend: "Рекомендуемая литература" section in LibraryView below source table
- Each gap shows: title, authors, year, citation count badge

## Note

Citation graph data is populated during PDF processing via `extract.md` prompt. If no sources have been processed yet, the gaps section will be empty. This is expected — gaps appear after the first few sources are processed and their bibliography references are extracted.

## Test plan

- [x] 1385 tests pass
- [x] ruff clean
- [x] Frontend builds clean
- [x] Deployed to litresearch.ru
- [ ] Manual: verify gaps appear after processing 3+ sources
- [ ] Manual: verify empty state when <3 sources

Closes #208
Part of #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `/library/gaps` recommendation endpoint

- Aggregate missing citations from `citation_graph`

- Show recommended literature in Library view

- Add frontend API client for gaps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  view["Library view"]
  api["`GET /library/gaps`"]
  route["Library gaps route"]
  store["`PaperStore.get_reference_gaps()`"]
  graph["`citation_graph` missing references"]

  view -- "loads recommendations" --> api
  api -- "handled by" --> route
  route -- "queries top gaps" --> store
  store -- "aggregates uncataloged citations" --> graph
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>library.py</strong><dd><code>Add library reference gaps API endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/api/routes/library.py

<ul><li>Add <code>GET /library/gaps</code> route<br> <li> Require at least 3 library sources<br> <li> Return empty result with guidance detail<br> <li> Fetch up to 30 gaps from paper store</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/210/files#diff-858dd4bb6beae7a27e620ebc70b27d0dc5882adfe072def2ac59cb65362504b3">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>paper_store.py</strong><dd><code>Query aggregated reference gaps from storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/stores/paper_store.py

<ul><li>Add <code>get_reference_gaps()</code> query helper<br> <li> Read missing references from <code>citation_graph</code><br> <li> Exclude papers already present in library<br> <li> Group by cited title and sort by frequency</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/210/files#diff-0e0b5218e426149735eb691b6037b0ac09ebaf49a82a04eaf5132fa92cb7f0ae">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LibraryView.vue</strong><dd><code>Display gap recommendations in library page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/LibraryView.vue

<ul><li>Define gap data model and state<br> <li> Load gaps on mount and project changes<br> <li> Render <code>Рекомендуемая литература</code> section<br> <li> Show title, authors, year, and citation count</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/210/files#diff-a300e8120a4e4e1e4c5d1462b69c2044e8ae579cec51594a5eb9b6519cae952f">+58/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Add typed client for gaps endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/api/client.ts

<ul><li>Add <code>library.gaps()</code> API client method<br> <li> Type response fields for gap metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/210/files#diff-d092565b085919a261ff1b5bd79d63d7cd909fe9c8b3f7983938c7664a083bf5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

