### PR TITLE
feat: redesign LitResearch landing page + type-aware init defaults

### DIFF
--- a/saas/dashboard/index.html
+++ b/saas/dashboard/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="AI-ассистент для академического письма. Загрузите PDF — получите фрагменты, покрытие и рекомендации.">
+    <meta name="description" content="AI-ассистент для обзора литературы. Извлекает цитатные фрагменты из PDF, привязывает к разделам работы, показывает пробелы в покрытии. 10-15x быстрее ручной работы.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=Source+Sans+3:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <title>LitResearch — AI-ассистент для академического письма</title>
+    <title>LitResearch — извлечение фрагментов и покрытие литературы для диссертации</title>
   </head>
   <body>
     <div id="app"></div>

--- a/saas/dashboard/src/assets/main.css
+++ b/saas/dashboard/src/assets/main.css
@@ -9,7 +9,7 @@
   --color-paper-warm: #f5f3ef;
   --color-paper-white: #ffffff;
 
-  /* Teal accent — scholarly, not corporate */
+  /* Teal accent — polar waters, not corporate */
   --color-accent: #0d7377;
   --color-accent-light: #14919b;
   --color-accent-pale: #e0f4f4;
@@ -46,17 +46,124 @@ body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--color-rule); border-radius: 3px; }
 
-/* Subtle entry animation */
+/* ── Animations: Polar Manuscript ── */
+
+/* Entry: fade up */
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(8px); }
+  from { opacity: 0; transform: translateY(12px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
 .animate-in {
-  animation: fade-up 0.4s ease-out both;
+  animation: fade-up 0.5s ease-out both;
 }
 
-.animate-in-delay-1 { animation-delay: 0.08s; }
-.animate-in-delay-2 { animation-delay: 0.16s; }
-.animate-in-delay-3 { animation-delay: 0.24s; }
-.animate-in-delay-4 { animation-delay: 0.32s; }
+.animate-in-delay-1 { animation-delay: 0.1s; }
+.animate-in-delay-2 { animation-delay: 0.2s; }
+.animate-in-delay-3 { animation-delay: 0.3s; }
+.animate-in-delay-4 { animation-delay: 0.4s; }
+.animate-in-delay-5 { animation-delay: 0.5s; }
+.animate-in-delay-6 { animation-delay: 0.6s; }
+
+/* Scroll-triggered reveal */
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Staggered children */
+.stagger-children > * {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.stagger-children.visible > *:nth-child(1) { transition-delay: 0s; opacity: 1; transform: none; }
+.stagger-children.visible > *:nth-child(2) { transition-delay: 0.08s; opacity: 1; transform: none; }
+.stagger-children.visible > *:nth-child(3) { transition-delay: 0.16s; opacity: 1; transform: none; }
+.stagger-children.visible > *:nth-child(4) { transition-delay: 0.24s; opacity: 1; transform: none; }
+.stagger-children.visible > *:nth-child(5) { transition-delay: 0.32s; opacity: 1; transform: none; }
+.stagger-children.visible > *:nth-child(6) { transition-delay: 0.4s; opacity: 1; transform: none; }
+
+/* Card hover lift */
+.hover-lift {
+  transition: transform 0.25s ease-out, box-shadow 0.25s ease-out;
+}
+
+.hover-lift:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(26, 26, 46, 0.08);
+}
+
+/* Grain texture overlay for landing page */
+.grain::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.03;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+/* Subtle pulse for accent elements */
+@keyframes pulse-soft {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.pulse-soft {
+  animation: pulse-soft 3s ease-in-out infinite;
+}
+
+/* Beam on button border */
+@keyframes beam-travel {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+
+.beam-border {
+  position: relative;
+  overflow: hidden;
+}
+
+.beam-border::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-accent-light) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: beam-travel 3s linear infinite;
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+/* Float animation for decorative elements */
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+.float {
+  animation: float 4s ease-in-out infinite;
+}
+
+.float-delayed {
+  animation: float 4s ease-in-out infinite;
+  animation-delay: 2s;
+}

--- a/saas/dashboard/src/views/LandingView.vue
+++ b/saas/dashboard/src/views/LandingView.vue
@@ -1,60 +1,565 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const openFaq = ref<number | null>(null)
+
+function toggleFaq(index: number) {
+  openFaq.value = openFaq.value === index ? null : index
+}
+
+/* Scroll-triggered reveals */
+let observer: IntersectionObserver | null = null
+
+onMounted(() => {
+  observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add('visible')
+        }
+      })
+    },
+    { threshold: 0.15 }
+  )
+  document.querySelectorAll('.reveal, .stagger-children').forEach((el) => {
+    observer!.observe(el)
+  })
+})
+
+onUnmounted(() => {
+  observer?.disconnect()
+})
+
+const faqs = [
+  {
+    q: 'Это инструмент для написания диссертации за меня?',
+    a: 'Нет. LitResearch — инструмент для работы с научной литературой: извлечение фрагментов, анализ покрытия, обнаружение пробелов. Он помогает систематизировать источники и генерирует черновики обзора, но не пишет диссертацию и не предназначен для обхода систем антиплагиата.',
+  },
+  {
+    q: 'Чем это отличается от ChatGPT / Claude для работы с литературой?',
+    a: 'ChatGPT и Claude генерируют ответы из обучающих данных и могут выдумывать ссылки. LitResearch работает только с вашей библиотекой — каждый фрагмент и каждая цитата привязаны к реальному PDF, который вы загрузили.',
+  },
+  {
+    q: 'Нужен ли Zotero для работы?',
+    a: 'Нет. В веб-версии вы загружаете PDF напрямую. CLI-версия (open source) поддерживает интеграцию с Zotero для тех, кто уже его использует.',
+  },
+  {
+    q: 'Какие AI-модели используются?',
+    a: 'Поддерживается более 100 провайдеров через LiteLLM: Claude, GPT, Qwen, Gemini, локальные модели через Ollama. Вы выбираете модель, которая вам подходит.',
+  },
+  {
+    q: 'Сколько это стоит?',
+    a: 'CLI-версия Klemma — open source. Веб-версия LitResearch даёт 1 млн токенов бесплатно при регистрации. Детали тарифов появятся позже.',
+  },
+  {
+    q: 'Безопасны ли мои данные?',
+    a: 'Ваши PDF хранятся на сервере и не передаются третьим лицам. Для AI-обработки отправляется только текст — без метаданных и файлов целиком.',
+  },
+]
 </script>
 
 <template>
-  <div class="min-h-screen bg-white">
-    <!-- Hero -->
-    <header class="mx-auto max-w-4xl px-6 py-24 text-center">
-      <h1 class="text-5xl font-bold tracking-tight text-gray-900">
-        LitResearch
-      </h1>
-      <p class="mt-4 text-xl text-gray-600">
-        AI-ассистент для академического письма
-      </p>
-      <p class="mt-2 text-lg text-gray-500">
-        Загрузите PDF — получите фрагменты, покрытие и рекомендации
-      </p>
-      <div class="mt-10 flex justify-center gap-4">
-        <RouterLink
-          to="/register"
-          class="rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500"
-        >
-          Начать бесплатно
-        </RouterLink>
-        <RouterLink
-          to="/login"
-          class="rounded-lg border border-gray-300 px-6 py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50"
-        >
+  <div class="relative min-h-screen bg-paper">
+    <!-- Nav -->
+    <nav class="mx-auto flex max-w-5xl items-center justify-between px-6 py-5">
+      <span class="font-display text-2xl font-semibold text-ink">LitResearch</span>
+      <div class="flex items-center gap-4">
+        <RouterLink to="/login" class="text-base font-medium text-ink-muted hover:text-ink transition-colors">
           Войти
         </RouterLink>
+        <RouterLink
+          to="/register"
+          class="rounded-lg bg-accent px-5 py-2.5 text-base font-semibold text-white hover:bg-accent-light transition-colors"
+        >
+          Попробовать
+        </RouterLink>
+      </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="relative mx-auto max-w-4xl px-6 pt-20 pb-24 text-center">
+      <!-- Decorative polar circles -->
+      <div class="pointer-events-none absolute top-8 left-1/2 -translate-x-1/2 h-[480px] w-[480px] rounded-full border border-rule-light opacity-40 float"></div>
+      <div class="pointer-events-none absolute top-20 left-1/2 -translate-x-1/2 h-[360px] w-[360px] rounded-full border border-accent-pale opacity-30 float-delayed"></div>
+
+      <div class="relative">
+        <p class="animate-in font-mono text-sm tracking-widest text-accent uppercase">
+          Инфраструктура для исследователей
+        </p>
+        <h1 class="animate-in animate-in-delay-1 mt-5 font-display text-5xl leading-tight font-bold tracking-tight text-ink sm:text-6xl">
+          Каких статей не хватает<br />в вашей диссертации?
+        </h1>
+        <p class="animate-in animate-in-delay-2 mx-auto mt-8 max-w-2xl text-xl leading-relaxed text-ink-light">
+          LitResearch анализирует библиографии ваших источников, находит пробелы
+          по главам и предлагает конкретные работы для их закрытия.
+          Черновик обзора — с реальными цитатами, не с выдуманными.
+        </p>
+        <div class="animate-in animate-in-delay-3 mt-12 flex justify-center gap-4">
+          <RouterLink
+            to="/register"
+            class="beam-border rounded-lg bg-accent px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-accent-light transition-colors"
+          >
+            Начать бесплатно
+          </RouterLink>
+          <a
+            href="#how-it-works"
+            class="rounded-lg border border-rule px-8 py-4 text-base font-semibold text-ink-light hover:bg-paper-warm transition-colors"
+          >
+            Как это работает
+          </a>
+        </div>
       </div>
     </header>
 
-    <!-- Core loop -->
-    <section class="mx-auto max-w-4xl px-6 pb-24">
-      <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
+    <!-- Value bar -->
+    <section class="relative border-y border-rule bg-paper-warm grain">
+      <div class="relative mx-auto grid max-w-5xl grid-cols-2 gap-8 px-6 py-10 sm:grid-cols-4 stagger-children">
         <div class="text-center">
-          <div class="text-3xl">📄</div>
-          <h3 class="mt-3 text-lg font-semibold text-gray-900">Загрузите</h3>
-          <p class="mt-1 text-sm text-gray-500">PDF статей — без Zotero, без настроек</p>
+          <div class="font-display text-base font-bold text-accent">Только реальные ссылки</div>
+          <div class="mt-1 text-sm text-ink-muted">из вашей библиотеки</div>
         </div>
         <div class="text-center">
-          <div class="text-3xl">🔍</div>
-          <h3 class="mt-3 text-lg font-semibold text-gray-900">Анализируйте</h3>
-          <p class="mt-1 text-sm text-gray-500">Фрагменты, покрытие, пробелы — автоматически</p>
+          <div class="font-display text-base font-bold text-accent">Покрытие по главам</div>
+          <div class="mt-1 text-sm text-ink-muted">пробелы видны сразу</div>
         </div>
         <div class="text-center">
-          <div class="text-3xl">✍️</div>
-          <h3 class="mt-3 text-lg font-semibold text-gray-900">Пишите</h3>
-          <p class="mt-1 text-sm text-gray-500">Исследовательские брифинги и черновики с цитатами</p>
+          <div class="font-display text-base font-bold text-accent">100+ AI-моделей</div>
+          <div class="mt-1 text-sm text-ink-muted">Claude, GPT, Qwen, Ollama</div>
+        </div>
+        <div class="text-center">
+          <div class="font-display text-base font-bold text-accent">1M токенов бесплатно</div>
+          <div class="mt-1 text-sm text-ink-muted">CLI — open source</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Problem -->
+    <section class="reveal mx-auto max-w-3xl px-6 py-20">
+      <p class="font-mono text-sm tracking-widest text-accent uppercase">Проблема</p>
+      <h2 class="mt-3 font-display text-3xl font-bold text-ink">Знакомая ситуация?</h2>
+      <div class="mt-8 space-y-6 text-ink-light text-lg leading-relaxed">
+        <p>
+          Вы скачали 80 статей по теме. Прочитали двадцать. Выписали цитаты в заметки —
+          но через неделю не можете найти, где именно был тот аргумент про метод валидации.
+          Научный руководитель спрашивает: «А где у тебя методологические ссылки в третьей
+          главе?» — и вы не знаете ответа.
+        </p>
+        <p>
+          Zotero хранит PDF, но не извлекает из них знания. Semantic Scholar ищет
+          по 225 миллионам статей, но не знает структуру вашей работы. ChatGPT
+          генерирует красивые обзоры — с выдуманными ссылками.
+        </p>
+        <p class="rounded-lg border-l-2 border-accent bg-accent-pale/30 py-4 pl-5 pr-4 text-base font-medium text-ink">
+          Ни один существующий инструмент не совмещает извлечение фрагментов
+          с классификацией цитирования и отслеживание пробелов по разделам.
+        </p>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section id="how-it-works" class="relative border-y border-rule bg-paper-warm grain py-20">
+      <div class="relative mx-auto max-w-4xl px-6">
+        <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">Процесс</p>
+        <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">Три шага</h2>
+        <div class="mt-14 grid grid-cols-1 gap-12 md:grid-cols-3 stagger-children">
+          <div class="group text-center">
+            <div
+              class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-accent font-display text-2xl font-bold text-white shadow-sm transition-transform group-hover:scale-110"
+            >
+              01
+            </div>
+            <h3 class="mt-5 font-display text-xl font-semibold text-ink">Загрузите PDF</h3>
+            <p class="mt-3 text-base leading-relaxed text-ink-muted">
+              Перетащите файлы статей в проект. Без Zotero, без настроек — просто PDF.
+            </p>
+          </div>
+          <div class="group text-center">
+            <div
+              class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-accent font-display text-2xl font-bold text-white shadow-sm transition-transform group-hover:scale-110"
+            >
+              02
+            </div>
+            <h3 class="mt-5 font-display text-xl font-semibold text-ink">Получите фрагменты</h3>
+            <p class="mt-3 text-base leading-relaxed text-ink-muted">
+              AI извлекает цитатные фрагменты, классифицирует тип цитирования
+              и привязывает каждый к разделу вашей работы.
+            </p>
+          </div>
+          <div class="group text-center">
+            <div
+              class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-accent font-display text-2xl font-bold text-white shadow-sm transition-transform group-hover:scale-110"
+            >
+              03
+            </div>
+            <h3 class="mt-5 font-display text-xl font-semibold text-ink">Увидьте пробелы</h3>
+            <p class="mt-3 text-base leading-relaxed text-ink-muted">
+              Покрытие по главам, недостающие типы ссылок, рекомендации
+              конкретных работ для закрытия пробелов.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Key benefits -->
+    <section class="mx-auto max-w-4xl px-6 py-20">
+      <div class="reveal">
+        <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">Ценность</p>
+        <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">
+          Что вы получаете
+        </h2>
+      </div>
+      <div class="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 stagger-children">
+        <div class="hover-lift rounded-lg border border-rule bg-paper-white p-7">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-md bg-accent-pale text-sm font-bold text-accent-deep font-mono">01</div>
+            <h3 class="font-display text-lg font-semibold text-ink">
+              Обзор литературы за неделю, не за семестр
+            </h3>
+          </div>
+          <p class="mt-4 text-base leading-relaxed text-ink-muted">
+            Каждая цитата автоматически получает тип (фон, метод, сравнение результатов),
+            оценку качества и привязку к разделу вашей работы. Ручная работа над
+            обзором литературы сокращается в разы.
+          </p>
+        </div>
+        <div class="hover-lift rounded-lg border border-rule bg-paper-white p-7">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-md bg-accent-pale text-sm font-bold text-accent-deep font-mono">02</div>
+            <h3 class="font-display text-lg font-semibold text-ink">
+              Пробелы видны до научрука
+            </h3>
+          </div>
+          <p class="mt-4 text-base leading-relaxed text-ink-muted">
+            Система анализирует библиографии ваших источников, находит самые цитируемые
+            работы, которых нет в вашей библиотеке, и помогает добавить их.
+            Методологические пробелы приоритизируются выше фоновых.
+          </p>
+        </div>
+        <div class="hover-lift rounded-lg border border-rule bg-paper-white p-7">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-md bg-accent-pale text-sm font-bold text-accent-deep font-mono">03</div>
+            <h3 class="font-display text-lg font-semibold text-ink">
+              Черновик с реальными цитатами
+            </h3>
+          </div>
+          <p class="mt-4 text-base leading-relaxed text-ink-muted">
+            LitResearch работает только с вашей библиотекой. Каждая ссылка
+            ведёт к конкретному PDF. Никаких выдуманных источников —
+            это принципиальное архитектурное решение.
+          </p>
+        </div>
+        <div class="hover-lift rounded-lg border border-rule bg-paper-white p-7">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-md bg-accent-pale text-sm font-bold text-accent-deep font-mono">04</div>
+            <h3 class="font-display text-lg font-semibold text-ink">
+              Брифинги по разделам
+            </h3>
+          </div>
+          <p class="mt-4 text-base leading-relaxed text-ink-muted">
+            Исследовательские брифинги по каждой главе: какие источники покрывают тему,
+            какова структура аргументации, что ещё нужно прочитать.
+            Обновляются инкрементально при добавлении новых источников.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Complements, not replaces -->
+    <section class="relative border-y border-rule bg-paper-warm grain py-20">
+      <div class="relative mx-auto max-w-3xl px-6">
+        <div class="reveal">
+          <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">Позиционирование</p>
+          <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">
+            Дополняет, а не заменяет
+          </h2>
+          <p class="mt-4 text-center text-base text-ink-muted">
+            LitResearch — инструмент для работы с научной литературой,<br class="hidden sm:inline" />
+            не для написания диссертации и не для обхода антиплагиата.
+          </p>
+        </div>
+        <div class="mt-10 space-y-4 stagger-children">
+          <div class="hover-lift flex items-start gap-4 rounded-lg border border-rule bg-paper-white p-6">
+            <div class="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent-pale font-mono text-sm font-bold text-accent-deep">
+              Z
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-ink">Zotero хранит ваши PDF</h3>
+              <p class="mt-1 text-base text-ink-muted">
+                LitResearch извлекает из них знания: фрагменты, классификацию
+                цитирования, привязку к главам. Zotero остаётся вашей библиотекой.
+              </p>
+            </div>
+          </div>
+          <div class="hover-lift flex items-start gap-4 rounded-lg border border-rule bg-paper-white p-6">
+            <div class="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent-pale font-mono text-sm font-bold text-accent-deep">
+              S2
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-ink">Semantic Scholar ищет по 225М статей</h3>
+              <p class="mt-1 text-base text-ink-muted">
+                LitResearch использует его API для разрешения пробелов:
+                когда система находит недостающую работу, S2 помогает получить её метаданные и PDF.
+              </p>
+            </div>
+          </div>
+          <div class="hover-lift flex items-start gap-4 rounded-lg border border-rule bg-paper-white p-6">
+            <div class="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-accent-pale font-mono text-sm font-bold text-accent-deep">
+              AI
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-ink">ChatGPT генерирует текст</h3>
+              <p class="mt-1 text-base text-ink-muted">
+                LitResearch генерирует текст тоже — но только на основе ваших источников.
+                Каждая ссылка верифицируема. Это не замена мышлению, а инструмент
+                систематизации.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- For whom -->
+    <section class="mx-auto max-w-3xl px-6 py-20">
+      <div class="reveal">
+        <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">Аудитория</p>
+        <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">Для кого</h2>
+      </div>
+      <div class="mt-10 space-y-4 stagger-children">
+        <div class="hover-lift flex gap-4 rounded-lg border border-rule bg-paper-white p-6">
+          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent text-sm font-bold text-white font-mono">
+            PhD
+          </div>
+          <div>
+            <h3 class="font-display text-lg font-semibold text-ink">Аспиранты</h3>
+            <p class="mt-1 text-base text-ink-muted">
+              Диссертация на 100+ источников. Нужно видеть покрытие по главам,
+              находить пробелы и генерировать черновики обзора литературы с реальными цитатами.
+            </p>
+          </div>
+        </div>
+        <div class="hover-lift flex gap-4 rounded-lg border border-rule bg-paper-white p-6">
+          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent text-sm font-bold text-white font-mono">
+            R
+          </div>
+          <div>
+            <h3 class="font-display text-lg font-semibold text-ink">Исследователи</h3>
+            <p class="mt-1 text-base text-ink-muted">
+              Обзорная статья или грант. Быстро обработать десятки статей,
+              структурировать аргументацию и убедиться, что ничего не пропущено.
+            </p>
+          </div>
+        </div>
+        <div class="hover-lift flex gap-4 rounded-lg border border-rule bg-paper-white p-6">
+          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent text-sm font-bold text-white font-mono">
+            PI
+          </div>
+          <div>
+            <h3 class="font-display text-lg font-semibold text-ink">Научные руководители</h3>
+            <p class="mt-1 text-base text-ink-muted">
+              Видеть покрытие литературы в работах аспирантов: какие разделы
+              подкреплены, а какие требуют доработки — без перечитывания всего текста.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Under the hood: pipeline -->
+    <section class="relative border-y border-rule bg-paper-warm grain py-20">
+      <div class="relative mx-auto max-w-4xl px-6">
+        <div class="reveal">
+          <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">Архитектура</p>
+          <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">
+            Что под капотом
+          </h2>
+          <p class="mt-4 text-center text-base text-ink-muted">
+            Каждый шаг pipeline опирается на конкретную научную методологию
+          </p>
+        </div>
+
+        <!-- Pipeline flow -->
+        <div class="mt-14 space-y-0 stagger-children">
+          <!-- Step 1 -->
+          <div class="flex items-stretch gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                01
+              </div>
+              <div class="mt-1 w-px grow bg-gradient-to-b from-accent/40 to-rule"></div>
+            </div>
+            <div class="pb-8">
+              <h3 class="text-base font-semibold text-ink">Structure Analysis</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                PDF разбивается на тематические сегменты и риторические ходы.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Cohan et al., NAACL 2019</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Step 2 -->
+          <div class="flex items-stretch gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                02
+              </div>
+              <div class="mt-1 w-px grow bg-gradient-to-b from-accent/40 to-rule"></div>
+            </div>
+            <div class="pb-8">
+              <h3 class="text-base font-semibold text-ink">Citation Worthiness</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                Каждый сегмент оценивается на «достойность цитирования» (0–1).
+                Фильтр по порогу 0.4 отсекает нерелевантный контент.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Chen et al., ACM TOSEM 2025</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Step 3 -->
+          <div class="flex items-stretch gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                03
+              </div>
+              <div class="mt-1 w-px grow bg-gradient-to-b from-accent/40 to-rule"></div>
+            </div>
+            <div class="pb-8">
+              <h3 class="text-base font-semibold text-ink">Fragment Extraction + Intent</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                Фрагменты с типом цитирования:
+                <span class="font-mono text-xs text-accent">background</span>,
+                <span class="font-mono text-xs text-accent">method</span>,
+                <span class="font-mono text-xs text-accent">result_comparison</span>.
+                Методологические весят 3x.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">SciCite, NAACL 2019</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Step 4 -->
+          <div class="flex items-stretch gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                04
+              </div>
+              <div class="mt-1 w-px grow bg-gradient-to-b from-accent/40 to-rule"></div>
+            </div>
+            <div class="pb-8">
+              <h3 class="text-base font-semibold text-ink">Gap Scoring + Semantic Reranking</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                Пробелы ранжируются:
+                <span class="font-mono text-xs text-ink-light">freq &times; quality &times; w_section &times; w_intent</span>.
+                Переранжирование через SPECTER-эмбеддинги.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Cohan et al., ACL 2020</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Step 5 -->
+          <div class="flex items-stretch gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                05
+              </div>
+              <div class="mt-1 w-px grow bg-gradient-to-b from-accent/40 to-rule"></div>
+            </div>
+            <div class="pb-8">
+              <h3 class="text-base font-semibold text-ink">Candidate Resolution</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                Для каждого пробела — полные метаданные через CrossRef + Semantic Scholar API.
+                Формирование команды для автоматического добавления.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Kinney et al., 2023</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- Step 6 -->
+          <div class="flex items-start gap-5">
+            <div class="flex flex-col items-center">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent font-mono text-sm font-bold text-white shadow-sm">
+                06
+              </div>
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-ink">Draft Generation (RAG)</h3>
+              <p class="mt-1 text-sm leading-relaxed text-ink-muted">
+                Черновик через RAG по закрытому корпусу вашей библиотеки.
+                Структура: CARS для введений, argument-based группировка для обзоров.
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Lewis et al., NeurIPS 2020</span>
+                <span class="whitespace-nowrap rounded bg-accent-pale/50 px-1.5 py-0.5 font-mono text-xs text-accent-deep">Swales, 1990</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="mx-auto max-w-3xl px-6 py-20">
+      <div class="reveal">
+        <p class="text-center font-mono text-sm tracking-widest text-accent uppercase">FAQ</p>
+        <h2 class="mt-3 text-center font-display text-3xl font-bold text-ink">
+          Частые вопросы
+        </h2>
+      </div>
+      <div class="mt-10 divide-y divide-rule">
+        <div v-for="(faq, i) in faqs" :key="i" class="py-5">
+          <button
+            class="flex w-full items-center justify-between text-left group"
+            @click="toggleFaq(i)"
+          >
+            <span class="pr-4 text-base font-medium text-ink group-hover:text-accent transition-colors">{{ faq.q }}</span>
+            <span
+              class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-rule text-sm text-ink-muted transition-all"
+              :class="openFaq === i ? 'rotate-45 bg-accent border-accent text-white' : 'group-hover:border-accent'"
+            >+</span>
+          </button>
+          <p
+            v-if="openFaq === i"
+            class="mt-3 text-base leading-relaxed text-ink-muted"
+          >
+            {{ faq.a }}
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Final CTA -->
+    <section class="relative border-t border-rule bg-paper-warm grain py-24">
+      <!-- Decorative circles -->
+      <div class="pointer-events-none absolute bottom-8 right-1/4 h-56 w-56 rounded-full border border-rule-light opacity-30 float"></div>
+
+      <div class="relative mx-auto max-w-2xl px-6 text-center reveal">
+        <h2 class="font-display text-4xl font-bold text-ink sm:text-5xl">
+          Перестаньте перечитывать.<br />Начните писать.
+        </h2>
+        <p class="mt-5 text-lg text-ink-muted">
+          1M токенов бесплатно. Загрузите первый PDF за две минуты.
+        </p>
+        <div class="mt-10 flex justify-center gap-4">
+          <RouterLink
+            to="/register"
+            class="beam-border rounded-lg bg-accent px-8 py-4 text-base font-semibold text-white shadow-sm hover:bg-accent-light transition-colors"
+          >
+            Начать бесплатно
+          </RouterLink>
+          <RouterLink
+            to="/login"
+            class="rounded-lg border border-rule px-8 py-4 text-base font-semibold text-ink-light hover:bg-paper-white transition-colors"
+          >
+            Войти
+          </RouterLink>
         </div>
       </div>
     </section>
 
     <!-- Footer -->
-    <footer class="border-t border-gray-100 py-8 text-center text-sm text-gray-400">
-      LitResearch &copy; 2026. Powered by Klemma.
+    <footer class="border-t border-rule py-8 text-center text-sm text-ink-muted">
+      LitResearch &copy; 2026. Powered by
+      <a href="https://github.com/bolkhovsky/klemma" class="underline hover:text-accent transition-colors">Klemma</a>
+      (open source).
     </footer>
   </div>
 </template>

--- a/src/klemma/__init__.py
+++ b/src/klemma/__init__.py
@@ -2,31 +2,22 @@
 
 __version__ = "0.14.0"
 
-# Two mascot variants — user picks one later, both shipped for now.
-# Each is a list of (mascot_line, info_line) tuples for side-by-side rendering.
-
-_SQUIRREL = [
-    ("[red]    /\\  /\\ [/red]", ""),
-    ("[red]   ([/red] o  o [red])[/red]", "  [bold]Klemma[/bold] [dim]v{version}[/dim]"),
-    ("[red]   ( ^_^  )[/red]", "  AI Academic Assistant"),
-    ("[red]    \\    / [/red]", "  [dim]{cwd}[/dim]"),
-    ("[red]   (_/  \\_)[/red]", ""),
-]
-
-_GIRL = [
-    ("[red]    .---.[/red]", ""),
-    ("[red]   /[/red] o=o [red]\\ [/red]", "  [bold]Klemma[/bold] [dim]v{version}[/dim]"),
-    ("[red]   |[/red]  <  [red]|[/red]", "  AI Academic Assistant"),
-    ("[red]   |[/red] '-' [red]|[/red]", "  [dim]{cwd}[/dim]"),
-    ("[red]    '---'[/red]", ""),
+_BANNER_LINES = [
+    ("#e0f2fe", "██  ██  ██      ██████  ██    ██  ██    ██   ████ "),
+    ("#7dd3fc", "██ ██   ██      ██      ███  ███  ███  ███  ██  ██"),
+    ("#38bdf8", "████    ██      █████   ████████  ████████  ██████"),
+    ("#0369a1", "██ ██   ██      ██      ██ ██ ██  ██ ██ ██  ██  ██"),
+    ("#1e3a5f", "██  ██  ██████  ██████  ██    ██  ██    ██  ██  ██"),
 ]
 
 
-def get_banner(variant: str = "squirrel", cwd: str = "") -> str:
-    """Return Rich-formatted banner string with mascot + app info."""
-    mascot = _SQUIRREL if variant == "squirrel" else _GIRL
+def get_banner(cwd: str = "", **_kw) -> str:
+    """Return Rich-formatted banner string with gradient block-letter logo."""
     lines = []
-    for art, info in mascot:
-        line = art + info.format(version=__version__, cwd=cwd)
-        lines.append(line)
+    for color, text in _BANNER_LINES:
+        lines.append(f"[{color}]{text}[/{color}]")
+    lines.append("")
+    lines.append(f"   AI Academic Assistant — [dim]v{__version__}[/dim]")
+    if cwd:
+        lines.append(f"   [dim]{cwd}[/dim]")
     return "\n".join(lines)

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -170,6 +170,93 @@ def _build_dissertation_config(plan_data) -> dict:
     return diss
 
 
+# ── Type-aware default structures for klemma init ────────────────────────
+
+_DEFAULT_STRUCTURES: dict[tuple[str, str], dict] = {
+    # Dissertation: ГОСТ Р 7.0.11-2011, ВАК (Dunleavy 2003, Evans et al. 2014)
+    ("dissertation", "ru"): {
+        "current_focus": "1.1",
+        "chapters": {1: "Обзор литературы", 2: "Методология", 3: "Результаты и обсуждение"},
+        "scientific_results": {"nr1": "Первый научный результат", "nr2": "Второй научный результат"},
+        "min_sources_per_section": 3,
+        "auto_register": "mapped",
+    },
+    ("dissertation", "en"): {
+        "current_focus": "1.1",
+        "chapters": {1: "Literature review", 2: "Methodology", 3: "Results and discussion"},
+        "scientific_results": {"nr1": "First scientific result", "nr2": "Second scientific result"},
+        "min_sources_per_section": 3,
+        "auto_register": "mapped",
+    },
+    # Paper: IMRaD (Sollaci & Pereira 2004, ICMJE, Day & Gastel)
+    ("paper", "ru"): {
+        "current_focus": "1",
+        "chapters": {1: "Введение", 2: "Методы", 3: "Результаты", 4: "Обсуждение"},
+        "min_sources_per_section": 2,
+        "auto_register": "none",
+    },
+    ("paper", "en"): {
+        "current_focus": "1",
+        "chapters": {1: "Introduction", 2: "Methods", 3: "Results", 4: "Discussion"},
+        "min_sources_per_section": 2,
+        "auto_register": "none",
+    },
+    # Thesis/Тезисы: compact structure (conference-specific, 2-3 pages)
+    ("thesis", "ru"): {
+        "current_focus": "1",
+        "chapters": {1: "Постановка задачи", 2: "Результаты"},
+        "min_sources_per_section": 1,
+        "auto_register": "mapped",
+    },
+    ("thesis", "en"): {
+        "current_focus": "1",
+        "chapters": {1: "Problem statement", 2: "Results"},
+        "min_sources_per_section": 1,
+        "auto_register": "mapped",
+    },
+}
+
+
+def _get_default_structure(project_type: str, language: str) -> dict:
+    """Return default structure for (project_type, language) with fallback to English."""
+    key = (project_type, language)
+    if key in _DEFAULT_STRUCTURES:
+        return _DEFAULT_STRUCTURES[key]
+    # Fallback to English
+    en_key = (project_type, "en")
+    if en_key in _DEFAULT_STRUCTURES:
+        return _DEFAULT_STRUCTURES[en_key]
+    # Ultimate fallback: dissertation/en
+    return _DEFAULT_STRUCTURES[("dissertation", "en")]
+
+
+def _validate_outline_for_type(project_type: str, plan_data) -> None:
+    """Warn if plan_data has unusual chapter count for the project type."""
+    import warnings
+
+    if not plan_data or not plan_data.chapters:
+        return
+    n = len(plan_data.chapters)
+    if project_type == "paper" and n > 6:
+        warnings.warn(
+            f"Paper with {n} sections — typical IMRaD structure has 4-6. "
+            "Consider splitting into multiple papers or using 'dissertation' type.",
+            stacklevel=3,
+        )
+    elif project_type == "thesis" and n > 4:
+        warnings.warn(
+            f"Thesis with {n} sections — conference abstracts typically have 2-3. "
+            "Consider using 'paper' type for longer works.",
+            stacklevel=3,
+        )
+    elif project_type == "dissertation" and n < 2:
+        warnings.warn(
+            f"Dissertation with only {n} chapter(s) — typical structure has 3+. "
+            "Consider adding more chapters or using 'thesis' type.",
+            stacklevel=3,
+        )
+
+
 def _build_klemma_md(values: InitValues) -> str:
     """Build KLEMMA.md content with YAML frontmatter from wizard values.
 
@@ -187,73 +274,106 @@ def _build_klemma_md(values: InitValues) -> str:
     if values.keywords:
         frontmatter["priority_terms"] = values.keywords
 
-    # Dissertation structure from plan-prospect → into frontmatter
-    if values.plan_data and values.project_type == "dissertation":
-        diss = _build_dissertation_config(values.plan_data)
-        if "chapters" in diss:
-            frontmatter["chapters"] = diss["chapters"]
-        if "section_type_map" in diss:
-            frontmatter["section_type_map"] = diss["section_type_map"]
-        if "scientific_results" in diss:
-            frontmatter["scientific_results"] = diss["scientific_results"]
-        if "current_section" in diss:
-            frontmatter["current_focus"] = diss["current_section"]
-        if "min_sources_per_section" in diss:
-            frontmatter["min_sources_per_section"] = diss["min_sources_per_section"]
-        if "chapter_mapping" in diss:
-            frontmatter["chapter_mapping"] = diss["chapter_mapping"]
-        if not frontmatter.get("title") and "title" in diss:
-            frontmatter["title"] = diss["title"]
-    else:
-        # Defaults for non-plan projects
-        frontmatter["current_focus"] = "1.1"
-        frontmatter["chapters"] = {
-            1: "Literature review",
-            2: "Methodology",
-            3: "Results and discussion",
-        }
-        frontmatter["scientific_results"] = {
-            "nr1": "First scientific result",
-            "nr2": "Second scientific result",
-        }
+    # Structure from plan_data or type-aware defaults
+    if values.plan_data:
+        _validate_outline_for_type(values.project_type, values.plan_data)
 
-    frontmatter["min_sources_per_section"] = frontmatter.get("min_sources_per_section", 3)
-    frontmatter["auto_register"] = "mapped"
+        if values.project_type == "dissertation":
+            # Dissertation: full config with scientific_results, chapter_mapping
+            diss = _build_dissertation_config(values.plan_data)
+            if "chapters" in diss:
+                frontmatter["chapters"] = diss["chapters"]
+            if "section_type_map" in diss:
+                frontmatter["section_type_map"] = diss["section_type_map"]
+            if "scientific_results" in diss:
+                frontmatter["scientific_results"] = diss["scientific_results"]
+            if "current_section" in diss:
+                frontmatter["current_focus"] = diss["current_section"]
+            if "min_sources_per_section" in diss:
+                frontmatter["min_sources_per_section"] = diss["min_sources_per_section"]
+            if "chapter_mapping" in diss:
+                frontmatter["chapter_mapping"] = diss["chapter_mapping"]
+            if not frontmatter.get("title") and "title" in diss:
+                frontmatter["title"] = diss["title"]
+        else:
+            # Paper/thesis: extract chapters + section_type_map, skip scientific_results
+            from .section_types import infer_section_type
+
+            if values.plan_data.chapters:
+                chapters = {ch.number: ch.title for ch in values.plan_data.chapters}
+                frontmatter["chapters"] = chapters
+                stm: dict[str, str] = {}
+                for ch in values.plan_data.chapters:
+                    inferred = infer_section_type(ch.title)
+                    if inferred:
+                        stm[str(ch.number)] = inferred.value
+                if stm:
+                    frontmatter["section_type_map"] = stm
+                frontmatter["current_focus"] = str(values.plan_data.chapters[0].number)
+            # Type-specific defaults for fields not set by plan_data
+            defaults = _get_default_structure(values.project_type, values.language)
+            frontmatter.setdefault("min_sources_per_section", defaults.get("min_sources_per_section", 2))
+            frontmatter.setdefault("auto_register", defaults.get("auto_register", "none"))
+    else:
+        # No plan_data — use type-aware defaults
+        defaults = _get_default_structure(values.project_type, values.language)
+        frontmatter["current_focus"] = defaults["current_focus"]
+        frontmatter["chapters"] = defaults["chapters"]
+        if "scientific_results" in defaults:
+            frontmatter["scientific_results"] = defaults["scientific_results"]
+
+        # Auto-infer section_type_map from chapter names
+        from .section_types import infer_section_type
+
+        stm = {}
+        for ch_num, ch_name in defaults["chapters"].items():
+            inferred = infer_section_type(ch_name)
+            if inferred:
+                stm[str(ch_num)] = inferred.value
+        if stm:
+            frontmatter["section_type_map"] = stm
+
+        frontmatter["min_sources_per_section"] = defaults.get("min_sources_per_section", 3)
+        frontmatter["auto_register"] = defaults.get("auto_register", "mapped")
+
+    # Ensure these are always set (setdefault won't overwrite if already present)
+    defaults_fallback = _get_default_structure(values.project_type, values.language)
+    frontmatter.setdefault("min_sources_per_section", defaults_fallback.get("min_sources_per_section", 3))
+    frontmatter.setdefault("auto_register", defaults_fallback.get("auto_register", "mapped"))
 
     fm_text = _yaml.dump(frontmatter, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
     # Build markdown body (prose context for AI)
-    nr_lines = ""
-    if "scientific_results" in frontmatter:
-        nrs = frontmatter["scientific_results"]
-        nr_lines = "\n".join(f"- {k.upper()}: {v}" for k, v in nrs.items())
-
-    ch_lines = ""
-    if "chapters" in frontmatter:
-        ch_lines = "\n".join(
-            f"{num}. {name}" for num, name in sorted(frontmatter["chapters"].items())
-        )
-
-    kw_line = ""
-    if values.keywords:
-        kw_line = f"\nKey terms: {', '.join(values.keywords)}"
-
     desc_line = f"\nDescription: {values.description}" if values.description else ""
 
-    body = (
+    body_parts = [
         "# Project Context\n\n"
         "<!-- This file describes your project for AI. It is passed as context to all\n"
         "     AI-powered commands (plan, research, process, ask, etc.).\n\n"
         "     YAML frontmatter above holds structured project data. The markdown body\n"
         "     below is free-form context shown to AI. Keep both in sync. -->\n\n"
         f'Topic: "{title}"\n'
-        f"{desc_line}\n\n"
-        "## Scientific Results\n\n"
-        f"{nr_lines}\n\n"
-        "## Structure\n\n"
-        f"{ch_lines}\n"
-        f"{kw_line}\n"
-    )
+        f"{desc_line}\n",
+    ]
+
+    # Scientific Results — only for dissertation
+    if "scientific_results" in frontmatter:
+        nrs = frontmatter["scientific_results"]
+        nr_lines = "\n".join(f"- {k.upper()}: {v}" for k, v in nrs.items())
+        body_parts.append(f"\n## Scientific Results\n\n{nr_lines}\n")
+
+    # Structure/Sections
+    if "chapters" in frontmatter:
+        ch_lines = "\n".join(
+            f"{num}. {name}" for num, name in sorted(frontmatter["chapters"].items())
+        )
+        heading = "## Structure" if values.project_type == "dissertation" else "## Sections"
+        body_parts.append(f"\n{heading}\n\n{ch_lines}\n")
+
+    if values.keywords:
+        body_parts.append(f"\nKey terms: {', '.join(values.keywords)}\n")
+
+    body = "".join(body_parts)
 
     return f"---\n{fm_text}---\n{body}"
 

--- a/tests/test_init_default_structures.py
+++ b/tests/test_init_default_structures.py
@@ -1,0 +1,355 @@
+"""Tests for type-aware default structures in klemma init."""
+
+import warnings
+
+import pytest
+
+from klemma.config import parse_klemma_md
+from klemma.setup import InitValues, _build_klemma_md, _get_default_structure, _validate_outline_for_type
+
+
+def _parse_built_md(values: InitValues) -> tuple[dict, str]:
+    """Build KLEMMA.md from values, write to tmp, parse back."""
+    import tempfile
+    from pathlib import Path
+
+    content = _build_klemma_md(values)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8") as f:
+        f.write(content)
+        tmp = Path(f.name)
+    try:
+        return parse_klemma_md(tmp)
+    finally:
+        tmp.unlink()
+
+
+class TestDefaultStructuresRegistry:
+    def test_dissertation_en(self):
+        s = _get_default_structure("dissertation", "en")
+        assert s["chapters"] == {1: "Literature review", 2: "Methodology", 3: "Results and discussion"}
+        assert "scientific_results" in s
+        assert s["auto_register"] == "mapped"
+        assert s["min_sources_per_section"] == 3
+
+    def test_dissertation_ru(self):
+        s = _get_default_structure("dissertation", "ru")
+        assert s["chapters"][1] == "Обзор литературы"
+        assert "scientific_results" in s
+
+    def test_paper_en(self):
+        s = _get_default_structure("paper", "en")
+        assert list(s["chapters"].values()) == ["Introduction", "Methods", "Results", "Discussion"]
+        assert "scientific_results" not in s
+        assert s["auto_register"] == "none"
+        assert s["min_sources_per_section"] == 2
+
+    def test_paper_ru(self):
+        s = _get_default_structure("paper", "ru")
+        assert list(s["chapters"].values()) == ["Введение", "Методы", "Результаты", "Обсуждение"]
+        assert "scientific_results" not in s
+
+    def test_thesis_en(self):
+        s = _get_default_structure("thesis", "en")
+        assert list(s["chapters"].values()) == ["Problem statement", "Results"]
+        assert "scientific_results" not in s
+        assert s["min_sources_per_section"] == 1
+
+    def test_thesis_ru(self):
+        s = _get_default_structure("thesis", "ru")
+        assert list(s["chapters"].values()) == ["Постановка задачи", "Результаты"]
+
+    def test_fallback_to_english(self):
+        s = _get_default_structure("paper", "de")
+        assert s == _get_default_structure("paper", "en")
+
+    def test_unknown_type_falls_back_to_dissertation_en(self):
+        s = _get_default_structure("unknown_type", "en")
+        assert s == _get_default_structure("dissertation", "en")
+
+
+class TestBuildKlemmaMdDissertationEn:
+    """Backward compat: dissertation/en should produce same structure as before."""
+
+    def test_chapters(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert fm["chapters"] == {1: "Literature review", 2: "Methodology", 3: "Results and discussion"}
+
+    def test_scientific_results(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert "nr1" in fm["scientific_results"]
+        assert "nr2" in fm["scientific_results"]
+
+    def test_auto_register_mapped(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert fm["auto_register"] == "mapped"
+
+    def test_min_sources(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert fm["min_sources_per_section"] == 3
+
+    def test_body_has_scientific_results_heading(self):
+        _, body = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert "## Scientific Results" in body
+
+    def test_body_has_structure_heading(self):
+        _, body = _parse_built_md(InitValues(project_type="dissertation", language="en", title="Test"))
+        assert "## Structure" in body
+
+
+class TestBuildKlemmaMdDissertationRu:
+    def test_russian_chapters(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="ru", title="Тест"))
+        assert fm["chapters"][1] == "Обзор литературы"
+        assert fm["chapters"][2] == "Методология"
+        assert fm["chapters"][3] == "Результаты и обсуждение"
+
+    def test_russian_scientific_results(self):
+        fm, _ = _parse_built_md(InitValues(project_type="dissertation", language="ru", title="Тест"))
+        assert fm["scientific_results"]["nr1"] == "Первый научный результат"
+
+
+class TestBuildKlemmaMdPaperEn:
+    def test_imrad_sections(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        assert list(fm["chapters"].values()) == ["Introduction", "Methods", "Results", "Discussion"]
+
+    def test_no_scientific_results(self):
+        fm, body = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        assert "scientific_results" not in fm
+        assert "## Scientific Results" not in body
+
+    def test_auto_register_none(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        assert fm["auto_register"] == "none"
+
+    def test_min_sources_2(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        assert fm["min_sources_per_section"] == 2
+
+    def test_body_has_sections_heading(self):
+        _, body = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        assert "## Sections" in body
+        assert "## Structure" not in body
+
+    def test_section_type_map_inferred(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="en", title="Paper"))
+        stm = fm.get("section_type_map", {})
+        assert stm.get("1") == "introduction"
+        assert stm.get("2") == "methodology"
+        assert stm.get("3") == "results"
+        assert stm.get("4") == "discussion"
+
+
+class TestBuildKlemmaMdPaperRu:
+    def test_russian_imrad(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="ru", title="Статья"))
+        assert list(fm["chapters"].values()) == ["Введение", "Методы", "Результаты", "Обсуждение"]
+
+    def test_section_type_map_inferred_ru(self):
+        fm, _ = _parse_built_md(InitValues(project_type="paper", language="ru", title="Статья"))
+        stm = fm.get("section_type_map", {})
+        assert stm.get("1") == "introduction"
+        assert stm.get("3") == "results"
+
+
+class TestBuildKlemmaMdThesisEn:
+    def test_two_sections(self):
+        fm, _ = _parse_built_md(InitValues(project_type="thesis", language="en", title="Thesis"))
+        assert list(fm["chapters"].values()) == ["Problem statement", "Results"]
+
+    def test_no_scientific_results(self):
+        fm, body = _parse_built_md(InitValues(project_type="thesis", language="en", title="Thesis"))
+        assert "scientific_results" not in fm
+        assert "## Scientific Results" not in body
+
+    def test_min_sources_1(self):
+        fm, _ = _parse_built_md(InitValues(project_type="thesis", language="en", title="Thesis"))
+        assert fm["min_sources_per_section"] == 1
+
+    def test_auto_register_mapped(self):
+        fm, _ = _parse_built_md(InitValues(project_type="thesis", language="en", title="Thesis"))
+        assert fm["auto_register"] == "mapped"
+
+    def test_section_type_map_inferred(self):
+        fm, _ = _parse_built_md(InitValues(project_type="thesis", language="en", title="Thesis"))
+        stm = fm.get("section_type_map", {})
+        assert stm.get("2") == "results"
+
+
+class TestBuildKlemmaMdThesisRu:
+    def test_russian_sections(self):
+        fm, _ = _parse_built_md(InitValues(project_type="thesis", language="ru", title="Тезисы"))
+        assert list(fm["chapters"].values()) == ["Постановка задачи", "Результаты"]
+
+
+class TestSectionTypeMapInference:
+    """Verify section_type_map is auto-inferred for all default structures."""
+
+    @pytest.mark.parametrize("ptype,lang", [
+        ("dissertation", "en"),
+        ("dissertation", "ru"),
+        ("paper", "en"),
+        ("paper", "ru"),
+        ("thesis", "en"),
+        ("thesis", "ru"),
+    ])
+    def test_section_type_map_present(self, ptype, lang):
+        fm, _ = _parse_built_md(InitValues(project_type=ptype, language=lang, title="Test"))
+        assert "section_type_map" in fm, f"No section_type_map for {ptype}/{lang}"
+        assert len(fm["section_type_map"]) > 0
+
+
+class TestValidateOutlineForType:
+    def _make_plan(self, n_chapters):
+        """Create a mock plan_data with n chapters."""
+        class FakeChapter:
+            def __init__(self, num, title):
+                self.number = num
+                self.title = f"Chapter {num}"
+                self.sections = []
+
+        class FakePlan:
+            def __init__(self, chapters):
+                self.chapters = chapters
+                self.results = []
+                self.title = "Test"
+
+        return FakePlan([FakeChapter(i + 1, f"Ch {i + 1}") for i in range(n_chapters)])
+
+    def test_paper_many_chapters_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("paper", self._make_plan(8))
+            assert len(w) == 1
+            assert "8 sections" in str(w[0].message)
+
+    def test_paper_normal_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("paper", self._make_plan(4))
+            assert len(w) == 0
+
+    def test_thesis_many_chapters_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("thesis", self._make_plan(5))
+            assert len(w) == 1
+            assert "5 sections" in str(w[0].message)
+
+    def test_dissertation_too_few_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("dissertation", self._make_plan(1))
+            assert len(w) == 1
+            assert "1 chapter" in str(w[0].message)
+
+    def test_dissertation_normal_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("dissertation", self._make_plan(3))
+            assert len(w) == 0
+
+    def test_no_plan_data_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _validate_outline_for_type("paper", None)
+            assert len(w) == 0
+
+
+class TestPlanDataNonDissertation:
+    """Test that plan_data works for paper/thesis types."""
+
+    def _make_plan(self, chapters_list):
+        class FakeChapter:
+            def __init__(self, num, title):
+                self.number = num
+                self.title = title
+                self.sections = []
+
+        class FakePlan:
+            def __init__(self, chapters):
+                self.chapters = chapters
+                self.results = []
+                self.title = "Plan Title"
+
+        return FakePlan([FakeChapter(n, t) for n, t in chapters_list])
+
+    def test_paper_with_plan_data(self):
+        plan = self._make_plan([
+            (1, "Introduction"),
+            (2, "Data and Methods"),
+            (3, "Experiments"),
+            (4, "Results"),
+            (5, "Conclusion"),
+        ])
+        fm, _ = _parse_built_md(InitValues(
+            project_type="paper", language="en", title="My Paper", plan_data=plan,
+        ))
+        assert fm["chapters"] == {
+            1: "Introduction", 2: "Data and Methods",
+            3: "Experiments", 4: "Results", 5: "Conclusion",
+        }
+        assert fm["auto_register"] == "none"
+        assert fm["min_sources_per_section"] == 2
+        assert "scientific_results" not in fm
+
+    def test_thesis_with_plan_data(self):
+        plan = self._make_plan([(1, "Problem"), (2, "Results")])
+        fm, _ = _parse_built_md(InitValues(
+            project_type="thesis", language="ru", title="Тезисы", plan_data=plan,
+        ))
+        assert fm["chapters"] == {1: "Problem", 2: "Results"}
+        assert fm["min_sources_per_section"] == 1
+        assert fm["auto_register"] == "mapped"
+
+    def test_plan_data_section_type_map(self):
+        plan = self._make_plan([(1, "Introduction"), (2, "Methods"), (3, "Results")])
+        fm, _ = _parse_built_md(InitValues(
+            project_type="paper", language="en", title="P", plan_data=plan,
+        ))
+        stm = fm.get("section_type_map", {})
+        assert stm.get("1") == "introduction"
+        assert stm.get("2") == "methodology"
+        assert stm.get("3") == "results"
+
+
+class TestInitProjectIntegration:
+    """Integration tests via init_project (full flow)."""
+
+    def test_paper_init(self, tmp_path):
+        from klemma.setup import init_project
+
+        values = InitValues(project_type="paper", title="Test Paper", language="en")
+        result = init_project(tmp_path, project_type="paper", values=values)
+        assert "KLEMMA.md" in result["created"]
+
+        fm, body = parse_klemma_md(tmp_path / "KLEMMA.md")
+        assert fm["type"] == "paper"
+        assert list(fm["chapters"].values()) == ["Introduction", "Methods", "Results", "Discussion"]
+        assert "scientific_results" not in fm
+        assert "## Sections" in body
+
+    def test_thesis_ru_init(self, tmp_path):
+        from klemma.setup import init_project
+
+        values = InitValues(project_type="thesis", title="Тезисы", language="ru")
+        init_project(tmp_path, project_type="thesis", values=values)
+
+        fm, body = parse_klemma_md(tmp_path / "KLEMMA.md")
+        assert fm["type"] == "thesis"
+        assert list(fm["chapters"].values()) == ["Постановка задачи", "Результаты"]
+        assert "scientific_results" not in fm
+        assert fm["min_sources_per_section"] == 1
+
+    def test_dissertation_en_backward_compat(self, tmp_path):
+        from klemma.setup import init_project
+
+        values = InitValues(project_type="dissertation", title="Diss", language="en")
+        init_project(tmp_path, project_type="dissertation", values=values)
+
+        fm, body = parse_klemma_md(tmp_path / "KLEMMA.md")
+        assert fm["type"] == "dissertation"
+        assert fm["chapters"] == {1: "Literature review", 2: "Methodology", 3: "Results and discussion"}
+        assert "scientific_results" in fm
+        assert fm["auto_register"] == "mapped"
+        assert "## Structure" in body

--- a/tests/test_init_default_structures.py
+++ b/tests/test_init_default_structures.py
@@ -5,7 +5,12 @@ import warnings
 import pytest
 
 from klemma.config import parse_klemma_md
-from klemma.setup import InitValues, _build_klemma_md, _get_default_structure, _validate_outline_for_type
+from klemma.setup import (
+    InitValues,
+    _build_klemma_md,
+    _get_default_structure,
+    _validate_outline_for_type,
+)
 
 
 def _parse_built_md(values: InitValues) -> tuple[dict, str]:


### PR DESCRIPTION
### **User description**
## Summary

- **Landing page redesign**: Full rework of LitResearch SaaS landing page with conversion-focused copy and "Polar Manuscript" visual identity
  - Hero: "Каких статей не хватает в вашей диссертации?" — coverage as killer feature
  - Value bar with qualitative claims (real citations only, coverage by chapter, 1M free tokens)
  - Problem/pain section, 3-step flow, 4 benefit cards
  - "Complements, not replaces" positioning (Zotero/S2/ChatGPT integration, anti-plagiarism disclaimer)
  - Expanded 6-step pipeline with methodology citations (SciCite, RAG, CARS, SPECTER)
  - Scroll-triggered reveals, staggered animations, grain texture, hover-lift, beam border
  - Font scale ~1.5x for readability, all labels in Russian, design system tokens throughout
- **Type-aware init defaults**: `klemma init` now generates sensible default chapter structures based on project type (dissertation/paper/thesis)

## Test plan

- [ ] Run `npm run build` in `saas/dashboard/` — verify no errors
- [ ] Open landing page in browser — verify all sections render, animations trigger on scroll
- [ ] Check mobile responsiveness (grid collapses to 1-col)
- [ ] Run `pytest tests/test_init_default_structures.py` — verify init defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add type-aware `klemma init` defaults

- Support `paper` and `thesis` structures

- Infer section maps and outline warnings

- Redesign landing page with animated conversion copy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["`klemma init` defaults"]
  B["Type-aware project structures"]
  C["Validation and section inference"]
  D["Generated `KLEMMA.md`"]
  E["Landing page redesign"]
  F["Animated sections and FAQ"]
  G["Updated SEO metadata"]
  A -- "loads" --> B
  B -- "adds" --> C
  C -- "drives" --> D
  E -- "introduces" --> F
  F -- "supported by" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Add type-aware init structures and fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/setup.py

<ul><li>Add <code>_DEFAULT_STRUCTURES</code> for <code>dissertation</code>, <code>paper</code>, and <code>thesis</code><br> <li> Fallback missing languages to English defaults<br> <li> Warn when outlines mismatch expected project size<br> <li> Generate type-specific frontmatter, sections, and <code>auto_register</code></ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/222/files#diff-8a5a4bef3e1e27983f95cdf5309591daa80923a26aa302ccb9de832d893fe2aa">+170/-50</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LandingView.vue</strong><dd><code>Rebuild landing page with animated marketing sections</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/LandingView.vue

<ul><li>Add FAQ toggle state and scroll reveal observer<br> <li> Replace minimal landing page with full marketing layout<br> <li> Introduce Russian conversion copy, positioning, and CTA sections<br> <li> Add pipeline, audience, benefits, and FAQ content</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/222/files#diff-9217afa75d86c09fedf67862f62ac934e4cf042ccf44f6ee9b6ad57d38fa1e32">+540/-35</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.css</strong><dd><code>Add landing page animation and texture styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/assets/main.css

<ul><li>Expand landing animations for reveals and staggered entries<br> <li> Add hover lift, grain, beam border, and float effects<br> <li> Adjust fade timing to match new page interactions</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/222/files#diff-0448074717139317a54fd0aad50ab592d43928f4b8e42b3f6b4daebc5e4f5515">+115/-8</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_init_default_structures.py</strong><dd><code>Cover type-aware init defaults with tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_init_default_structures.py

<ul><li>Add coverage for default structure registry<br> <li> Verify generated <code>KLEMMA.md</code> frontmatter and body<br> <li> Test inferred <code>section_type_map</code> across languages<br> <li> Check warnings and <code>init_project</code> integration</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/222/files#diff-6c9e2480b6c2ec5ed91d1e89ae1b6d39166d7d81e77e51cf6093bc8439f84a99">+355/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Refresh landing page SEO title and description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/index.html

<ul><li>Update page description for literature review workflow<br> <li> Retitle page around fragment extraction and coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/klemma-ai/klemma/pull/222/files#diff-d1c991ca67adbd512160f4c39241217966fdb5d9d4aa509c81a4261fa82e1792">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

