### PR TITLE
fix: restructure klemma init wizard

### DIFF
--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -948,6 +948,70 @@ def _discover_paper_sources(project_dir: Path, values):
     click.echo(f"  {len(citekeys)} sources registered.")
 
 
+def _read_multiline_input() -> str:
+    """Read multi-line input until double-Enter or EOF."""
+    lines: list[str] = []
+    empty_count = 0
+    try:
+        while True:
+            line = input("    ")
+            if not line.strip():
+                empty_count += 1
+                if empty_count >= 2:
+                    break
+                lines.append("")
+            else:
+                empty_count = 0
+                lines.append(line)
+    except EOFError:
+        pass
+    return "\n".join(lines).rstrip()
+
+
+def _detect_openai_key(prefill: dict | None) -> str:
+    """Auto-detect OpenAI API key from env vars, klemmarc, or parent config.
+
+    Returns the key string if found, empty string otherwise.
+    """
+    import os
+
+    # 1. Check environment variable
+    env_key = os.environ.get("OPENAI_API_KEY", "")
+    if env_key:
+        return env_key
+
+    # 2. Check klemmarc
+    try:
+        import yaml as _yaml
+
+        from .setup import _find_klemmarc
+
+        klemmarc = _find_klemmarc(Path.home())
+        if klemmarc:
+            krc = _yaml.safe_load(klemmarc.read_text(encoding="utf-8")) or {}
+            krc_key = krc.get("api_keys", {}).get("openai", "")
+            if krc_key:
+                return krc_key
+    except Exception:
+        pass
+
+    # 3. Check parent project config (config cascade)
+    try:
+        from .config import discover_project_chain, resolve_effective_config
+
+        chain = discover_project_chain(Path.cwd())
+        if chain:
+            cfg = resolve_effective_config(chain)
+            resolved = getattr(cfg.ai, "_resolved_api_keys", {})
+            parent_key = resolved.get("openai", "")
+            if parent_key:
+                return parent_key
+    except Exception:
+        pass
+
+    return ""
+
+
 def _interactive_init(project_type: str, prefill: dict | None = None):
     """Run interactive setup wizard, return collected values.
 
@@ -964,60 +1028,24 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
 
     click.echo("\nKlemma project setup\n")
 
-    # --- Plan-prospect (first question) ---
-    plan_data = pf.get("_plan_data")  # set when --plan was passed
-    if not plan_data:
-        plan_path_str = click.prompt(
-            "  Dissertation plan (.docx) — path or empty to skip",
-            default="",
-            show_default=False,
-        )
-        if plan_path_str:
-            plan_file = Path(plan_path_str.strip())
-            if plan_file.exists():
-                try:
-                    from .plan_parser import parse as parse_plan
-
-                    plan_data = parse_plan(plan_file)
-                    click.echo(f"    Parsed: {plan_data.title[:70]}...")
-                    click.echo(
-                        f"    Chapters: {len(plan_data.chapters)}, "
-                        f"НР: {len(plan_data.results)}, "
-                        f"Tasks: {len(plan_data.tasks)}"
-                    )
-                except ImportError:
-                    click.echo(
-                        "    [warning] python-docx not installed: pip install python-docx"
-                    )
-                except Exception as e:
-                    click.echo(f"    [warning] Could not parse: {e}")
-            else:
-                click.echo(f"    [warning] File not found: {plan_file}")
-
-    # --- Project basics (pre-filled from plan if available) ---
-    if plan_data:
-        project_type = "dissertation"
-        title = plan_data.title
-        click.echo(f"\n  Project type: {project_type}")
-        click.echo(f"  Title: {title[:80]}...")
-    else:
-        project_type = click.prompt(
-            "  Project type",
-            type=click.Choice(
-                ["dissertation", "paper", "thesis"], case_sensitive=False
-            ),
-            default=pf.get("project_type", project_type),
-        )
-        title = click.prompt(
-            "  Project title",
-            default=pf.get("title", ""),
-            show_default=bool(pf.get("title")),
-        )
+    # --- Step 1: Project type ---
+    project_type = click.prompt(
+        "  Project type",
+        type=click.Choice(
+            ["dissertation", "paper", "thesis"], case_sensitive=False
+        ),
+        default=pf.get("project_type", project_type),
+    )
+    title = click.prompt(
+        "  Project title",
+        default=pf.get("title", ""),
+        show_default=bool(pf.get("title")),
+    )
 
     # Paper-specific: description and keywords are essential for source discovery
     description = ""
     keywords: list[str] = []
-    if project_type == "paper" and not plan_data:
+    if project_type == "paper":
         description = click.prompt(
             "  Research description (1-2 sentences)",
             default=pf.get("description", ""),
@@ -1031,23 +1059,106 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
         )
         keywords = [k.strip() for k in kw_str.split(",") if k.strip()] if kw_str else []
 
+    # --- Step 2: Project outline ---
+    click.echo()
+    click.echo("  Project outline")
+    click.echo("  " + "─" * 50)
+    click.echo("  Klemma uses the outline to build chapter/section")
+    click.echo("  structure for your project. All subsequent commands")
+    click.echo("  (research, process, draft) use this structure to")
+    click.echo("  filter sources and generate section-targeted content.")
+    click.echo("  Formats: .docx, .md, .txt — or type text directly.")
+    click.echo()
+
+    plan_data = pf.get("_plan_data")  # set when --plan was passed
+    if plan_data:
+        click.echo(f"  Outline loaded: {plan_data.title[:70]}...")
+        click.echo(
+            f"    Chapters: {len(plan_data.chapters)}, "
+            f"НР: {len(plan_data.results)}, "
+            f"Tasks: {len(plan_data.tasks)}"
+        )
+    else:
+        outline_path_str = click.prompt(
+            "  File path (.docx, .md, .txt) — or empty to type/skip",
+            default="",
+            show_default=False,
+        )
+        if outline_path_str:
+            outline_file = Path(outline_path_str.strip()).expanduser()
+            if outline_file.exists():
+                try:
+                    from .plan_parser import parse_file
+
+                    plan_data = parse_file(outline_file)
+                    if plan_data.title:
+                        click.echo(f"    Parsed: {plan_data.title[:70]}...")
+                    if plan_data.chapters:
+                        click.echo(
+                            f"    Chapters: {len(plan_data.chapters)}, "
+                            f"НР: {len(plan_data.results)}, "
+                            f"Tasks: {len(plan_data.tasks)}"
+                        )
+                    else:
+                        click.echo("    No chapter structure detected — stored as context")
+                except ImportError:
+                    click.echo(
+                        "    [warning] python-docx not installed: pip install python-docx"
+                    )
+                except Exception as e:
+                    click.echo(f"    [warning] Could not parse: {e}")
+            else:
+                click.echo(f"    [warning] File not found: {outline_file}")
+
+        if not plan_data:
+            if click.confirm("  Type or paste outline text?", default=False):
+                click.echo("    Enter text below. Press Enter twice to finish.")
+                raw_text = _read_multiline_input()
+                if raw_text:
+                    from .plan_parser import parse_text
+
+                    plan_data = parse_text(raw_text)
+                    if plan_data.chapters:
+                        click.echo(f"    Parsed: {len(plan_data.chapters)} chapters")
+                    elif plan_data.title:
+                        click.echo(f"    Title: {plan_data.title[:70]}")
+                    else:
+                        click.echo("    Stored as project context")
+                    # If no chapters detected, store raw text as description
+                    if not plan_data.chapters and not description:
+                        description = raw_text[:500]
+
+    # Use plan title if available and user didn't provide one
+    if plan_data and plan_data.title and not title:
+        title = plan_data.title
+        click.echo(f"  Title (from outline): {title[:80]}")
+
     language = click.prompt(
         "  AI language",
         default=pf.get("language", "ru"),
     )
 
-    # --- AI setup ---
-    # Step 1: OpenAI key (needed for embeddings; optionally for LLM too)
+    # --- Step 3: AI setup ---
+    # Auto-detect OpenAI key from env / klemmarc / parent config
     click.echo("\n  AI setup")
+    detected_key = _detect_openai_key(pf)
     openai_api_key = ""
-    has_openai = click.confirm(
-        "  Do you have an OpenAI API key? (needed for embeddings)",
-        default=bool(pf.get("openai_api_key")),
-    )
-    if has_openai:
-        openai_api_key = click.prompt("  OpenAI API key", hide_input=True)
-        if not openai_api_key.startswith("sk-"):
-            click.echo("    [warning] Key doesn't start with sk- — saving anyway")
+
+    if detected_key:
+        # Key found — show masked version and skip the question
+        masked = detected_key[:7] + "..." + detected_key[-4:]
+        click.echo(f"  + OpenAI API key detected: {masked}")
+        openai_api_key = detected_key
+        has_openai = True
+    else:
+        has_openai = click.confirm(
+            "  Do you have an OpenAI API key? (needed for embeddings)",
+            default=bool(pf.get("openai_api_key")),
+        )
+        if has_openai:
+            openai_api_key = click.prompt("  OpenAI API key", hide_input=True)
+            if not openai_api_key.startswith("sk-"):
+                click.echo("    [warning] Key doesn't start with sk- — saving anyway")
 
     # Step 2: LLM backend
     backend = ""

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -52,7 +52,7 @@ from ..config import (
     "plan_path",
     default=None,
     type=click.Path(exists=True),
-    help="Path to dissertation plan-prospect .docx \u2014 auto-fills project from it",
+    help="Path to project outline (.docx, .md, .txt) \u2014 auto-fills structure from it",
 )
 @click.option(
     "--name", "project_name", default=None, help="Project title (non-interactive)"
@@ -155,30 +155,33 @@ def init(
     if not force and config_path.exists():
         no_input = True
 
-    # --- --plan: initialize from dissertation plan-prospect .docx ---
+    # --- --plan: initialize from project outline file ---
     plan_data = None
     if plan_path:
-        from ..plan_parser import parse as parse_plan
+        from ..plan_parser import parse_file
 
         try:
-            plan_data = parse_plan(plan_path)
+            plan_data = parse_file(plan_path)
         except ImportError as e:
             console.print(f"[red]{e}[/red]")
             return
         except (FileNotFoundError, ValueError) as e:
-            console.print(f"[red]Cannot parse plan: {e}[/red]")
+            console.print(f"[red]Cannot parse outline: {e}[/red]")
             return
 
-        console.print(f"\n[green]Parsed plan-prospect:[/green] {plan_path}")
-        console.print(f"  Title: {plan_data.title[:80]}...")
+        console.print(f"\n[green]Parsed project outline:[/green] {plan_path}")
+        if plan_data.title:
+            console.print(f"  Title: {plan_data.title[:80]}...")
         console.print(f"  Chapters: {len(plan_data.chapters)}")
-        console.print(f"  Scientific results: {len(plan_data.results)}")
-        console.print(f"  Research tasks: {len(plan_data.tasks)}")
+        if plan_data.results:
+            console.print(f"  Scientific results: {len(plan_data.results)}")
+        if plan_data.tasks:
+            console.print(f"  Research tasks: {len(plan_data.tasks)}")
 
         # Pre-fill from plan (user can still override via wizard)
         project_name = project_name or plan_data.title
-        description = description or plan_data.description[:200]
-        project_type = "dissertation"
+        if plan_data.description:
+            description = description or plan_data.description[:200]
         # Auto-enable outline
         outline = True
 
@@ -187,11 +190,11 @@ def init(
         # --plan mode: run wizard but pre-fill from plan, pass plan_data through
         prefill = prefill or {}
         prefill["title"] = plan_data.title
-        prefill["description"] = plan_data.description[:200]
-        prefill["project_type"] = "dissertation"
+        if plan_data.description:
+            prefill["description"] = plan_data.description[:200]
+        prefill["project_type"] = project_type
         prefill["_plan_data"] = plan_data
         values = _interactive_init(project_type, prefill=prefill)
-        values.project_type = "dissertation"
         if not values.plan_data:
             values.plan_data = plan_data
     elif not no_input:
@@ -200,8 +203,6 @@ def init(
         # Plan may have been provided interactively
         if values.plan_data:
             plan_data = values.plan_data
-            project_type = "dissertation"
-            values.project_type = "dissertation"
             outline = True
     elif has_value_flags:
         # Build InitValues from CLI flags

--- a/src/klemma/plan_parser.py
+++ b/src/klemma/plan_parser.py
@@ -1,13 +1,16 @@
-"""Parser for dissertation plan-prospect .docx files.
+"""Parser for project plan / outline files.
 
-Extracts structured data from a standard Russian dissertation plan-prospect:
+Extracts structured data from academic project outlines:
 title, description (актуальность), research objectives, scientific results,
 and full chapter structure.
 
+Supported formats:
+- .docx — full structured parsing from dissertation plan-prospect (python-docx required)
+- .md / .txt — text-based structure extraction from headings and numbered lists
+- Raw text — same extraction via parse_text()
+
 Designed as a pure module — no CLI dependencies. Works with file paths
 or BytesIO for SaaS use.
-
-Requires: python-docx (optional dependency).
 """
 
 import re
@@ -152,6 +155,133 @@ def parse(source: Union[str, Path, BytesIO]) -> PlanData:
             data.chapters = _parse_chapters(body_paragraphs)
 
     return data
+
+
+# --- Alternative chapter heading patterns for text/markdown ---
+_RE_CHAPTER_EN = re.compile(r"^(?:Chapter|Раздел)\s+(\d+)[\.:\s]\s*(.+)", re.IGNORECASE)
+_RE_CHAPTER_PLAIN = re.compile(r"^(\d+)[\.:\s]\s+(.+)")
+
+
+def parse_text(text: str) -> PlanData:
+    """Parse outline structure from plain text or markdown.
+
+    Extracts chapter/section structure from headings and numbered patterns.
+    Supports Russian (Глава N.) and English (Chapter N.) formats,
+    as well as plain numbered lists (1. Title, 1.1. Section).
+
+    Args:
+        text: outline text (plain or markdown).
+
+    Returns:
+        PlanData with extracted fields (may have empty chapters if
+        no structure detected — the raw text is still useful as context).
+    """
+    data = PlanData()
+    lines = text.strip().split("\n")
+
+    if not lines:
+        return data
+
+    current_chapter: Optional[Chapter] = None
+    title_found = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Remove markdown heading markers for pattern matching
+        clean = stripped.lstrip("#").strip()
+
+        # First significant heading → title
+        if not title_found and stripped.startswith("#") and not stripped.startswith("##"):
+            data.title = clean
+            title_found = True
+            continue
+
+        # Try chapter patterns: "Глава N. Title"
+        ch_match = _RE_CHAPTER.match(clean)
+        if not ch_match:
+            ch_match = _RE_CHAPTER_EN.match(clean)
+        if not ch_match:
+            # "N. Title" (single number, not "N.N. Title")
+            m = _RE_CHAPTER_PLAIN.match(clean)
+            if m and "." not in m.group(1):
+                ch_match = m
+
+        if ch_match:
+            num = int(ch_match.group(1))
+            title = ch_match.group(2).strip()
+            if title.upper() in _STRUCTURAL_LINES:
+                continue
+            current_chapter = Chapter(number=num, title=title)
+            data.chapters.append(current_chapter)
+            continue
+
+        # Section: "N.N. Title" or "- N.N. Title"
+        sec_match = _RE_SECTION.match(clean)
+        if sec_match and current_chapter is not None:
+            sec_num = sec_match.group(1)
+            sec_title = sec_match.group(2).strip()
+            if _RE_CONCLUSIONS.match(clean):
+                continue
+            level = sec_num.count(".") + 1
+            section = Section(number=sec_num, title=sec_title, level=level)
+            current_chapter.sections.append(section)
+            continue
+
+        # Scientific results: "НР N. Title"
+        nr_match = _RE_NR.match(clean)
+        if nr_match:
+            data.results.append(ScientificResult(
+                number=int(nr_match.group(1)),
+                title=nr_match.group(2).strip(),
+                description="",
+            ))
+
+    # Fallback title: first non-empty line
+    if not data.title:
+        for line in lines:
+            s = line.strip().lstrip("#").strip()
+            if s:
+                data.title = s
+                break
+
+    return data
+
+
+def parse_file(source: Union[str, Path]) -> PlanData:
+    """Parse plan/outline from file, auto-detecting format by extension.
+
+    Supported formats:
+    - .docx — full structured parsing (python-docx required)
+    - .md, .txt, .text, .markdown — text-based structure extraction
+
+    Args:
+        source: file path.
+
+    Returns:
+        PlanData with extracted fields.
+
+    Raises:
+        FileNotFoundError: if file doesn't exist.
+        ValueError: if format is not supported.
+        ImportError: if .docx and python-docx not installed.
+    """
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    ext = path.suffix.lower()
+    if ext == ".docx":
+        return parse(path)
+    elif ext in (".md", ".txt", ".text", ".markdown"):
+        text = path.read_text(encoding="utf-8")
+        return parse_text(text)
+    else:
+        raise ValueError(
+            f"Unsupported format: {ext}. Use .docx, .md, or .txt"
+        )
 
 
 def _extract_title(paragraphs) -> str:


### PR DESCRIPTION
### **User description**
## Summary

- **Logical wizard order**: project type → title → outline → AI setup (was: outline → type → title → AI)
- **Multi-format outline**: supports `.docx`, `.md`, `.txt` files and direct text input (type/paste in terminal)
- **Outline explanation**: tells users why the outline matters — it drives source filtering, research targeting, and draft generation
- **Auto-detect OpenAI key**: checks `OPENAI_API_KEY` env var, `~/.klemmarc.yaml`, and parent config cascade — skips the question if already found
- **No hardcoded dissertation type**: respects user's project type choice when outline is provided

## Changes

### `plan_parser.py`
- Added `parse_text(text)` — extracts chapters/sections from markdown or plain numbered lists
- Added `parse_file(path)` — auto-detects format by extension, dispatches to appropriate parser

### `cli.py`
- Restructured `_interactive_init()` — project type first, then outline with explanation
- Added `_read_multiline_input()` for terminal text paste (double-Enter to finish)
- Added `_detect_openai_key()` — checks env → klemmarc → parent config

### `commands/manage.py`
- Updated `--plan` help text and parsing to use `parse_file()` (supports all formats)
- Removed hardcoded `project_type = "dissertation"` override

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 1386 passed
- [x] Manual test: `parse_text()` with markdown (chapters, sections, НР extracted correctly)
- [x] Manual test: `parse_text()` with plain numbered list
- [x] Manual test: `parse_file()` with `.md` extension
- [ ] Manual test: run `klemma init` interactively to verify new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Reorder init wizard around project basics

- Add multi-format outline parsing and entry

- Support pasted outline text in terminal

- Auto-detect OpenAI keys, keep chosen type


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wizard["Interactive init wizard"]
  outline["Outline file or pasted text"]
  parser["Multi-format outline parsing"]
  keydetect["OpenAI key auto-detection"]
  sources["Env, klemmarc, parent config"]
  setup["Prefilled project configuration"]

  wizard -- "accepts" --> outline
  outline -- "uses" --> parser
  parser -- "fills" --> setup
  sources -- "checked by" --> keydetect
  keydetect -- "prepopulates" --> setup
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Restructure interactive init and outline input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/cli.py

<ul><li>Added <code>_read_multiline_input()</code> for pasted outlines<br> <li> Added <code>_detect_openai_key()</code> across config sources<br> <li> Reordered wizard to ask type and title first<br> <li> Added outline explanation, parsing, and title fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/221/files#diff-71bbd85653e4f71964d6a4f9d2880996406e9b1d6830fecadd1dd7927b3aa983">+171/-60</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plan_parser.py</strong><dd><code>Add text and file outline parsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/plan_parser.py

<ul><li>Expanded parser docs for outline formats<br> <li> Added regexes for English and plain numbering<br> <li> Added <code>parse_text()</code> for markdown and plain text<br> <li> Added <code>parse_file()</code> extension-based dispatch and validation</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/221/files#diff-1eabcd2166fd4071486f729543d76d5baa18f75f9b8cf26b4bf325317c5a4cfc">+134/-4</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manage.py</strong><dd><code>Generalize `--plan` handling for outlines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/commands/manage.py

<ul><li>Updated <code>--plan</code> help for outline formats<br> <li> Switched plan loading to <code>parse_file()</code><br> <li> Improved outline parse output for optional fields<br> <li> Removed forced <code>dissertation</code> project type overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/221/files#diff-70e4727a66fef57a4e0d8cc986a0aedaba26bd6ccfd2cc240634d3144db71f1d">+17/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

