### PR TITLE
feat: Branch Store for Guided Serendipity (#231)

### DIFF
--- a/src/klemma/commands/__init__.py
+++ b/src/klemma/commands/__init__.py
@@ -4,4 +4,14 @@ Each module registers its commands/groups against ``main`` from ``..cli``.
 Importing this package triggers registration of all commands.
 """
 
-from . import acquire, analyze, benchmark, bib, manage, process, research, write  # noqa: F401
+from . import (  # noqa: F401
+    acquire,
+    analyze,
+    benchmark,
+    bib,
+    decisions,
+    manage,
+    process,
+    research,
+    write,
+)

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -1,0 +1,222 @@
+"""Guided Serendipity: decisions and briefing commands."""
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from ..cli import _get_context, console, main
+
+
+@main.group(invoke_without_command=True)
+@click.pass_context
+def decisions(ctx):
+    """View and manage research decisions (Guided Serendipity)."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(decisions_list)
+
+
+@decisions.command("list")
+@click.option(
+    "--section", "-s", default=None, help="Filter by section (e.g. 3.2)"
+)
+@click.option(
+    "--pending", is_flag=True, help="Show only pending (undecided) decisions"
+)
+@click.option(
+    "--all", "show_all", is_flag=True, help="Include skipped decisions"
+)
+@click.option("--limit", "-n", default=20, help="Max decisions to show")
+@click.pass_context
+def decisions_list(ctx, section, pending, show_all, limit):
+    """List research decisions."""
+    kctx = _get_context(ctx)
+    repo = kctx.state.decisions
+
+    if pending:
+        items = repo.get_pending_decisions()
+    else:
+        items = repo.get_decisions(
+            section=section, limit=limit, include_skipped=show_all
+        )
+
+    if not items:
+        console.print("[dim]No decisions yet. Decisions appear after briefings.[/dim]")
+        return
+
+    counts = repo.count_decisions()
+    console.print(
+        f"[bold]Research Trail:[/bold] {counts['decided']} decided, "
+        f"{counts['pending']} pending, {counts['skipped']} skipped\n"
+    )
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", style="dim", width=4)
+    table.add_column("Date", width=10)
+    table.add_column("Type", width=9)
+    table.add_column("Source", width=20)
+    table.add_column("Choice", width=8)
+    table.add_column("Sections", width=10)
+
+    for d in items:
+        date = d["created_at"][:10] if d.get("created_at") else ""
+        source = d.get("trigger_source") or ""
+        if len(source) > 20:
+            source = source[:17] + "..."
+
+        choice = d.get("chosen_option")
+        if choice is None:
+            choice_str = "[yellow]pending[/yellow]"
+        elif choice == "__skipped__":
+            choice_str = "[dim]skipped[/dim]"
+        else:
+            choice_str = f"[green]{choice}[/green]"
+
+        sections = d.get("sections")
+        sections_str = ", ".join(sections) if isinstance(sections, list) else ""
+
+        table.add_row(
+            str(d["id"]),
+            date,
+            d.get("trigger_type", ""),
+            source,
+            choice_str,
+            sections_str,
+        )
+
+    console.print(table)
+
+
+@decisions.command("show")
+@click.argument("decision_id", type=int)
+@click.pass_context
+def decisions_show(ctx, decision_id):
+    """Show details of a specific decision."""
+    kctx = _get_context(ctx)
+    d = kctx.state.decisions.get_decision(decision_id)
+
+    if not d:
+        console.print(f"[red]Decision #{decision_id} not found[/red]")
+        return
+
+    # Header
+    status = "pending" if d.get("chosen_option") is None else "decided"
+    if d.get("chosen_option") == "__skipped__":
+        status = "skipped"
+    console.print(
+        Panel(
+            f"[bold]{d.get('trigger_type', '').upper()}[/bold] — "
+            f"{'@' + d['trigger_source'] if d.get('trigger_source') else 'library analysis'}\n"
+            f"Status: {status} | Created: {d.get('created_at', '')[:16]}",
+            title=f"Decision #{d['id']}",
+        )
+    )
+
+    # Options
+    options = d.get("options_json", [])
+    if isinstance(options, list):
+        console.print("\n[bold]Options:[/bold]")
+        for opt in options:
+            key = opt.get("key", "?")
+            title = opt.get("title", "")
+            desc = opt.get("description", "")
+            chosen = d.get("chosen_option") == key
+            marker = " [green]← chosen[/green]" if chosen else ""
+            console.print(f"  [{key}] [bold]{title}[/bold]{marker}")
+            if desc:
+                console.print(f"      {desc}")
+
+    # Rationale
+    if d.get("rationale"):
+        console.print(f"\n[bold]Rationale:[/bold] {d['rationale']}")
+
+    # Context summary
+    context = d.get("context_json", {})
+    if isinstance(context, dict) and context.get("key_claims"):
+        console.print("\n[bold]Key claims:[/bold]")
+        for claim in context["key_claims"]:
+            console.print(f"  • {claim}")
+
+    # Pending action hint
+    if d.get("chosen_option") is None:
+        console.print(
+            f"\n[yellow]Decide:[/yellow] klemma decide {d['id']} A|B|C"
+        )
+
+
+@main.command()
+@click.argument("decision_id", type=int)
+@click.argument("option", type=str)
+@click.option("--reason", "-r", default=None, help="Why you chose this option")
+@click.pass_context
+def decide(ctx, decision_id, option, reason):
+    """Record your choice for a pending decision."""
+    kctx = _get_context(ctx)
+    repo = kctx.state.decisions
+
+    d = repo.get_decision(decision_id)
+    if not d:
+        console.print(f"[red]Decision #{decision_id} not found[/red]")
+        return
+
+    if d.get("chosen_option") is not None:
+        console.print(
+            f"[yellow]Decision #{decision_id} already "
+            f"{'skipped' if d['chosen_option'] == '__skipped__' else 'decided'}: "
+            f"{d['chosen_option']}[/yellow]"
+        )
+        return
+
+    # Validate option against available options
+    options = d.get("options_json", [])
+    valid_keys = {opt.get("key") for opt in options if isinstance(opt, dict)}
+    if valid_keys and option.upper() not in valid_keys:
+        console.print(
+            f"[red]Invalid option '{option}'. Valid: {', '.join(sorted(valid_keys))}[/red]"
+        )
+        return
+
+    updated = repo.decide(decision_id, option.upper(), reason)
+    if updated:
+        console.print(
+            f"[green]✓ Decision #{decision_id} → {option.upper()}[/green]"
+        )
+        if reason:
+            console.print(f"  Rationale: {reason}")
+    else:
+        console.print(f"[red]Failed to update decision #{decision_id}[/red]")
+
+
+@decisions.command("trail")
+@click.pass_context
+def decisions_trail(ctx):
+    """Show the research trail — chronological path of decisions."""
+    kctx = _get_context(ctx)
+    trail = kctx.state.decisions.get_trail()
+
+    if not trail:
+        console.print("[dim]No decisions made yet. Your research trail is empty.[/dim]")
+        return
+
+    console.print(f"[bold]Research Trail[/bold] — {len(trail)} decisions\n")
+
+    for i, d in enumerate(trail):
+        prefix = "└─" if i == len(trail) - 1 else "├─"
+        source = f"@{d['trigger_source']}" if d.get("trigger_source") else "library"
+        date = d["created_at"][:10] if d.get("created_at") else ""
+
+        # Find chosen option title
+        choice_title = d.get("chosen_option", "?")
+        options = d.get("options_json", [])
+        if isinstance(options, list):
+            for opt in options:
+                if isinstance(opt, dict) and opt.get("key") == d.get("chosen_option"):
+                    choice_title = opt.get("title", choice_title)
+                    break
+
+        console.print(
+            f"  {prefix} [{date}] {d['trigger_type']}: {source} "
+            f"→ [green]{choice_title}[/green]"
+        )
+        if d.get("rationale"):
+            pad = "   " if i == len(trail) - 1 else "│  "
+            console.print(f"  {pad} [dim]{d['rationale']}[/dim]")

--- a/src/klemma/repositories/__init__.py
+++ b/src/klemma/repositories/__init__.py
@@ -3,6 +3,7 @@
 from .base import BaseRepository
 from .benchmarks import BenchmarkRepository
 from .citations import CitationsRepository
+from .decisions import DecisionsRepository
 from .embeddings_store import EmbeddingsStoreRepository
 from .fragments import FragmentRepository
 from .gaps import GapsRepository
@@ -14,6 +15,7 @@ __all__ = [
     "BaseRepository",
     "BenchmarkRepository",
     "CitationsRepository",
+    "DecisionsRepository",
     "EmbeddingsStoreRepository",
     "FragmentRepository",
     "GapsRepository",

--- a/src/klemma/repositories/decisions.py
+++ b/src/klemma/repositories/decisions.py
@@ -1,0 +1,196 @@
+"""Guided Serendipity decisions — branching points and researcher choices."""
+
+import json
+from typing import Optional
+
+from .base import BaseRepository
+
+
+class DecisionsRepository(BaseRepository):
+    """CRUD for research decisions (Guided Serendipity branching points)."""
+
+    def save_decision(
+        self,
+        *,
+        trigger_type: str,
+        trigger_source: Optional[str] = None,
+        context: dict,
+        options: list[dict],
+        sections: Optional[list[str]] = None,
+        chosen_option: Optional[str] = None,
+        rationale: Optional[str] = None,
+        influenced_by: Optional[list[int]] = None,
+    ) -> int:
+        """Save a new decision (branching point).
+
+        Returns the decision ID.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                """INSERT INTO decisions
+                   (trigger_type, trigger_source, context_json, options_json,
+                    chosen_option, rationale, sections, influenced_by)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    trigger_type,
+                    trigger_source,
+                    json.dumps(context, ensure_ascii=False),
+                    json.dumps(options, ensure_ascii=False),
+                    chosen_option,
+                    rationale,
+                    json.dumps(sections) if sections else None,
+                    json.dumps(influenced_by) if influenced_by else None,
+                ),
+            )
+            return cur.lastrowid
+
+    def decide(
+        self,
+        decision_id: int,
+        chosen_option: str,
+        rationale: Optional[str] = None,
+    ) -> bool:
+        """Record the researcher's choice for a pending decision.
+
+        Returns True if the decision was updated.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                """UPDATE decisions
+                   SET chosen_option = ?, rationale = ?, decided_at = datetime('now')
+                   WHERE id = ? AND chosen_option IS NULL""",
+                (chosen_option, rationale, decision_id),
+            )
+            return cur.rowcount > 0
+
+    def skip_decision(self, decision_id: int) -> bool:
+        """Mark a decision as skipped."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                """UPDATE decisions
+                   SET chosen_option = '__skipped__', decided_at = datetime('now')
+                   WHERE id = ? AND chosen_option IS NULL""",
+                (decision_id,),
+            )
+            return cur.rowcount > 0
+
+    def get_decision(self, decision_id: int) -> Optional[dict]:
+        """Get a single decision by ID."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM decisions WHERE id = ?", (decision_id,)
+            ).fetchone()
+            if not row:
+                return None
+            return self._row_to_dict(row)
+
+    def get_pending_decisions(
+        self, trigger_type: Optional[str] = None
+    ) -> list[dict]:
+        """Get all decisions without a choice yet."""
+        sql = "SELECT * FROM decisions WHERE chosen_option IS NULL"
+        params: list = []
+        if trigger_type:
+            sql += " AND trigger_type = ?"
+            params.append(trigger_type)
+        sql += " ORDER BY created_at DESC"
+        with self._conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+
+    def get_decisions(
+        self,
+        *,
+        section: Optional[str] = None,
+        trigger_type: Optional[str] = None,
+        limit: int = 50,
+        include_skipped: bool = False,
+    ) -> list[dict]:
+        """Get decisions with optional filters."""
+        sql = "SELECT * FROM decisions WHERE 1=1"
+        params: list = []
+
+        if not include_skipped:
+            sql += " AND (chosen_option IS NULL OR chosen_option != '__skipped__')"
+
+        if trigger_type:
+            sql += " AND trigger_type = ?"
+            params.append(trigger_type)
+
+        if section:
+            sql += " AND sections LIKE ?"
+            params.append(f'%"{section}"%')
+
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        with self._conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+
+    def get_trail(self) -> list[dict]:
+        """Get the full decision trail (only decided, ordered chronologically).
+
+        Returns decisions with their influenced_by links for graph construction.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                """SELECT * FROM decisions
+                   WHERE chosen_option IS NOT NULL
+                     AND chosen_option != '__skipped__'
+                   ORDER BY created_at ASC"""
+            ).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+
+    def get_decisions_for_context(
+        self, sections: Optional[list[str]] = None
+    ) -> list[dict]:
+        """Get decided decisions suitable for prompt injection.
+
+        Returns compact summaries for downstream use in research/draft prompts.
+        """
+        sql = """SELECT id, trigger_type, trigger_source, chosen_option,
+                        rationale, sections, created_at
+                 FROM decisions
+                 WHERE chosen_option IS NOT NULL
+                   AND chosen_option != '__skipped__'"""
+        params: list = []
+
+        if sections:
+            conditions = " OR ".join(
+                "sections LIKE ?" for _ in sections
+            )
+            sql += f" AND ({conditions})"
+            params.extend(f'%"{s}"%' for s in sections)
+
+        sql += " ORDER BY created_at ASC"
+
+        with self._conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+            return [dict(r) for r in rows]
+
+    def count_decisions(self) -> dict:
+        """Return counts by status."""
+        with self._conn() as conn:
+            row = conn.execute(
+                """SELECT
+                     COUNT(*) as total,
+                     SUM(CASE WHEN chosen_option IS NULL THEN 1 ELSE 0 END) as pending,
+                     SUM(CASE WHEN chosen_option IS NOT NULL
+                          AND chosen_option != '__skipped__' THEN 1 ELSE 0 END) as decided,
+                     SUM(CASE WHEN chosen_option = '__skipped__' THEN 1 ELSE 0 END) as skipped
+                   FROM decisions"""
+            ).fetchone()
+            return dict(row)
+
+    @staticmethod
+    def _row_to_dict(row) -> dict:
+        """Convert a sqlite3.Row to a dict with parsed JSON fields."""
+        d = dict(row)
+        for key in ("context_json", "options_json", "sections", "influenced_by"):
+            if d.get(key) and isinstance(d[key], str):
+                try:
+                    d[key] = json.loads(d[key])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return d

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -9,6 +9,7 @@ from typing import Optional
 from .repositories import (
     BenchmarkRepository,
     CitationsRepository,
+    DecisionsRepository,
     EmbeddingsStoreRepository,
     FragmentRepository,
     GapsRepository,
@@ -158,6 +159,7 @@ class StateManager:
         self.plans = PlansRepository(self._conn)
         self.prune = PruneRepository(self._conn)
         self.benchmarks = BenchmarkRepository(self._conn)
+        self.decisions = DecisionsRepository(self._conn)
 
     @contextmanager
     def _conn(self):
@@ -183,7 +185,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 12  # bump this when adding new migrations
+        target = 13  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -431,6 +433,31 @@ class StateManager:
                     conn.execute(
                         f"ALTER TABLE sources ADD COLUMN {col} {col_type}"
                     )
+
+        if version < 13:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS decisions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    decided_at TEXT,
+                    trigger_type TEXT NOT NULL,
+                    trigger_source TEXT,
+                    context_json TEXT NOT NULL DEFAULT '{}',
+                    options_json TEXT NOT NULL DEFAULT '[]',
+                    chosen_option TEXT,
+                    rationale TEXT,
+                    sections TEXT,
+                    influenced_by TEXT
+                )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_decisions_pending
+                   ON decisions(chosen_option) WHERE chosen_option IS NULL"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_decisions_source
+                   ON decisions(trigger_source) WHERE trigger_source IS NOT NULL"""
+            )
 
         conn.execute(f"PRAGMA user_version = {target}")
 

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 12
+        assert version == 13
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 12
+        assert version == 13
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -1,0 +1,276 @@
+"""Tests for Guided Serendipity decisions repository and migration."""
+
+import pytest
+
+from klemma.state import StateManager
+
+
+@pytest.fixture
+def state(tmp_path):
+    """Create a StateManager with a fresh DB."""
+    db_path = tmp_path / "test.db"
+    return StateManager(db_path)
+
+
+class TestDecisionsMigration:
+    """Verify v13 migration creates the decisions table."""
+
+    def test_decisions_table_exists(self, state):
+        with state._conn() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            assert "decisions" in tables
+
+    def test_db_version_is_13(self, state):
+        with state._conn() as conn:
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == 13
+
+    def test_decisions_columns(self, state):
+        with state._conn() as conn:
+            cols = {
+                row[1] for row in conn.execute("PRAGMA table_info(decisions)")
+            }
+            expected = {
+                "id",
+                "created_at",
+                "decided_at",
+                "trigger_type",
+                "trigger_source",
+                "context_json",
+                "options_json",
+                "chosen_option",
+                "rationale",
+                "sections",
+                "influenced_by",
+            }
+            assert expected == cols
+
+    def test_indexes_created(self, state):
+        with state._conn() as conn:
+            indexes = {
+                row[1]
+                for row in conn.execute(
+                    "SELECT * FROM sqlite_master WHERE type='index' "
+                    "AND tbl_name='decisions'"
+                )
+                if row[1]
+            }
+            assert "idx_decisions_pending" in indexes
+            assert "idx_decisions_source" in indexes
+
+
+class TestDecisionsRepository:
+    """Test CRUD operations on DecisionsRepository."""
+
+    def test_save_and_get_decision(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="goessling2016",
+            context={"key_claims": ["IIEE splits error into 3 components"]},
+            options=[
+                {"key": "A", "title": "Use as one metric"},
+                {"key": "B", "title": "Make displacement central"},
+                {"key": "C", "title": "Propose Arctic modification"},
+            ],
+            sections=["3.2"],
+        )
+        assert decision_id > 0
+
+        d = state.decisions.get_decision(decision_id)
+        assert d is not None
+        assert d["trigger_type"] == "briefing"
+        assert d["trigger_source"] == "goessling2016"
+        assert d["chosen_option"] is None
+        assert len(d["options_json"]) == 3
+        assert d["sections"] == ["3.2"]
+
+    def test_decide(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="test2024",
+            context={},
+            options=[{"key": "A", "title": "Option A"}, {"key": "B", "title": "Option B"}],
+        )
+
+        result = state.decisions.decide(decision_id, "B", "Aligns with my thesis")
+        assert result is True
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["chosen_option"] == "B"
+        assert d["rationale"] == "Aligns with my thesis"
+        assert d["decided_at"] is not None
+
+    def test_decide_already_decided(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="test2024",
+            context={},
+            options=[{"key": "A", "title": "A"}],
+        )
+        state.decisions.decide(decision_id, "A")
+
+        # Second decide should fail (already decided)
+        result = state.decisions.decide(decision_id, "B")
+        assert result is False
+
+        # Original choice preserved
+        d = state.decisions.get_decision(decision_id)
+        assert d["chosen_option"] == "A"
+
+    def test_skip_decision(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[{"key": "A", "title": "Explore"}, {"key": "B", "title": "Ignore"}],
+        )
+
+        result = state.decisions.skip_decision(decision_id)
+        assert result is True
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["chosen_option"] == "__skipped__"
+
+    def test_get_pending_decisions(self, state):
+        # Create 3 decisions: 1 decided, 1 pending, 1 skipped
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        id2 = state.decisions.save_decision(
+            trigger_type="insight", context={}, options=[]
+        )
+        id3 = state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        state.decisions.decide(id1, "A")
+        state.decisions.skip_decision(id3)
+
+        pending = state.decisions.get_pending_decisions()
+        assert len(pending) == 1
+        assert pending[0]["id"] == id2
+
+    def test_get_pending_by_type(self, state):
+        state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        state.decisions.save_decision(
+            trigger_type="insight", context={}, options=[]
+        )
+
+        briefing_pending = state.decisions.get_pending_decisions(
+            trigger_type="briefing"
+        )
+        assert len(briefing_pending) == 1
+
+    def test_get_decisions_filters(self, state):
+        state.decisions.save_decision(
+            trigger_type="briefing",
+            context={},
+            options=[],
+            sections=["3.2"],
+        )
+        state.decisions.save_decision(
+            trigger_type="insight",
+            context={},
+            options=[],
+            sections=["4.1"],
+        )
+
+        by_section = state.decisions.get_decisions(section="3.2")
+        assert len(by_section) == 1
+
+        by_type = state.decisions.get_decisions(trigger_type="insight")
+        assert len(by_type) == 1
+
+    def test_get_trail(self, state):
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="paper1",
+            context={},
+            options=[{"key": "A", "title": "Direction A"}],
+        )
+        id2 = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="paper2",
+            context={},
+            options=[{"key": "B", "title": "Direction B"}],
+            influenced_by=[id1],
+        )
+        id3 = state.decisions.save_decision(
+            trigger_type="insight",
+            context={},
+            options=[{"key": "A", "title": "Explore"}],
+        )
+
+        state.decisions.decide(id1, "A")
+        state.decisions.decide(id2, "B")
+        state.decisions.skip_decision(id3)
+
+        trail = state.decisions.get_trail()
+        assert len(trail) == 2  # skipped excluded
+        assert trail[0]["trigger_source"] == "paper1"
+        assert trail[1]["influenced_by"] == [id1]
+
+    def test_count_decisions(self, state):
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        _id2 = state.decisions.save_decision(  # noqa: F841
+            trigger_type="insight", context={}, options=[]
+        )
+        id3 = state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        state.decisions.decide(id1, "A")
+        state.decisions.skip_decision(id3)
+
+        counts = state.decisions.count_decisions()
+        assert counts["total"] == 3
+        assert counts["decided"] == 1
+        assert counts["pending"] == 1
+        assert counts["skipped"] == 1
+
+    def test_get_decisions_for_context(self, state):
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="paper1",
+            context={},
+            options=[],
+            sections=["3.2", "3.3"],
+        )
+        state.decisions.decide(id1, "A", "Focus on IIEE")
+
+        # Should find by section
+        ctx_decisions = state.decisions.get_decisions_for_context(
+            sections=["3.2"]
+        )
+        assert len(ctx_decisions) == 1
+        assert ctx_decisions[0]["chosen_option"] == "A"
+
+        # Should not find for unrelated section
+        ctx_decisions = state.decisions.get_decisions_for_context(
+            sections=["5.1"]
+        )
+        assert len(ctx_decisions) == 0
+
+    def test_influenced_by_stored(self, state):
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing", context={}, options=[]
+        )
+        id2 = state.decisions.save_decision(
+            trigger_type="briefing",
+            context={},
+            options=[],
+            influenced_by=[id1],
+        )
+
+        d = state.decisions.get_decision(id2)
+        assert d["influenced_by"] == [id1]
+
+    def test_nonexistent_decision(self, state):
+        assert state.decisions.get_decision(999) is None
+        assert state.decisions.decide(999, "A") is False

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 12
+    assert version == 13
     conn.close()
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `decisions` table (migration v13) for storing research branching points
- `DecisionsRepository` with 9 CRUD methods: save, decide, skip, get, pending, list, trail, context injection, counts
- CLI commands: `klemma decisions list/show/trail`, `klemma decide <id> <option>`
- 16 tests covering migration, CRUD, filters, trail, and counts

This is Phase 1 (Branch Store) of the Guided Serendipity epic (#231) — the foundation layer for storing researcher decisions at branching points.

## Release Note

### Problem
Klemma's current pipeline excludes the researcher from the discovery process. After setting up the library and outline, the system produces research reports without involving the researcher in interpreting connections between sources or making directional choices.

### Academic Foundation
The Guided Serendipity methodology is grounded in 23 academic sources across 5 axes: cultivated serendipity (Busch 2024, Merton 2004), Literature-Based Discovery (Swanson 1986), mixed-initiative interaction (Horvitz 1999), explicit research forking paths (Gelman & Loken 2013), and AI-augmented creativity (Boden 2004, Lubart 2005).

### Implementation
- `src/klemma/repositories/decisions.py` — `DecisionsRepository` (170 lines): save/decide/skip/get/pending/list/trail/context/count
- `src/klemma/commands/decisions.py` — CLI commands (200 lines): `decisions list`, `decisions show`, `decisions trail`, `decide`
- `src/klemma/state.py` — migration v13: `decisions` table with `idx_decisions_pending` and `idx_decisions_source` indexes
- `tests/test_decisions.py` — 16 tests

### Results
- 1455 tests pass (16 new + 3 version assertions updated)
- 0 lint errors (ruff)
- Schema: v12 → v13
- New CLI surface: 4 commands (`decisions list`, `decisions show`, `decisions trail`, `decide`)

## Test plan
- [x] Migration creates `decisions` table with correct columns and indexes
- [x] Save/get/decide/skip roundtrips work correctly
- [x] Pending filter excludes decided and skipped
- [x] Trail excludes skipped, returns chronological order
- [x] Section and type filters work on JSON-stored arrays
- [x] `influenced_by` chain stored and retrieved correctly
- [x] Full test suite passes (1455 tests)
- [x] Lint clean (ruff)

Part of #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `decisions` storage and migration

- Implement decision repository CRUD and queries

- Add CLI for listing and choosing

- Cover migration, trail, and counts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  M["Migration v13 adds `decisions` table"]
  S["`StateManager` exposes `state.decisions`"]
  R["`DecisionsRepository` manages decision lifecycle"]
  C["CLI commands list, show, trail, decide"]
  T["Tests validate schema and behavior"]

  M -- "creates storage" --> S
  S -- "instantiates" --> R
  R -- "powers" --> C
  M -- "verified by" --> T
  R -- "covered by" --> T
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Register decisions commands in CLI imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-d789a4ff067ce4dc7198a308adc90195055398685bf19a92c71544bb792b0112">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>decisions.py</strong><dd><code>Add CLI for decision browsing and choice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-43ee523a3f829e6eb2f1d3a04ee415903b3cbb8fdd867f318d49d606e87d73b9">+222/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export decisions repository from package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-91b1f2e43681ba00c35fb26a5c74b27b768e2cc439035f3b861a5a2c45660357">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>decisions.py</strong><dd><code>Implement decisions persistence, filters, and trail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-a52a5abab14a063416dbcfbf73075ece94b89b844653eef8c4f91bc7bfd603ac">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>state.py</strong><dd><code>Add decisions repository and schema migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-cfc87038a29732ba5c6b2a84586a214ce4adfe95a3b24972462e570ed2cc09f5">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_benchmark_history.py</strong><dd><code>Update expected schema version to v13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-a8b7c386d41234272d9cc7092a57250ad946040739d1951d0c58eec56dab5450">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_citation_graph.py</strong><dd><code>Update migration version assertion to v13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-d9554cc614f2e6c0918e9657ed0a97d9b387e5388fd8b5e5db9112cd1e60a73b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_decisions.py</strong><dd><code>Add migration and decisions repository coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-753bbe136fe319544d229110e9926de251bdde0873b2479844d9ac500f047d9d">+276/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_source_role.py</strong><dd><code>Update source role migration version check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/232/files#diff-c02e113756d9f7d5e3a3be7de94f5baa94d36267fbb496a3abfe3a3d8d05a261">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

