### PR TITLE
feat: extract citation links from PDF bibliography (#219)

### DIFF
--- a/prompts/extract.md
+++ b/prompts/extract.md
@@ -75,7 +75,14 @@ Return a JSON object:
       "citation_intent": "method"
     }
   ],
-  "summary": "2-3 sentence summary of the paper's contribution to the project"
+  "summary": "2-3 sentence summary of the paper's contribution to the project",
+  "key_references": [
+    {
+      "title": "Title of a key paper cited in the bibliography",
+      "authors": "First Author et al.",
+      "year": 2020
+    }
+  ]
 }
 ```
 
@@ -89,8 +96,9 @@ Guidelines:
 7. Usage hints should be in {{ language }}
 8. Fragments text stays in original paper language
 9. citation_intent must be one of: background, method, result_comparison, extends, contrasts, uses_data
+10. key_references: extract 5-15 most important papers from the bibliography/references section. Include title, authors, year. These are used to identify gaps in the user's library
 {% if section_types %}
-10. When assigning section, prefer semantic section types: {{ section_types }}
+11. When assigning section, prefer semantic section types: {{ section_types }}
 {% endif %}
 
 Respond with ONLY valid JSON.

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -269,6 +269,12 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
                 sorted(predicted_sections), citekey, project_id,
             )
 
+        # Save citation links from bibliography (for reference gap analysis)
+        key_refs = data.get("key_references", [])
+        if key_refs:
+            links_saved = paper_store.save_citation_links(paper_id, key_refs)
+            logger.info("Saved %d citation links for %s", links_saved, citekey)
+
         user_library.update_status(citekey, "completed")
         logger.info("Extracted %d fragments for %s (%s)", saved, citekey, paper_id)
 

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -332,6 +332,42 @@ class LocalPaperStore:
         return inserted
 
     # ------------------------------------------------------------------ #
+    # Citation graph                                                       #
+    # ------------------------------------------------------------------ #
+
+    def save_citation_links(self, paper_id: str, references: list[dict]) -> int:
+        """Save citation links from a paper's bibliography to citation_graph.
+
+        Each reference: {"title": str, "authors": str, "year": int|None}.
+        Returns count of links saved.
+        """
+        import hashlib
+
+        saved = 0
+        with self._conn() as conn:
+            for ref in references:
+                title = (ref.get("title") or "").strip()
+                if not title:
+                    continue
+                title_hash = hashlib.md5(title.lower().encode()).hexdigest()
+                conn.execute(
+                    """INSERT OR IGNORE INTO citation_graph
+                       (citing_paper_id, cited_title_hash, cited_title,
+                        cited_authors, cited_year, citation_intent)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        paper_id,
+                        title_hash,
+                        title,
+                        ref.get("authors", ""),
+                        ref.get("year"),
+                        ref.get("citation_intent", "background"),
+                    ),
+                )
+                saved += 1
+        return saved
+
+    # ------------------------------------------------------------------ #
     # Citation graph — reference gaps                                      #
     # ------------------------------------------------------------------ #
 


### PR DESCRIPTION
### **User description**
## Summary

Extract citation links (key references) from PDF bibliography during processing. Unblocks the "Рекомендуемая литература" gaps feature in the Library view.

### Changes

1. **`extract.md` prompt**: Added `key_references` field — AI extracts 5-15 key papers from the bibliography
2. **`paper_store.save_citation_links()`**: New method, writes to existing `citation_graph` table (MD5 title hash for dedup)
3. **`process_source()`**: Parses `key_references` from AI response, saves to citation_graph

### Before
`citation_graph` had 0 rows on production → `/library/gaps` always empty → "Рекомендуемая литература" section never shown.

### After
Each processed source contributes 5-15 bibliography entries → citation_graph fills up → gaps appear after 3+ sources.

## PM Review
Approved. Tier 1 Analyze step. ~20 lines, unblocks #208. Core differentiator.

## CTO Review
Approved. No red line violations. save_citation_links() implementation-only (not in PaperStore protocol). No migration needed.

## Test plan

- [x] ruff clean
- [x] 50 tests pass (test_paper_store + test_prompts)
- [x] Deployed to litresearch.ru
- [ ] Manual: upload PDF → verify citation_graph populated
- [ ] Manual: after 3+ processed sources, /library/gaps returns data

Closes #219
Part of #208, #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `key_references` to extraction prompt

- Persist bibliography links in `citation_graph`

- Save references during SaaS processing

- Unblock library gap recommendations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  prompt["`extract.md` returns `key_references`"]
  task["`process_source()` reads extracted references"]
  store["`paper_store.save_citation_links()` writes `citation_graph`"]
  gaps["Library gap analysis gets citation data"]
  prompt -- "AI response includes" --> task
  task -- "persists via" --> store
  store -- "populates data for" --> gaps
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Save extracted references during processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/api/tasks.py

<ul><li>Parse <code>key_references</code> from extraction response<br> <li> Save bibliography links with <code>paper_store.save_citation_links()</code><br> <li> Log how many citation links were saved</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/220/files#diff-932e9e2fb59ba03031134ebed9bae0d96b7b3efed441e6f53a63f3f8870e5f93">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>paper_store.py</strong><dd><code>Add citation graph persistence helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/stores/paper_store.py

<ul><li>Add <code>save_citation_links()</code> for <code>citation_graph</code><br> <li> Skip references without a usable title<br> <li> Generate MD5 title hashes for deduplication<br> <li> Insert reference metadata with default intent</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/220/files#diff-0e0b5218e426149735eb691b6037b0ac09ebaf49a82a04eaf5132fa92cb7f0ae">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extract.md</strong><dd><code>Expand extraction prompt for bibliography references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prompts/extract.md

<ul><li>Extend JSON output with <code>key_references</code><br> <li> Define reference fields: title, authors, year<br> <li> Instruct extraction of 5-15 bibliography papers<br> <li> Renumber section assignment guideline accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/220/files#diff-d23d59f996ff4b4ee8677033cf19a399cdf4e3c835a094abc5c982b291fa75b2">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

