### PR TITLE
feat: Briefing skill + CLI for Guided Serendipity (#231)

### DIFF
--- a/prompts/briefing.md
+++ b/prompts/briefing.md
@@ -1,0 +1,101 @@
+You are a research advisor analyzing a newly added source in the context of the researcher's library and dissertation. Your goal is to identify key claims, unexpected connections, and propose 2-3 branching directions for the researcher to choose from.
+
+Respond entirely in {{ language }}.
+
+## Project Context
+
+{{ dissertation_context }}
+
+{% if outline_summary %}
+## Dissertation Structure
+
+{{ outline_summary }}
+{% endif %}
+
+## New Source
+
+**{{ source_citekey }}**: {{ source_title }}
+{% if source_authors %}Authors: {{ source_authors }}{% endif %}
+{% if source_year %}Year: {{ source_year }}{% endif %}
+
+{% if abstract %}
+### Abstract
+{{ abstract }}
+{% endif %}
+
+### Extracted Fragments ({{ fragments | length }} total)
+
+{% for f in fragments[:15] %}
+- [{{ f.citation_intent or 'general' }}] {{ f.fragment_text[:300] }}
+{% endfor %}
+
+## Related Sources in Library (by embedding similarity)
+
+{% for s in similar_sources %}
+{{ loop.index }}. **@{{ s.citekey }}** ({{ s.year or '?' }}) — {{ s.title }}
+   Similarity: {{ "%.2f" | format(s.similarity) }}
+   {% if s.fragments %}Fragments: {% for f in s.fragments[:3] %}{{ f[:150] }}; {% endfor %}{% endif %}
+{% endfor %}
+
+{% if previous_decisions %}
+## Previous Research Decisions
+
+The researcher has already made these choices:
+{% for d in previous_decisions %}
+- [{{ d.created_at[:10] }}] {{ d.trigger_type }}: chose "{{ d.chosen_option }}" {% if d.rationale %}({{ d.rationale }}){% endif %}
+{% endfor %}
+{% endif %}
+
+## Your Task
+
+Analyze this new source in context and produce a JSON response:
+
+```json
+{
+  "key_claims": [
+    "Claim 1 from the new source",
+    "Claim 2 from the new source",
+    "Claim 3 from the new source"
+  ],
+  "connections": [
+    {
+      "related_citekey": "@citekey",
+      "relationship": "supports|contradicts|extends|complements|overlaps",
+      "description": "How the new source relates to this existing source"
+    }
+  ],
+  "niches": [
+    "Gap or niche this source reveals in the library"
+  ],
+  "forks": [
+    {
+      "key": "A",
+      "title": "Short title for direction A",
+      "description": "What this direction means for the research. 1-2 sentences.",
+      "sections": ["3.2"]
+    },
+    {
+      "key": "B",
+      "title": "Short title for direction B",
+      "description": "What this direction means for the research. 1-2 sentences.",
+      "sections": ["3.2", "4.1"]
+    },
+    {
+      "key": "C",
+      "title": "Short title for direction C",
+      "description": "What this direction means for the research. 1-2 sentences.",
+      "sections": ["3.2"]
+    }
+  ],
+  "recommended_sections": ["3.2", "4.1"]
+}
+```
+
+Rules:
+- `key_claims`: 3-5 main contributions or findings of the new source
+- `connections`: link to specific sources already in the library (use their citekeys). Include relationship type.
+- `niches`: gaps or opportunities this source reveals. What's missing in the library?
+- `forks`: 2-3 mutually exclusive directions the researcher could take. Each fork should represent a meaningfully different way to use this source in the dissertation. Include relevant section IDs.
+- `recommended_sections`: which dissertation sections this source is most relevant to
+
+Respond ONLY with the JSON block. No commentary before or after.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/klemma"]
+exclude = ["src/klemma/api"]
 
 [tool.ruff]
 line-length = 100

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -190,18 +190,20 @@ def decide(ctx, decision_id, option, reason):
 
 @main.command()
 @click.argument("citekey", required=False)
-@click.option("--pending", is_flag=True, help="Process all sources without briefings")
+@click.option("--pending", is_flag=True, help="Process sources without briefings (most relevant first)")
+@click.option("--limit", "-n", default=10, help="Max sources to brief in --pending mode")
 @click.option("--model", default=None, help="Override AI model")
 @click.pass_context
-def briefing(ctx, citekey, pending, model):
+def briefing(ctx, citekey, pending, limit, model):
     """Generate a Guided Serendipity briefing for a source.
 
     Analyzes a newly added source, finds connections in your library,
     and proposes 2-3 research directions (forks) for you to choose from.
 
     Usage:
-      klemma briefing <citekey>     — briefing for specific source
-      klemma briefing --pending     — process sources without briefings
+      klemma briefing <citekey>        — briefing for specific source
+      klemma briefing --pending        — top 10 most relevant unbriefed sources
+      klemma briefing --pending -n 5   — top 5
     """
     from ..skills.briefer import generate_briefing, save_briefing_as_decision
 
@@ -228,15 +230,29 @@ def briefing(ctx, citekey, pending, model):
             for d in state.decisions.get_decisions(trigger_type="briefing", limit=9999)
             if d.get("trigger_source")
         }
-        targets = [
-            s["id"] for s in all_sources
+        unbriefed = [
+            s for s in all_sources
             if s["id"] not in existing_briefings
             and s.get("fragment_count", 0) > 0
         ]
-        if not targets:
+        if not unbriefed:
             console.print("[dim]No sources pending briefing.[/dim]")
             return
-        console.print(f"[blue]{len(targets)} source(s) pending briefing[/blue]\n")
+
+        # Sort by relevance: quality_score desc, fragment_count desc, year desc
+        unbriefed.sort(
+            key=lambda s: (
+                s.get("quality_score") or 0,
+                s.get("fragment_count") or 0,
+                s.get("year") or 0,
+            ),
+            reverse=True,
+        )
+        targets = [s["id"] for s in unbriefed[:limit]]
+        console.print(
+            f"[blue]{len(unbriefed)} source(s) pending briefing, "
+            f"processing top {len(targets)}[/blue]\n"
+        )
     else:
         targets = [citekey]
 

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -1,10 +1,12 @@
 """Guided Serendipity: decisions and briefing commands."""
 
+import sys
+
 import click
 from rich.panel import Panel
 from rich.table import Table
 
-from ..cli import _get_context, console, main
+from ..cli import _get_context, _init_ai, console, main
 
 
 @main.group(invoke_without_command=True)
@@ -184,6 +186,162 @@ def decide(ctx, decision_id, option, reason):
             console.print(f"  Rationale: {reason}")
     else:
         console.print(f"[red]Failed to update decision #{decision_id}[/red]")
+
+
+@main.command()
+@click.argument("citekey", required=False)
+@click.option("--pending", is_flag=True, help="Process all sources without briefings")
+@click.option("--model", default=None, help="Override AI model")
+@click.pass_context
+def briefing(ctx, citekey, pending, model):
+    """Generate a Guided Serendipity briefing for a source.
+
+    Analyzes a newly added source, finds connections in your library,
+    and proposes 2-3 research directions (forks) for you to choose from.
+
+    Usage:
+      klemma briefing <citekey>     — briefing for specific source
+      klemma briefing --pending     — process sources without briefings
+    """
+    from ..skills.briefer import generate_briefing, save_briefing_as_decision
+
+    kctx = _get_context(ctx)
+    cfg, state = kctx.config, kctx.state
+
+    if not citekey and not pending:
+        console.print("[red]Provide a citekey or use --pending[/red]")
+        return
+
+    if model:
+        cfg.ai.model = model
+    ai = _init_ai(cfg)
+    if not ai:
+        console.print("[red]AI backend required for briefing. Configure in klemmarc.[/red]")
+        return
+
+    # Determine which sources to brief
+    if pending:
+        # Find sources that have fragments but no briefing decision
+        all_sources = state.sources.get_all_sources()
+        existing_briefings = {
+            d["trigger_source"]
+            for d in state.decisions.get_decisions(trigger_type="briefing", limit=9999)
+            if d.get("trigger_source")
+        }
+        targets = [
+            s["id"] for s in all_sources
+            if s["id"] not in existing_briefings
+            and s.get("fragment_count", 0) > 0
+        ]
+        if not targets:
+            console.print("[dim]No sources pending briefing.[/dim]")
+            return
+        console.print(f"[blue]{len(targets)} source(s) pending briefing[/blue]\n")
+    else:
+        targets = [citekey]
+
+    for target_citekey in targets:
+        console.print(f"\n[bold]Briefing: @{target_citekey}[/bold]")
+        console.print("[dim]Analyzing source, finding connections...[/dim]")
+
+        result = generate_briefing(
+            source_citekey=target_citekey,
+            config=cfg,
+            state=state,
+            ai=ai,
+            dissertation_context=kctx.dissertation_context,
+            embeddings=kctx.embeddings,
+            klemma_home=kctx.klemma_home,
+            project_root=kctx.project_root,
+            language=getattr(cfg.dissertation, "language", "Russian") if cfg.dissertation else "Russian",
+        )
+
+        if result.error:
+            console.print(f"[red]Error: {result.error}[/red]")
+            continue
+
+        # Display briefing
+        _display_briefing(result)
+
+        # Save as decision
+        decision_id = save_briefing_as_decision(result, state)
+        if decision_id is None:
+            console.print("[yellow]No forks generated — skipping decision.[/yellow]")
+            continue
+
+        # Interactive choice if TTY
+        if sys.stdin.isatty() and len(targets) <= 3:
+            _interactive_decide(state, decision_id, result)
+        else:
+            console.print(
+                f"\n[yellow]Decision #{decision_id} saved as pending.[/yellow]"
+                f"\nDecide later: klemma decide {decision_id} A|B|C"
+            )
+
+
+def _display_briefing(result):
+    """Display briefing results in the terminal."""
+    # Key claims
+    if result.key_claims:
+        console.print("\n[bold]Key claims:[/bold]")
+        for claim in result.key_claims:
+            console.print(f"  • {claim}")
+
+    # Connections
+    if result.connections:
+        console.print("\n[bold]Connections:[/bold]")
+        for conn in result.connections:
+            rel = conn.get("relationship", "related")
+            ckey = conn.get("related_citekey", "?")
+            desc = conn.get("description", "")
+            console.print(f"  {rel}: {ckey} — {desc}")
+
+    # Niches
+    if result.niches:
+        console.print("\n[bold]Niches/gaps:[/bold]")
+        for niche in result.niches:
+            console.print(f"  → {niche}")
+
+    # Forks
+    if result.forks:
+        console.print("\n[bold]── Fork ──[/bold]")
+        for fork in result.forks:
+            key = fork.get("key", "?")
+            title = fork.get("title", "")
+            desc = fork.get("description", "")
+            sections = fork.get("sections", [])
+            sec_str = f" (sections: {', '.join(sections)})" if sections else ""
+            console.print(f"  [{key}] [bold]{title}[/bold]{sec_str}")
+            if desc:
+                console.print(f"      {desc}")
+
+
+def _interactive_decide(state, decision_id, result):
+    """Prompt the user to choose a fork interactively."""
+    valid_keys = [f.get("key", "?") for f in result.forks]
+    keys_str = "/".join(valid_keys)
+
+    console.print(f"\n[yellow]Choose direction [{keys_str}/skip]:[/yellow] ", end="")
+    try:
+        choice = input().strip().upper()
+    except (EOFError, KeyboardInterrupt):
+        console.print("\n[dim]Skipped[/dim]")
+        return
+
+    if choice in ("SKIP", "S", ""):
+        state.decisions.skip_decision(decision_id)
+        console.print("[dim]Skipped — you can revisit later with 'klemma decisions --pending'[/dim]")
+    elif choice in valid_keys:
+        # Ask for rationale
+        console.print("[dim]Why? (optional, press Enter to skip):[/dim] ", end="")
+        try:
+            reason = input().strip() or None
+        except (EOFError, KeyboardInterrupt):
+            reason = None
+        state.decisions.decide(decision_id, choice, reason)
+        console.print(f"[green]✓ Decision #{decision_id} → {choice}[/green]")
+    else:
+        console.print(f"[red]Invalid choice. Saved as pending (decide later: klemma decide {decision_id} {keys_str})[/red]")
 
 
 @decisions.command("trail")

--- a/src/klemma/skills/briefer.py
+++ b/src/klemma/skills/briefer.py
@@ -1,0 +1,240 @@
+"""Guided Serendipity briefing skill — analyzes new sources and generates branching points."""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from ..ai import AIProvider
+from ..config import KlemmaConfig, resolve_prompt
+from ..embeddings import EmbeddingProvider, cosine_similarity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SimilarSource:
+    """A source similar to the new one, found via embedding search."""
+
+    citekey: str
+    title: str
+    year: Optional[int] = None
+    similarity: float = 0.0
+    fragments: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BriefingResult:
+    """Result of a briefing analysis for a new source."""
+
+    source_citekey: str
+    key_claims: list[str] = field(default_factory=list)
+    connections: list[dict] = field(default_factory=list)
+    niches: list[str] = field(default_factory=list)
+    forks: list[dict] = field(default_factory=list)
+    recommended_sections: list[str] = field(default_factory=list)
+    similar_sources: list[SimilarSource] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def find_similar_sources(
+    source_citekey: str,
+    state,
+    embeddings: Optional[EmbeddingProvider] = None,
+    top_k: int = 7,
+) -> list[SimilarSource]:
+    """Find sources most similar to the given one via embedding cosine similarity."""
+    if not embeddings:
+        return []
+
+    target_embedding = state.get_embedding(source_citekey)
+    if not target_embedding:
+        return []
+
+    all_embeddings = state.get_all_embeddings()
+    if not all_embeddings:
+        return []
+
+    scored = []
+    for citekey, vec in all_embeddings.items():
+        if citekey == source_citekey:
+            continue
+        sim = cosine_similarity(target_embedding, vec)
+        if sim > 0.3:
+            scored.append((citekey, sim))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    results = []
+    for citekey, sim in scored[:top_k]:
+        source = state.get_source(citekey)
+        title = source.get("title", "") if source else ""
+        year = source.get("year") if source else None
+
+        # Get a few fragment texts for context
+        frags = state.get_fragments(citekey) if hasattr(state, "get_fragments") else []
+        frag_texts = [
+            f.get("fragment_text", "")[:200]
+            for f in (frags[:3] if isinstance(frags, list) else [])
+        ]
+
+        results.append(SimilarSource(
+            citekey=citekey,
+            title=title,
+            year=year,
+            similarity=sim,
+            fragments=frag_texts,
+        ))
+
+    return results
+
+
+def generate_briefing(
+    source_citekey: str,
+    config: KlemmaConfig,
+    state,
+    ai: AIProvider,
+    dissertation_context: str = "",
+    embeddings: Optional[EmbeddingProvider] = None,
+    klemma_home: Optional[Path] = None,
+    project_root: Optional[Path] = None,
+    language: str = "Russian",
+) -> BriefingResult:
+    """Generate a Guided Serendipity briefing for a newly acquired source.
+
+    The briefing extracts key claims, finds connections to the existing library,
+    identifies niches, and proposes 2-3 branching directions (forks).
+    """
+    source = state.get_source(source_citekey)
+    if not source:
+        return BriefingResult(
+            source_citekey=source_citekey,
+            error=f"Source @{source_citekey} not found in database",
+        )
+
+    # Gather source metadata
+    title = source.get("title", source_citekey)
+    authors = source.get("authors", "")
+    year = source.get("year")
+    abstract = source.get("abstract", "")
+
+    # Get fragments
+    fragments_raw = state.fragments.get_fragments(source_citekey)
+    fragments = [dict(f) for f in fragments_raw] if fragments_raw else []
+
+    if not fragments and not abstract:
+        return BriefingResult(
+            source_citekey=source_citekey,
+            error=f"No fragments or abstract for @{source_citekey}. Run 'klemma process' first.",
+        )
+
+    # Find similar sources
+    similar = find_similar_sources(source_citekey, state, embeddings, top_k=7)
+
+    # Load previous decisions for context
+    previous_decisions = []
+    if hasattr(state, "decisions"):
+        previous_decisions = state.decisions.get_decisions_for_context()
+
+    # Load outline summary
+    outline_summary = ""
+    if project_root:
+        from .context_loader import load_outline_context
+        outline_ctx = load_outline_context(None, project_root)
+        if outline_ctx.get("description"):
+            outline_summary = outline_ctx["description"]
+        if outline_ctx.get("current_chapter_desc"):
+            outline_summary += "\n" + outline_ctx["current_chapter_desc"]
+
+    # Render prompt
+    prompt_path = (
+        resolve_prompt("briefing.md", klemma_home)
+        if klemma_home
+        else Path(__file__).parent.parent.parent.parent / "prompts" / "briefing.md"
+    )
+    prompt = ai.render_prompt(
+        str(prompt_path),
+        language=language,
+        dissertation_context=dissertation_context,
+        outline_summary=outline_summary,
+        source_citekey=source_citekey,
+        source_title=title,
+        source_authors=authors,
+        source_year=year,
+        abstract=abstract,
+        fragments=fragments,
+        similar_sources=similar,
+        previous_decisions=previous_decisions,
+    )
+
+    # Call LLM
+    result = ai.call_json(prompt)
+    if not result:
+        return BriefingResult(
+            source_citekey=source_citekey,
+            similar_sources=similar,
+            error="LLM call returned no result",
+        )
+
+    return BriefingResult(
+        source_citekey=source_citekey,
+        key_claims=result.get("key_claims", []),
+        connections=result.get("connections", []),
+        niches=result.get("niches", []),
+        forks=result.get("forks", []),
+        recommended_sections=result.get("recommended_sections", []),
+        similar_sources=similar,
+    )
+
+
+def save_briefing_as_decision(
+    briefing: BriefingResult,
+    state,
+) -> Optional[int]:
+    """Save a briefing result as a pending decision in the Branch Store.
+
+    Returns the decision ID, or None if briefing has no forks.
+    """
+    if not briefing.forks or briefing.error:
+        return None
+
+    context = {
+        "key_claims": briefing.key_claims,
+        "connections": briefing.connections,
+        "niches": briefing.niches,
+        "similar_sources": [
+            {"citekey": s.citekey, "title": s.title, "similarity": s.similarity}
+            for s in briefing.similar_sources[:5]
+        ],
+    }
+
+    options = [
+        {
+            "key": fork.get("key", chr(65 + i)),
+            "title": fork.get("title", f"Option {chr(65 + i)}"),
+            "description": fork.get("description", ""),
+        }
+        for i, fork in enumerate(briefing.forks)
+    ]
+
+    sections = briefing.recommended_sections or []
+    # Also collect sections from forks
+    for fork in briefing.forks:
+        for s in fork.get("sections", []):
+            if s not in sections:
+                sections.append(s)
+
+    # Find previous decisions to link influenced_by
+    influenced_by = None
+    if hasattr(state, "decisions"):
+        trail = state.decisions.get_trail()
+        if trail:
+            influenced_by = [trail[-1]["id"]]
+
+    return state.decisions.save_decision(
+        trigger_type="briefing",
+        trigger_source=briefing.source_citekey,
+        context=context,
+        options=options,
+        sections=sections if sections else None,
+        influenced_by=influenced_by,
+    )

--- a/src/klemma/skills/briefer.py
+++ b/src/klemma/skills/briefer.py
@@ -152,7 +152,7 @@ def generate_briefing(
         else Path(__file__).parent.parent.parent.parent / "prompts" / "briefing.md"
     )
     prompt = ai.render_prompt(
-        str(prompt_path),
+        prompt_path,
         language=language,
         dissertation_context=dissertation_context,
         outline_summary=outline_summary,

--- a/src/klemma/skills/briefer.py
+++ b/src/klemma/skills/briefer.py
@@ -167,7 +167,12 @@ def generate_briefing(
     )
 
     # Call LLM
-    result = ai.call_json(prompt)
+    user_prompt = (
+        f"Analyze the source @{source_citekey} and generate a briefing "
+        f"with key claims, connections, niches, and 2-3 fork options. "
+        f"Respond with JSON only."
+    )
+    result = ai.call_json(prompt, user_prompt, max_tokens=4096)
     if not result:
         return BriefingResult(
             source_citekey=source_citekey,

--- a/tests/test_briefer.py
+++ b/tests/test_briefer.py
@@ -1,0 +1,206 @@
+"""Tests for Guided Serendipity briefer skill."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from klemma.skills.briefer import (
+    BriefingResult,
+    SimilarSource,
+    find_similar_sources,
+    generate_briefing,
+    save_briefing_as_decision,
+)
+from klemma.state import StateManager
+
+
+@pytest.fixture
+def state(tmp_path):
+    db_path = tmp_path / "test.db"
+    sm = StateManager(db_path)
+    # Register a source with fragments
+    sm.register_sources(["goessling2016"])
+    sm.update_source_info(
+        "goessling2016",
+        title="Evaluating sea ice forecasts with IIEE",
+        authors="Goessling H.F.",
+        year=2016,
+        abstract="IIEE separates forecast error into miss, false alarm, and displacement components.",
+    )
+    sm.mark_completed("goessling2016", note_path="@goessling2016.md")
+    sm.fragments.save_fragments("goessling2016", [
+        {
+            "fragment_text": "IIEE decomposes errors into three components",
+            "fragment_type": "quote",
+            "chapter": 3,
+            "section": "3.2",
+            "relevance_score": 0.9,
+            "citation_intent": "method",
+        },
+        {
+            "fragment_text": "40% of forecast error is displacement",
+            "fragment_type": "paraphrase",
+            "chapter": 3,
+            "section": "3.2",
+            "relevance_score": 0.85,
+            "citation_intent": "result_comparison",
+        },
+    ])
+    return sm
+
+
+class TestFindSimilarSources:
+    def test_no_embeddings_returns_empty(self, state):
+        result = find_similar_sources("goessling2016", state, embeddings=None)
+        assert result == []
+
+    def test_no_target_embedding_returns_empty(self, state):
+        embeddings = MagicMock()
+        result = find_similar_sources("goessling2016", state, embeddings=embeddings)
+        assert result == []
+
+
+class TestGenerateBriefing:
+    def test_source_not_found(self, state):
+        ai = MagicMock()
+        cfg = MagicMock()
+        result = generate_briefing("nonexistent", cfg, state, ai)
+        assert result.error is not None
+        assert "not found" in result.error
+
+    def test_no_fragments_no_abstract(self, state):
+        state.register_sources(["empty2024"])
+        state.mark_completed("empty2024", note_path="@empty2024.md")
+        ai = MagicMock()
+        cfg = MagicMock()
+        result = generate_briefing("empty2024", cfg, state, ai)
+        assert result.error is not None
+        assert "No fragments" in result.error
+
+    def test_successful_briefing(self, state):
+        ai = MagicMock()
+        ai.render_prompt.return_value = "rendered prompt"
+        ai.call_json.return_value = {
+            "key_claims": ["IIEE splits error into 3 components"],
+            "connections": [
+                {"related_citekey": "@author2020", "relationship": "extends", "description": "Extends binary metrics"}
+            ],
+            "niches": ["No displacement error analysis for Arctic"],
+            "forks": [
+                {"key": "A", "title": "Use IIEE as one metric", "description": "Include in comparison table", "sections": ["3.2"]},
+                {"key": "B", "title": "Focus on displacement", "description": "Make displacement central", "sections": ["3.2", "4.1"]},
+            ],
+            "recommended_sections": ["3.2"],
+        }
+        cfg = MagicMock()
+        cfg.dissertation = MagicMock()
+        cfg.dissertation.language = "Russian"
+
+        result = generate_briefing(
+            "goessling2016", cfg, state, ai,
+            dissertation_context="Sea ice forecast verification",
+        )
+
+        assert result.error is None
+        assert len(result.key_claims) == 1
+        assert len(result.forks) == 2
+        assert result.forks[0]["key"] == "A"
+        assert result.recommended_sections == ["3.2"]
+        ai.call_json.assert_called_once()
+
+    def test_llm_returns_none(self, state):
+        ai = MagicMock()
+        ai.render_prompt.return_value = "prompt"
+        ai.call_json.return_value = None
+        cfg = MagicMock()
+        cfg.dissertation = MagicMock()
+        cfg.dissertation.language = "Russian"
+
+        result = generate_briefing("goessling2016", cfg, state, ai)
+        assert result.error is not None
+        assert "no result" in result.error
+
+
+class TestSaveBriefingAsDecision:
+    def test_save_successful(self, state):
+        briefing = BriefingResult(
+            source_citekey="goessling2016",
+            key_claims=["Claim 1"],
+            connections=[{"related_citekey": "@x", "relationship": "extends", "description": "test"}],
+            niches=["Niche 1"],
+            forks=[
+                {"key": "A", "title": "Direction A", "description": "Desc A", "sections": ["3.2"]},
+                {"key": "B", "title": "Direction B", "description": "Desc B", "sections": ["4.1"]},
+            ],
+            recommended_sections=["3.2"],
+            similar_sources=[SimilarSource(citekey="other2020", title="Other", similarity=0.85)],
+        )
+
+        decision_id = save_briefing_as_decision(briefing, state)
+        assert decision_id is not None
+        assert decision_id > 0
+
+        # Verify stored decision
+        d = state.decisions.get_decision(decision_id)
+        assert d["trigger_type"] == "briefing"
+        assert d["trigger_source"] == "goessling2016"
+        assert d["chosen_option"] is None  # pending
+        assert len(d["options_json"]) == 2
+        assert d["options_json"][0]["key"] == "A"
+        assert "3.2" in d["sections"]
+        assert "4.1" in d["sections"]
+
+    def test_no_forks_returns_none(self, state):
+        briefing = BriefingResult(
+            source_citekey="goessling2016",
+            key_claims=["Claim"],
+            forks=[],
+        )
+        assert save_briefing_as_decision(briefing, state) is None
+
+    def test_error_returns_none(self, state):
+        briefing = BriefingResult(
+            source_citekey="goessling2016",
+            error="Something failed",
+            forks=[{"key": "A", "title": "X", "description": "Y"}],
+        )
+        assert save_briefing_as_decision(briefing, state) is None
+
+    def test_influenced_by_links_to_previous(self, state):
+        # Create a previous decision
+        prev_id = state.decisions.save_decision(
+            trigger_type="briefing",
+            trigger_source="prev2020",
+            context={},
+            options=[{"key": "A", "title": "X"}],
+        )
+        state.decisions.decide(prev_id, "A")
+
+        briefing = BriefingResult(
+            source_citekey="goessling2016",
+            forks=[
+                {"key": "A", "title": "Dir A", "description": "Desc"},
+                {"key": "B", "title": "Dir B", "description": "Desc"},
+            ],
+        )
+
+        decision_id = save_briefing_as_decision(briefing, state)
+        d = state.decisions.get_decision(decision_id)
+        assert d["influenced_by"] == [prev_id]
+
+    def test_context_includes_similar_sources(self, state):
+        briefing = BriefingResult(
+            source_citekey="goessling2016",
+            key_claims=["C1"],
+            similar_sources=[
+                SimilarSource(citekey="a2020", title="A", similarity=0.9),
+                SimilarSource(citekey="b2021", title="B", similarity=0.8),
+            ],
+            forks=[{"key": "A", "title": "X", "description": "Y"}],
+        )
+
+        decision_id = save_briefing_as_decision(briefing, state)
+        d = state.decisions.get_decision(decision_id)
+        ctx = d["context_json"]
+        assert len(ctx["similar_sources"]) == 2
+        assert ctx["similar_sources"][0]["citekey"] == "a2020"

--- a/tests/test_briefer.py
+++ b/tests/test_briefer.py
@@ -106,7 +106,7 @@ class TestGenerateBriefing:
         assert len(result.forks) == 2
         assert result.forks[0]["key"] == "A"
         assert result.recommended_sections == ["3.2"]
-        ai.call_json.assert_called_once()
+        assert ai.call_json.call_count == 1
 
     def test_llm_returns_none(self, state):
         ai = MagicMock()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -202,6 +202,21 @@ TEMPLATE_CONTEXTS = {
         "source_summaries": [],
         "language": "ru",
     },
+    "briefing.md": {
+        "language": "Russian",
+        "dissertation_context": "Test context",
+        "outline_summary": "",
+        "source_citekey": "goessling2016",
+        "source_title": "Evaluating sea ice forecasts with IIEE",
+        "source_authors": "Goessling H.F.",
+        "source_year": 2016,
+        "abstract": "IIEE separates errors into components.",
+        "fragments": [
+            {"citation_intent": "method", "fragment_text": "IIEE decomposes errors"},
+        ],
+        "similar_sources": [],
+        "previous_decisions": [],
+    },
     "reconstruct.md": {
         "paper_title": "Test Paper",
         "abstract": "An abstract",


### PR DESCRIPTION
### **User description**
## Summary
- Briefing prompt template (`briefing.md`) — single LLM call: key claims + library connections + niches + 2-3 research forks
- `briefer.py` skill — orchestrates: source metadata → embedding search → LLM → `BriefingResult`
- `klemma briefing <citekey>` CLI — with `--pending` mode for batch and interactive TTY fork selection
- `save_briefing_as_decision()` — connects briefings to Branch Store with `influenced_by` chain
- `pyproject.toml` exclude `api/` from pip wheel (researchers get clean CLI-only package)
- 11 new tests for briefer skill + prompt template context

## Release Note

### Problem
After acquiring a new source, klemma immediately moves to fragment extraction without helping the researcher understand how the source relates to their existing library. The researcher discovers connections only during writing — too late to inform their research direction.

### Academic Foundation
Guided Serendipity (Busch 2024, Swanson 1986, Horvitz 1999) — cultivating unexpected discoveries through explicit branching points. The briefing mechanism implements the "Briefing" primitive: triggered after acquire, surfaces claims, connections, niches, and forks.

### Implementation
- `prompts/briefing.md` — Jinja2 template: project context + source fragments + similar sources + previous decisions → structured JSON (claims, connections, niches, forks)
- `src/klemma/skills/briefer.py` (195 lines) — `generate_briefing()` orchestration + `find_similar_sources()` embedding search + `save_briefing_as_decision()` Branch Store integration
- `src/klemma/commands/decisions.py` — `klemma briefing` command with `--pending`, `--model`, interactive TTY prompt
- `pyproject.toml` — `exclude = ["src/klemma/api"]` (pip wheel cleanup)

### Results
- 1467 tests pass (11 new briefer + 1 prompt context)
- 0 lint errors (ruff)
- New CLI: `klemma briefing <citekey>`, `klemma briefing --pending`
- Interactive fork selection with optional rationale capture

## Test plan
- [x] `generate_briefing` with mocked AI returns structured BriefingResult
- [x] Missing source returns error
- [x] No fragments/abstract returns error
- [x] LLM returning None handled gracefully
- [x] `save_briefing_as_decision` creates pending decision with correct fields
- [x] No forks → returns None (no decision created)
- [x] Error in briefing → returns None
- [x] `influenced_by` links to most recent trail decision
- [x] Context includes similar sources metadata
- [x] Prompt template renders without Jinja2 errors
- [x] Full test suite passes (1467 tests)

Part of #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add briefing generation pipeline

- Add interactive `klemma briefing` command

- Save forks into decision trail

- Add prompt, tests, wheel cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["`klemma briefing` command"]
  skill["Briefing generation skill"]
  embed["Embedding similarity search"]
  prompt["`briefing.md` prompt template"]
  llm["LLM JSON analysis"]
  store["Pending Branch Store decision"]
  cli -- "invokes" --> skill
  skill -- "searches library" --> embed
  skill -- "renders" --> prompt
  prompt -- "structures output" --> llm
  llm -- "returns claims and forks" --> skill
  skill -- "persists result" --> store
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>decisions.py</strong><dd><code>Add briefing command and terminal interaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/klemma/commands/decisions.py

<ul><li>Add top-level <code>klemma briefing</code> CLI command<br> <li> Support single-source and <code>--pending</code> workflows<br> <li> Initialize AI backend with optional model override<br> <li> Render briefing output and interactive fork selection</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-43ee523a3f829e6eb2f1d3a04ee415903b3cbb8fdd867f318d49d606e87d73b9">+159/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>briefer.py</strong><dd><code>Implement briefing orchestration and decision persistence</code></dd></summary>
<hr>

src/klemma/skills/briefer.py

<ul><li>Introduce <code>BriefingResult</code> and <code>SimilarSource</code> data models<br> <li> Add embedding-based similar source lookup<br> <li> Generate briefing prompts from source, outline, and decisions<br> <li> Save generated forks as pending Branch Store decisions</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-11d1b24ccb0809f6ae711b7c3267ec5574b4edda88620d840303b8dda95756fc">+240/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>briefing.md</strong><dd><code>Add structured briefing prompt template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prompts/briefing.md

<ul><li>Add briefing prompt for Guided Serendipity analysis<br> <li> Include dissertation context, outline, fragments, and library matches<br> <li> Define strict JSON schema for claims, connections, niches, and forks</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-aa9e52fb16d7eb0692ca14ea5bb82d4c5e00aa3ce0c28b06e4b95f83d9102eb2">+101/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_briefer.py</strong><dd><code>Cover briefer generation and persistence behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_briefer.py

<ul><li>Add coverage for similar-source lookup edge cases<br> <li> Test briefing generation success and failure paths<br> <li> Verify decision persistence, context, and <code>influenced_by</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-dba0b5933b995c4bb83af5331d134e592289a30329c6b294c2748d55c9685508">+206/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_prompts.py</strong><dd><code>Add briefing prompt test context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_prompts.py

<ul><li>Register required render context for <code>briefing.md</code><br> <li> Validate prompt template inputs in prompt tests</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-93eab87f4134131c2b98b2e6c8a90dcf85f6b025f03a0c81069141a640393d02">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Exclude API package from wheel build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Exclude <code>src/klemma/api</code> from wheel builds<br> <li> Keep packaged install focused on CLI components</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/233/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

