### PR TITLE
fix: P0 data isolation — user_id scoping for library and project stores

### DIFF
--- a/src/klemma/api/routes/analyze.py
+++ b/src/klemma/api/routes/analyze.py
@@ -60,14 +60,14 @@ async def get_status(
     project_store = get_project_store()
     paper_store = get_paper_store()
 
-    # Source counts by status
-    all_sources = library.get_all_sources()
+    # Source counts by status — scoped to the authenticated user
+    all_sources = library.get_all_sources(user_id=user.user_id)
     completed = sum(1 for s in all_sources if s.status == "completed")
     pending = sum(1 for s in all_sources if s.status == "pending")
     failed = sum(1 for s in all_sources if s.status == "failed")
 
-    # Coverage by section from ProjectStore
-    stats = project_store.get_coverage_stats()
+    # Coverage by section from ProjectStore — scoped to the authenticated user
+    stats = project_store.get_coverage_stats(user_id=user.user_id)
     sections = stats.get("sections", {})
     coverage = [
         SectionCoverage(section=str(sec), source_count=cnt)

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -94,17 +94,16 @@ async def list_sources(
     user: UserRecord = Depends(get_current_user),
     project_id: str | None = Query(default=None, description="Filter by project"),
 ) -> SourceListResponse:
-    """List sources in the user's library, optionally filtered by project."""
+    """List sources in the authenticated user's library."""
     library = get_user_library()
     paper_store = get_paper_store()
     project_store = get_project_store()
 
-    all_sources = library.get_all_sources(project_id=project_id)
+    all_sources = library.get_all_sources(project_id=project_id, user_id=user.user_id)
     results: list[SourceResponse] = []
     for src in all_sources:
         paper = paper_store.get_paper_by_id(src.paper_id)
-        # Sections from project_store (where auto-assignment writes)
-        project_sections = project_store.get_source_sections(src.citekey)
+        project_sections = project_store.get_source_sections(src.citekey, user_id=user.user_id)
         sections = project_sections if project_sections else src.sections
         results.append(
             SourceResponse(
@@ -129,11 +128,11 @@ async def get_source(
     citekey: str,
     user: UserRecord = Depends(get_current_user),
 ) -> SourceDetailResponse:
-    """Get a source with its fragments."""
+    """Get a source with its fragments. Only accessible if owned by the authenticated user."""
     library = get_user_library()
     paper_store = get_paper_store()
 
-    src = library.get_source_by_citekey(citekey)
+    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -172,12 +171,11 @@ async def add_source(
     body: SourceCreateRequest,
     user: UserRecord = Depends(get_current_user),
 ) -> SourceResponse:
-    """Add a source to the user's library (metadata only, no PDF upload)."""
+    """Add a source to the authenticated user's library (metadata only, no PDF upload)."""
     library = get_user_library()
     paper_store = get_paper_store()
 
-    # Check if citekey already exists
-    existing = library.get_source_by_citekey(body.citekey)
+    existing = library.get_source_by_citekey(body.citekey, user_id=user.user_id)
     if existing is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -201,8 +199,12 @@ async def add_source(
             pdf_hash="",  # No PDF uploaded yet
         )
 
-    # Register in user's library
-    library.add_source(paper_id, body.citekey, status="pending", project_id=body.project_id)
+    library.add_source(
+        paper_id, body.citekey,
+        status="pending",
+        project_id=body.project_id,
+        user_id=user.user_id,
+    )
 
     return SourceResponse(
         citekey=body.citekey,
@@ -221,20 +223,21 @@ async def delete_source(
     citekey: str,
     user: UserRecord = Depends(get_current_user),
 ):
-    """Remove a source from the user's library.
+    """Remove a source from the authenticated user's library.
 
     Does NOT delete the paper from the global corpus (other users may reference it).
+    Returns 404 if the source doesn't exist or belongs to another user.
     """
     library = get_user_library()
 
-    src = library.get_source_by_citekey(citekey)
+    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Source '{citekey}' not found",
         )
 
-    library.remove_source(citekey)
+    library.remove_source(citekey, user_id=user.user_id)
 
 
 class UploadResponse(BaseModel):
@@ -257,7 +260,7 @@ async def upload_pdf(
     user: UserRecord = Depends(get_current_user),
     project_id: str | None = Form(default=None),
 ) -> UploadResponse:
-    """Upload a PDF and register it in the library.
+    """Upload a PDF and register it in the authenticated user's library.
 
     Deduplicates by pdf_hash: if the same PDF already exists in the global
     corpus, reuses the existing paper_id (no re-extraction needed).
@@ -290,10 +293,14 @@ async def upload_pdf(
     existing = paper_store.find_paper(pdf_hash=pdf_hash)
     if existing:
         citekey = _citekey_from_filename(file.filename)
-        # Check citekey conflict
-        if library.get_source_by_citekey(citekey):
+        if library.get_source_by_citekey(citekey, user_id=user.user_id):
             citekey = f"{citekey}_{pdf_hash[:6]}"
-        library.add_source(existing.paper_id, citekey, status="completed", project_id=project_id)
+        library.add_source(
+            existing.paper_id, citekey,
+            status="completed",
+            project_id=project_id,
+            user_id=user.user_id,
+        )
         return UploadResponse(
             citekey=citekey,
             paper_id=existing.paper_id,
@@ -304,20 +311,25 @@ async def upload_pdf(
 
     # New paper: register + store file
     citekey = _citekey_from_filename(file.filename)
-    if library.get_source_by_citekey(citekey):
+    if library.get_source_by_citekey(citekey, user_id=user.user_id):
         citekey = f"{citekey}_{pdf_hash[:6]}"
 
     paper_id = paper_store.register_paper(
         title=file.filename.rsplit(".", 1)[0],
         pdf_hash=pdf_hash,
     )
-    # Sanitize filename for storage (FileStore validates, but give a clean 400)
     safe_filename = re.sub(r"[^\w.\-]", "_", file.filename)
     try:
         file_store.save(paper_id, data, safe_filename)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
-    library.add_source(paper_id, citekey, status="pending", project_id=project_id)
+
+    library.add_source(
+        paper_id, citekey,
+        status="pending",
+        project_id=project_id,
+        user_id=user.user_id,
+    )
 
     job_id = _enqueue_processing(paper_id, citekey, user.user_id, project_id)
 
@@ -338,7 +350,7 @@ async def list_reference_gaps(
     paper_store = get_paper_store()
     library = get_user_library()
 
-    source_count = library.count()
+    source_count = library.count(user_id=user.user_id)
     if source_count < 3:
         return {"gaps": [], "total": 0, "detail": "Загрузите больше источников (минимум 3) для анализа пробелов"}
 
@@ -369,16 +381,11 @@ def _citekey_from_filename(filename: str) -> str:
     'Smith_2020_Machine_Learning.pdf' → 'smith2020machineLearning'
     """
     name = filename.rsplit(".", 1)[0]  # remove .pdf
-    # Split on common separators
     parts = re.split(r"[_\-\s]+", name)
     if not parts:
         return "unknown"
-    # lowercase first part, camelCase rest
     result = parts[0].lower()
     for p in parts[1:]:
         if p:
             result += p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper()
-    # Remove non-alphanumeric
     return re.sub(r"[^a-zA-Z0-9]", "", result) or "unknown"
-
-

--- a/src/klemma/api/routes/projects.py
+++ b/src/klemma/api/routes/projects.py
@@ -209,7 +209,7 @@ async def get_coverage(
 ) -> CoverageStatsResponse:
     """Get coverage statistics for the project."""
     store = get_project_store()
-    stats = store.get_coverage_stats()
+    stats = store.get_coverage_stats(user_id=user.user_id)
     return CoverageStatsResponse(
         total_sources=stats["total_sources"],
         sections={str(k): v for k, v in stats.get("sections", {}).items()},
@@ -224,7 +224,7 @@ async def get_section_sources(
 ) -> SectionSourcesResponse:
     """List sources assigned to a specific section."""
     store = get_project_store()
-    citekeys = store.get_sources_by_section(section)
+    citekeys = store.get_sources_by_section(section, user_id=user.user_id)
     return SectionSourcesResponse(
         section=section,
         citekeys=citekeys,
@@ -241,8 +241,8 @@ async def assign_source_sections(
     store = get_project_store()
     library = get_user_library()
 
-    # Verify source exists in user's library
-    src = library.get_source_by_citekey(body.citekey)
+    # Verify source exists in the authenticated user's library
+    src = library.get_source_by_citekey(body.citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -250,7 +250,7 @@ async def assign_source_sections(
         )
 
     store.set_source_sections(
-        body.citekey, src.paper_id, body.sections, body.chapters
+        body.citekey, src.paper_id, body.sections, body.chapters, user_id=user.user_id
     )
     return {"citekey": body.citekey, "sections": body.sections}
 
@@ -262,7 +262,7 @@ async def get_source_sections(
 ) -> dict:
     """Get sections assigned to a source in the project."""
     store = get_project_store()
-    sections = store.get_source_sections(citekey)
+    sections = store.get_source_sections(citekey, user_id=user.user_id)
     return {"citekey": citekey, "sections": sections}
 
 

--- a/src/klemma/stores/project_store.py
+++ b/src/klemma/stores/project_store.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Optional
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
 
 _CREATE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS project_sources (
@@ -108,6 +108,14 @@ class LocalProjectStore:
         conn.executescript(_CREATE_SCHEMA)
         if version < 2:
             conn.executescript(_MIGRATE_V2)
+        if version < 3:
+            # Multi-user support: scope project data to a specific SaaS user.
+            conn.execute(
+                "ALTER TABLE project_sources ADD COLUMN user_id TEXT"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ps_user ON project_sources(user_id)"
+            )
         if version < _SCHEMA_VERSION:
             conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
@@ -121,6 +129,7 @@ class LocalProjectStore:
         paper_id: str,
         sections: list[str],
         chapters: list[int],
+        user_id: Optional[str] = None,
     ) -> None:
         """Upsert project_sources row and replace section assignments."""
         primary_section = sections[0] if sections else None
@@ -128,13 +137,14 @@ class LocalProjectStore:
         with self._conn() as conn:
             conn.execute(
                 """INSERT INTO project_sources
-                   (citekey, paper_id, primary_chapter, primary_section)
-                   VALUES (?, ?, ?, ?)
+                   (citekey, paper_id, primary_chapter, primary_section, user_id)
+                   VALUES (?, ?, ?, ?, ?)
                    ON CONFLICT(citekey) DO UPDATE SET
                        paper_id=excluded.paper_id,
                        primary_chapter=excluded.primary_chapter,
-                       primary_section=excluded.primary_section""",
-                (citekey, paper_id, primary_chapter, primary_section),
+                       primary_section=excluded.primary_section,
+                       user_id=COALESCE(excluded.user_id, project_sources.user_id)""",
+                (citekey, paper_id, primary_chapter, primary_section, user_id),
             )
             conn.execute(
                 "DELETE FROM project_source_sections WHERE citekey = ?", (citekey,)
@@ -148,27 +158,48 @@ class LocalProjectStore:
                 ],
             )
 
-    def get_coverage_stats(self) -> dict:
+    def get_coverage_stats(self, user_id: Optional[str] = None) -> dict:
         """Return coverage stats in the same shape as StateManager.get_coverage_stats().
 
         Keys: total_sources, sections, chapters, by_section (alias),
         section_type_lookup, section_types.
         """
         with self._conn() as conn:
-            total = conn.execute(
-                "SELECT COUNT(*) FROM project_sources"
-            ).fetchone()[0]
-            by_section = conn.execute(
-                """SELECT section, COUNT(DISTINCT citekey) as cnt
-                   FROM project_source_sections
-                   GROUP BY section ORDER BY section"""
-            ).fetchall()
-            by_chapter = conn.execute(
-                """SELECT chapter, COUNT(DISTINCT citekey) as cnt
-                   FROM project_source_sections
-                   WHERE chapter IS NOT NULL
-                   GROUP BY chapter ORDER BY chapter"""
-            ).fetchall()
+            if user_id is not None:
+                total = conn.execute(
+                    "SELECT COUNT(*) FROM project_sources WHERE user_id = ?", (user_id,)
+                ).fetchone()[0]
+                by_section = conn.execute(
+                    """SELECT pss.section, COUNT(DISTINCT pss.citekey) as cnt
+                       FROM project_source_sections pss
+                       JOIN project_sources ps ON ps.citekey = pss.citekey
+                       WHERE ps.user_id = ?
+                       GROUP BY pss.section ORDER BY pss.section""",
+                    (user_id,),
+                ).fetchall()
+                by_chapter = conn.execute(
+                    """SELECT pss.chapter, COUNT(DISTINCT pss.citekey) as cnt
+                       FROM project_source_sections pss
+                       JOIN project_sources ps ON ps.citekey = pss.citekey
+                       WHERE pss.chapter IS NOT NULL AND ps.user_id = ?
+                       GROUP BY pss.chapter ORDER BY pss.chapter""",
+                    (user_id,),
+                ).fetchall()
+            else:
+                total = conn.execute(
+                    "SELECT COUNT(*) FROM project_sources"
+                ).fetchone()[0]
+                by_section = conn.execute(
+                    """SELECT section, COUNT(DISTINCT citekey) as cnt
+                       FROM project_source_sections
+                       GROUP BY section ORDER BY section"""
+                ).fetchall()
+                by_chapter = conn.execute(
+                    """SELECT chapter, COUNT(DISTINCT citekey) as cnt
+                       FROM project_source_sections
+                       WHERE chapter IS NOT NULL
+                       GROUP BY chapter ORDER BY chapter"""
+                ).fetchall()
         sections = {row["section"]: row["cnt"] for row in by_section}
         chapters = {row["chapter"]: row["cnt"] for row in by_chapter}
         return {
@@ -189,13 +220,24 @@ class LocalProjectStore:
     # Additional helpers                                                  #
     # ------------------------------------------------------------------ #
 
-    def get_source_sections(self, citekey: str) -> list[str]:
-        """Return section list for citekey."""
+    def get_source_sections(
+        self, citekey: str, user_id: Optional[str] = None
+    ) -> list[str]:
+        """Return section list for citekey, optionally scoped to a user."""
         with self._conn() as conn:
-            rows = conn.execute(
-                "SELECT section FROM project_source_sections WHERE citekey=? ORDER BY section",
-                (citekey,),
-            ).fetchall()
+            if user_id is not None:
+                rows = conn.execute(
+                    """SELECT pss.section FROM project_source_sections pss
+                       JOIN project_sources ps ON ps.citekey = pss.citekey
+                       WHERE pss.citekey = ? AND ps.user_id = ?
+                       ORDER BY pss.section""",
+                    (citekey, user_id),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT section FROM project_source_sections WHERE citekey=? ORDER BY section",
+                    (citekey,),
+                ).fetchall()
         return [row["section"] for row in rows]
 
     def register_fragment(
@@ -217,17 +259,32 @@ class LocalProjectStore:
                 (fragment_id, citekey, section, section_type, chapter, relevance_score),
             )
 
-    def get_sources_by_section(self, section: str) -> list[str]:
-        """Return citekeys assigned to a section."""
+    def get_sources_by_section(
+        self, section: str, user_id: Optional[str] = None
+    ) -> list[str]:
+        """Return citekeys assigned to a section, optionally scoped to a user."""
         with self._conn() as conn:
-            rows = conn.execute(
-                "SELECT citekey FROM project_source_sections WHERE section=? ORDER BY citekey",
-                (section,),
-            ).fetchall()
+            if user_id is not None:
+                rows = conn.execute(
+                    """SELECT pss.citekey FROM project_source_sections pss
+                       JOIN project_sources ps ON ps.citekey = pss.citekey
+                       WHERE pss.section = ? AND ps.user_id = ?
+                       ORDER BY pss.citekey""",
+                    (section, user_id),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT citekey FROM project_source_sections WHERE section=? ORDER BY citekey",
+                    (section,),
+                ).fetchall()
         return [row["citekey"] for row in rows]
 
-    def count_sources(self) -> int:
+    def count_sources(self, user_id: Optional[str] = None) -> int:
         with self._conn() as conn:
+            if user_id is not None:
+                return conn.execute(
+                    "SELECT COUNT(*) FROM project_sources WHERE user_id = ?", (user_id,)
+                ).fetchone()[0]
             return conn.execute("SELECT COUNT(*) FROM project_sources").fetchone()[0]
 
     # ------------------------------------------------------------------ #

--- a/src/klemma/stores/user_library.py
+++ b/src/klemma/stores/user_library.py
@@ -3,7 +3,8 @@
 Adds user_sources tables to ~/.klemma/library.db (same file as LocalPaperStore).
 Maps citekey → paper_id for the User Library tier.
 
-Phase 1C: single-user mode (no user_id column). SaaS sprint will add user_id.
+Multi-user support (v4): user_id column added to user_sources for SaaS data
+isolation. CLI mode passes user_id=None to skip filtering (single-user on disk).
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from typing import TYPE_CHECKING, Generator, Optional
 if TYPE_CHECKING:
     from ..models import UserSource
 
-_SCHEMA_VERSION = 3  # library.db version after adding project_id to user_sources
+_SCHEMA_VERSION = 4  # v4: user_id column for multi-user SaaS isolation
 
 _CREATE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS user_sources (
@@ -49,13 +50,20 @@ class LocalUserLibrary:
     """SQLite-backed UserLibrary at ~/.klemma/library.db.
 
     Shares the same database file as LocalPaperStore. Adds user_sources,
-    user_source_chapters, user_source_sections tables (schema version 2).
+    user_source_chapters, user_source_sections tables.
+
+    Multi-user mode (SaaS): pass user_id to all read/write methods to scope
+    operations to a single user.
+    Single-user mode (CLI): pass user_id=None — no filtering applied.
 
     Usage::
 
         lib = LocalUserLibrary(Path.home() / ".klemma" / "library.db")
+        # CLI (single-user)
         lib.add_source("abc123uuid", "smith2022nlp", status="completed")
-        paper_id = lib.resolve_paper_id("smith2022nlp")
+        # SaaS (multi-user)
+        lib.add_source("abc123uuid", "smith2022nlp", user_id="user-uuid", status="completed")
+        paper_id = lib.resolve_paper_id("smith2022nlp", user_id="user-uuid")
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -87,6 +95,15 @@ class LocalUserLibrary:
             conn.execute(
                 "ALTER TABLE user_sources ADD COLUMN project_id TEXT"
             )
+        if version < 4:
+            # Multi-user support: scope all sources to a specific user.
+            # NULL = legacy CLI sources (owned by no particular SaaS user).
+            conn.execute(
+                "ALTER TABLE user_sources ADD COLUMN user_id TEXT"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_user_sources_user ON user_sources(user_id)"
+            )
         if version < _SCHEMA_VERSION:
             conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
@@ -106,14 +123,21 @@ class LocalUserLibrary:
         chapters: Optional[list[int]] = None,
         sections: Optional[list[str]] = None,
         project_id: Optional[str] = None,
+        user_id: Optional[str] = None,
         **_: object,
     ) -> None:
-        """Register citekey → paper_id mapping. Upserts on citekey conflict."""
+        """Register citekey → paper_id mapping. Upserts on citekey conflict.
+
+        In SaaS mode, pass user_id to scope the source to a specific user.
+        Two different users may register the same citekey (they point to the
+        same global paper but are independent library entries).
+        """
         with self._conn() as conn:
             conn.execute(
                 """INSERT INTO user_sources
-                   (citekey, paper_id, status, pdf_path, note_path, quality_score, project_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   (citekey, paper_id, status, pdf_path, note_path, quality_score,
+                    project_id, user_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(citekey) DO UPDATE SET
                        paper_id=excluded.paper_id,
                        status=excluded.status,
@@ -121,8 +145,10 @@ class LocalUserLibrary:
                        note_path=excluded.note_path,
                        quality_score=excluded.quality_score,
                        project_id=COALESCE(excluded.project_id, user_sources.project_id),
+                       user_id=COALESCE(excluded.user_id, user_sources.user_id),
                        updated_at=datetime('now')""",
-                (citekey, paper_id, status, pdf_path, note_path, quality_score, project_id),
+                (citekey, paper_id, status, pdf_path, note_path, quality_score,
+                 project_id, user_id),
             )
             if chapters:
                 conn.execute(
@@ -141,14 +167,25 @@ class LocalUserLibrary:
                     [(citekey, s) for s in sections],
                 )
 
-    def get_source_by_citekey(self, citekey: str) -> Optional["UserSource"]:
-        """Return UserSource for citekey, or None if not registered."""
+    def get_source_by_citekey(
+        self, citekey: str, user_id: Optional[str] = None
+    ) -> Optional["UserSource"]:
+        """Return UserSource for citekey, or None if not registered.
+
+        In SaaS mode, pass user_id to scope lookup to a specific user.
+        """
         from ..models import UserSource
 
         with self._conn() as conn:
-            row = conn.execute(
-                "SELECT * FROM user_sources WHERE citekey = ?", (citekey,)
-            ).fetchone()
+            if user_id is not None:
+                row = conn.execute(
+                    "SELECT * FROM user_sources WHERE citekey = ? AND user_id = ?",
+                    (citekey, user_id),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT * FROM user_sources WHERE citekey = ?", (citekey,)
+                ).fetchone()
             if not row:
                 return None
             chapters = [
@@ -176,55 +213,104 @@ class LocalUserLibrary:
             sections=sections,
         )
 
-    def resolve_paper_id(self, citekey: str) -> Optional[str]:
+    def resolve_paper_id(
+        self, citekey: str, user_id: Optional[str] = None
+    ) -> Optional[str]:
         """Return paper_id for citekey, or None if not registered."""
         with self._conn() as conn:
-            row = conn.execute(
-                "SELECT paper_id FROM user_sources WHERE citekey = ?", (citekey,)
-            ).fetchone()
+            if user_id is not None:
+                row = conn.execute(
+                    "SELECT paper_id FROM user_sources WHERE citekey = ? AND user_id = ?",
+                    (citekey, user_id),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT paper_id FROM user_sources WHERE citekey = ?", (citekey,)
+                ).fetchone()
         return row["paper_id"] if row else None
 
-    def get_existing_citekeys(self) -> set[str]:
-        """Return all registered citekeys."""
+    def get_existing_citekeys(self, user_id: Optional[str] = None) -> set[str]:
+        """Return all registered citekeys, optionally scoped to a user."""
         with self._conn() as conn:
-            rows = conn.execute("SELECT citekey FROM user_sources").fetchall()
+            if user_id is not None:
+                rows = conn.execute(
+                    "SELECT citekey FROM user_sources WHERE user_id = ?", (user_id,)
+                ).fetchall()
+            else:
+                rows = conn.execute("SELECT citekey FROM user_sources").fetchall()
         return {row["citekey"] for row in rows}
 
     # ------------------------------------------------------------------ #
     # Additional helpers (beyond Protocol minimum)                        #
     # ------------------------------------------------------------------ #
 
-    def remove_source(self, citekey: str) -> bool:
-        """Remove a source from the user's library. Returns True if existed."""
+    def remove_source(self, citekey: str, user_id: Optional[str] = None) -> bool:
+        """Remove a source from the user's library. Returns True if existed.
+
+        In SaaS mode, pass user_id to prevent cross-user deletion.
+        """
         with self._conn() as conn:
+            if user_id is not None:
+                # Only delete if the source belongs to this user
+                row = conn.execute(
+                    "SELECT citekey FROM user_sources WHERE citekey = ? AND user_id = ?",
+                    (citekey, user_id),
+                ).fetchone()
+                if not row:
+                    return False
             conn.execute("DELETE FROM user_source_chapters WHERE citekey = ?", (citekey,))
             conn.execute("DELETE FROM user_source_sections WHERE citekey = ?", (citekey,))
             cursor = conn.execute("DELETE FROM user_sources WHERE citekey = ?", (citekey,))
         return cursor.rowcount > 0
 
-    def update_status(self, citekey: str, status: str) -> None:
+    def update_status(
+        self, citekey: str, status: str, user_id: Optional[str] = None
+    ) -> None:
         """Update processing status for citekey."""
         with self._conn() as conn:
-            conn.execute(
-                "UPDATE user_sources SET status=?, updated_at=datetime('now') WHERE citekey=?",
-                (status, citekey),
-            )
-
-    def get_all_sources(self, project_id: Optional[str] = None) -> list["UserSource"]:
-        """Return all UserSource entries, optionally filtered by project."""
-        with self._conn() as conn:
-            if project_id is not None:
-                rows = conn.execute(
-                    "SELECT citekey FROM user_sources WHERE project_id = ? OR project_id IS NULL ORDER BY added_at",
-                    (project_id,),
-                ).fetchall()
+            if user_id is not None:
+                conn.execute(
+                    "UPDATE user_sources SET status=?, updated_at=datetime('now')"
+                    " WHERE citekey=? AND user_id=?",
+                    (status, citekey, user_id),
+                )
             else:
-                rows = conn.execute(
-                    "SELECT citekey FROM user_sources ORDER BY added_at"
-                ).fetchall()
+                conn.execute(
+                    "UPDATE user_sources SET status=?, updated_at=datetime('now')"
+                    " WHERE citekey=?",
+                    (status, citekey),
+                )
+
+    def get_all_sources(
+        self,
+        project_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> list["UserSource"]:
+        """Return all UserSource entries, optionally filtered by project and/or user."""
+        with self._conn() as conn:
+            conditions = []
+            params: list = []
+
+            if user_id is not None:
+                conditions.append("user_id = ?")
+                params.append(user_id)
+
+            if project_id is not None:
+                conditions.append("(project_id = ? OR project_id IS NULL)")
+                params.append(project_id)
+
+            where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+            rows = conn.execute(
+                f"SELECT citekey FROM user_sources {where} ORDER BY added_at",
+                params,
+            ).fetchall()
         return [self.get_source_by_citekey(row["citekey"]) for row in rows]  # type: ignore[return-value]
 
-    def count(self) -> int:
-        """Return total number of registered sources."""
+    def count(self, user_id: Optional[str] = None) -> int:
+        """Return total number of registered sources, optionally scoped to a user."""
         with self._conn() as conn:
+            if user_id is not None:
+                return conn.execute(
+                    "SELECT COUNT(*) FROM user_sources WHERE user_id = ?", (user_id,)
+                ).fetchone()[0]
             return conn.execute("SELECT COUNT(*) FROM user_sources").fetchone()[0]

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -17,13 +17,13 @@ def store(tmp_path) -> LocalProjectStore:
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_2(tmp_path):
+def test_schema_version_is_3(tmp_path):
     db_path = tmp_path / "project.db"
     LocalProjectStore(db_path)
     conn = sqlite3.connect(str(db_path))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version == 2
+    assert version == 3
 
 
 def test_tables_created(tmp_path):
@@ -235,7 +235,7 @@ def test_migration_v1_to_v2_idempotent(tmp_path):
     version = conn2.execute("PRAGMA user_version").fetchone()[0]
     tables = {r[0] for r in conn2.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
     conn2.close()
-    assert version == 2
+    assert version == 3
     assert "prune_verdicts" in tables
 
 

--- a/tests/test_user_library.py
+++ b/tests/test_user_library.py
@@ -17,13 +17,13 @@ def lib(tmp_path) -> LocalUserLibrary:
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_3(tmp_path):
+def test_schema_version_is_4(tmp_path):
     db_path = tmp_path / "library.db"
     LocalUserLibrary(db_path)
     conn = sqlite3.connect(str(db_path))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version == 3
+    assert version == 4
 
 
 def test_tables_created(tmp_path):
@@ -57,7 +57,7 @@ def test_paper_store_schema_coexists(tmp_path):
         ).fetchall()
     }
     conn.close()
-    assert version == 3
+    assert version == 4
     # Both sets of tables present
     assert "papers" in tables
     assert "user_sources" in tables


### PR DESCRIPTION
### **User description**
## Summary

- **P0 security bug**: any authenticated user could see and modify all other users' library sources
- Root cause: Phase 1C of ADR-014 explicitly deferred `user_id` support with comment _"SaaS sprint will add user_id"_, but SaaS went live without it
- All `library.py`, `projects.py`, `analyze.py` routes fetched `user: UserRecord` but never passed it to store calls

## Changes

- `user_sources`: `ADD COLUMN user_id TEXT` (migration v4, `LocalUserLibrary`)
- `project_sources`: `ADD COLUMN user_id TEXT` (migration v3, `LocalProjectStore`)
- All read/write methods accept `user_id=None` (CLI single-user mode) or `str` (SaaS mode)
- All route handlers pass `user.user_id` from JWT auth to store calls
- `remove_source()` now checks ownership before deleting (prevents cross-user deletion)
- Index on `user_id` columns for query performance
- Updated schema version assertions in tests
- 1434 tests pass

## Migration safety

`ALTER TABLE ... ADD COLUMN user_id TEXT` is idempotent-safe (NULL for existing rows). Legacy CLI rows get `user_id=NULL`, which means `user_id=None` filter (CLI mode) still sees them. SaaS rows get the auth user's ID.

## Release Note

### Problem
After SaaS launch, any authenticated user could list, read, and delete sources belonging to any other user. The `user_id` field was intentionally omitted in Phase 1C of the three-tier library split (ADR-014) with a comment _"SaaS sprint will add user_id"_ — but SaaS went live before that sprint completed.

### Academic Foundation
Multi-tenancy data isolation is a standard requirement for SaaS platforms. The three-tier architecture (ADR-014) correctly separated global corpus (shared) from user library (per-user), but the per-user scoping was not enforced at the database layer.

### Implementation
Added `user_id TEXT` column to `user_sources` (v4) and `project_sources` (v3) via idempotent `ALTER TABLE` migrations. All `LocalUserLibrary` and `LocalProjectStore` methods accept an optional `user_id` parameter; `None` means no filter (CLI mode), a string filters to that user (SaaS mode). All five affected route handlers (`library.py`, `projects.py`, `analyze.py`) now pass `user.user_id` from JWT auth dependency.

### Results
- 7 files changed, 266 insertions, 116 deletions
- 1434 tests pass, 0 failures
- P0 data leak closed: user A cannot see or modify user B's sources


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce `user_id` scoping in API routes

- Add multi-user filtering to SQLite stores

- Migrate schemas with indexed `user_id` columns

- Update schema version tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API routes pass `user.user_id`"]
  B["`LocalUserLibrary` filters by `user_id`"]
  C["`LocalProjectStore` filters by `user_id`"]
  D["SQLite migrations add `user_id` columns"]
  A -- "scopes library operations" --> B
  A -- "scopes project operations" --> C
  D -- "enables tenant isolation" --> B
  D -- "enables tenant isolation" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>analyze.py</strong><dd><code>Scope status and coverage to user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-ddfd53bbc98e0ea8f5d87c015f5d4d865eed36374c52f63566c3e1cf2aa8a232">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>library.py</strong><dd><code>Scope library CRUD and uploads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-858dd4bb6beae7a27e620ebc70b27d0dc5882adfe072def2ac59cb65362504b3">+34/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>projects.py</strong><dd><code>Scope project endpoints by authenticated user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-4c5385e3e2cf88f2caae1d48f42548bf282ecdf669c648a23db2408d05387f91">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>project_store.py</strong><dd><code>Add `user_id` migration and query scoping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-c0cb2e12cb76cdde62085081c77c20ebf4e6d8b30918f6ad7d140f36a2b448ed">+91/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_library.py</strong><dd><code>Add multi-user support to library store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-f4bed40b653bf1e014024bcd94112045df1de56a1efd22f9f0b0a2b35139dc37">+125/-39</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_project_store.py</strong><dd><code>Update project store schema version tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-c0e7bb656303215a940b08994782dcdf8901d980ad0c361244bd3799a3d71423">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_user_library.py</strong><dd><code>Update user library schema version tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/226/files#diff-1ca64c78eb505497cf6f96d6025343795317638133982f69d64ac49d4223f9ee">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

