### PR TITLE
feat: redesign klemma insights — 3-stage curated pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,45 @@ klemma ask "Какие методы валидации прогнозов лед
 # 8. Структура проекта
 klemma outline                                 # AI-генерация outline
 klemma outline -p "Фокус на методологии"       # с директивой
+
+# 9. Guided Serendipity — исследовательские развилки
+klemma briefing goessling2016                  # анализ нового источника → развилки
+klemma insights                                # слепые пятна + скрытые кластеры
+klemma decisions trail                         # тропинка принятых решений
+```
+
+## Guided Serendipity
+
+Методология AI-ассистированного исследования: система обнаруживает неожиданные связи в библиотеке и предлагает развилки, на которых исследователь принимает осознанные решения. Накопление решений формирует уникальную исследовательскую тропинку (Research Trail).
+
+### `klemma briefing <citekey>`
+Анализ нового источника: ключевые тезисы, связи с библиотекой, ниши, 2-3 развилки.
+
+```bash
+klemma briefing goessling2016              # briefing для одного источника
+klemma briefing --pending                  # top-10 необработанных (по релевантности)
+klemma briefing --pending -n 5             # top-5
+```
+
+### `klemma insights`
+Анализ библиотеки без AI — чистый SQL + embeddings:
+
+- **Слепые пятна** — разделы с количеством источников <50% от среднего
+- **Скрытые кластеры** — семантически похожие источники из разных разделов
+
+```bash
+klemma insights                            # таблица + сохранение как decisions
+```
+
+### `klemma decisions`
+Просмотр и управление исследовательскими решениями:
+
+```bash
+klemma decisions                           # список всех решений
+klemma decisions --pending                 # только ожидающие ответа
+klemma decisions show 5                    # детали решения #5
+klemma decisions trail                     # хронологическая тропинка
+klemma decide 5 B --reason "Ближе к IIEE" # выбрать вариант B
 ```
 
 ## GitHub PR Auto-Checking (Codex)
@@ -89,7 +128,7 @@ klemma outline -p "Фокус на методологии"       # с дирек
 
 Логика: при падении workflow `CI` Codex пытается сделать минимальный фикс, повторно запускает `ruff` и `pytest`, и открывает PR с исправлением.
 
-## Команды (17)
+## Команды (20)
 
 ### `klemma init`
 Инициализация проекта в текущей директории. Создаёт `.klemma/` (config, tags, DB) и `KLEMMA.md` (контекст для AI). Интерактивный мастер обнаруживает Obsidian vault и Zotero автоматически.
@@ -422,12 +461,13 @@ klemma (CLI, v0.4.1)
 ├── Zotero storage ─── PDF файлы
 ├── PyMuPDF ────────── извлечение текста из PDF
 ├── Config ────────── ~/.klemmarc.yaml → ~/.klemma/ → .klemma/ (3-level merge)
-└── SQLite (schema v9)
+└── SQLite (schema v13)
     ├── sources ─────────── записи Zotero (+ embedding BLOB, embedding_model)
     ├── source_sections ─── source × section (multi-section)
     ├── fragments ───────── фрагменты для цитирования (+ citation_intent, embedding, embedding_model)
     ├── reference_gaps ──── пробелы из библиографий (+ citation_intent, intent scoring)
     ├── citation_links ──── citation graph (source → target, intent, in_library)
+    ├── decisions ───────── Guided Serendipity: развилки, выборы, Research Trail
     ├── daily_plans ─────── сгенерированные планы
     ├── reading_queue ───── очередь чтения
     ├── prune_verdicts ──── результаты аудита (drop/maybe)

--- a/README_EN.md
+++ b/README_EN.md
@@ -77,9 +77,48 @@ klemma ask "What are the main methods for validating ice forecasts?"
 # 8. Project structure
 klemma outline                                 # AI-generated outline
 klemma outline -p "Focus on methodology"       # with a directive
+
+# 9. Guided Serendipity — research branching points
+klemma briefing goessling2016                  # analyze new source → forks
+klemma insights                                # blind spots + hidden clusters
+klemma decisions trail                         # trail of research decisions
 ```
 
-## Commands (16)
+## Guided Serendipity
+
+AI-assisted research methodology where the system discovers unexpected connections in your library and presents explicit branching points (forks) for you to choose from. Your accumulated choices form a unique Research Trail.
+
+### `klemma briefing <citekey>`
+Analyze a new source: key claims, library connections, niches, 2-3 fork options.
+
+```bash
+klemma briefing goessling2016              # briefing for one source
+klemma briefing --pending                  # top-10 unbriefed (by relevance)
+klemma briefing --pending -n 5             # top-5
+```
+
+### `klemma insights`
+Library analysis without AI — pure SQL + embeddings:
+
+- **Blind spots** — sections with source count <50% of average
+- **Hidden clusters** — semantically similar sources from different sections
+
+```bash
+klemma insights                            # table + save as decisions
+```
+
+### `klemma decisions`
+View and manage research decisions:
+
+```bash
+klemma decisions                           # list all decisions
+klemma decisions --pending                 # only awaiting response
+klemma decisions show 5                    # details of decision #5
+klemma decisions trail                     # chronological trail
+klemma decide 5 B --reason "Closer to IIEE"  # choose option B
+```
+
+## Commands (20)
 
 ### `klemma init`
 Initialize a project in the current directory. Creates `.klemma/` (config, tags, DB) and `KLEMMA.md` (AI context). The interactive wizard auto-discovers Obsidian vaults and Zotero exports.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -636,6 +636,131 @@ Intent Benchmark
 
 ---
 
+## 5.x Guided Serendipity — исследовательские развилки
+
+Guided Serendipity — методология AI-ассистированного исследования, в которой система обнаруживает неожиданные связи в вашей библиотеке и предлагает явные точки ветвления (развилки). Вы делаете осознанный выбор на каждой развилке, и ваши решения накапливаются в уникальную исследовательскую тропинку (Research Trail).
+
+### Briefing — анализ нового источника
+
+После добавления нового источника запустите briefing — система проанализирует его тезисы, найдёт связи с вашей библиотекой и предложит 2-3 направления:
+
+```bash
+klemma briefing goessling2016
+```
+
+Вывод:
+```
+Briefing: @goessling2016
+Analyzing source, finding connections...
+
+Key claims:
+  • IIEE разделяет ошибку прогноза на 3 компонента (miss, false alarm, displacement)
+  • 40% ошибки в сезонных прогнозах — displacement, не miss/FA
+  • Метрика применима к любому пространственному бинарному полю
+
+Connections:
+  extends: @dukhovskoy2015 — Оба используют spatial decomposition
+  contradicts: @author2020 — Разные оценки вклада displacement error
+
+Niches/gaps:
+  → Нет анализа displacement error для Арктики отдельно
+
+── Fork ──
+  [A] Взять IIEE как одну метрику в обзоре (sections: 3.2)
+      Включить в сравнительную таблицу наряду с SPS и bias
+  [B] Сделать displacement error центральной темой (sections: 3.2, 4.1)
+      Посвятить отдельный раздел компонентному анализу ошибок
+  [C] Предложить модификацию IIEE для Арктики (sections: 3.2)
+      Адаптировать метрику для специфики ледовой кромки
+
+Choose direction [A/B/C/skip]: B
+Why? (optional): Displacement error — ниша, не покрытая в литературе
+✓ Decision #1 → B
+```
+
+Для пакетной обработки:
+
+```bash
+klemma briefing --pending           # top-10 необработанных источников
+klemma briefing --pending -n 3      # только top-3
+```
+
+### Insights — анализ библиотеки
+
+Периодически запускайте `klemma insights` для обнаружения паттернов:
+
+```bash
+klemma insights
+```
+
+Вывод:
+```
+Blind Spots (2 sections)
+
+┌──────────┬─────────┬─────────┬──────┬──────────┐
+│ Section  │ Sources │ Average │ Gaps │ Severity │
+├──────────┼─────────┼─────────┼──────┼──────────┤
+│ 3.1      │       1 │     5.2 │    3 │ high     │
+│ 4.1      │       2 │     5.2 │    1 │ medium   │
+└──────────┴─────────┴─────────┴──────┴──────────┘
+
+Hidden Clusters (1 pairs)
+
+  @goessling2016 (3.2) ↔ @dukhovskoy2015 (4.1)  similarity: 0.89
+    Evaluating sea ice forecasts with IIEE
+    Arctic Ocean circulation analysis
+
+2 insight(s) saved as pending decisions.
+Review: klemma decisions --pending
+```
+
+**Слепые пятна** — разделы с количеством источников менее 50% от среднего. Высокая severity (<25%) означает, что раздел практически не покрыт.
+
+**Скрытые кластеры** — пары источников из разных разделов, которые семантически очень близки. Это потенциальные undiscovered connections — связи, которые вы ещё не осознали.
+
+Оба типа insights сохраняются как pending decisions — вы решаете, что с ними делать.
+
+### Decisions — управление решениями
+
+Все развилки из briefings и insights сохраняются в Branch Store:
+
+```bash
+klemma decisions                   # список всех решений
+klemma decisions --pending         # только ожидающие
+klemma decisions show 3            # детали решения #3
+klemma decide 3 A                  # выбрать вариант A
+klemma decide 3 A -r "Ближе к теме"  # с обоснованием
+```
+
+### Research Trail — тропинка решений
+
+Просмотр хронологической цепочки всех принятых решений:
+
+```bash
+klemma decisions trail
+```
+
+```
+Research Trail — 4 decisions
+
+  ├─ [2026-03-22] briefing: @goessling2016 → Focus on displacement error
+  │  Displacement error — ниша, не покрытая в литературе
+  ├─ [2026-03-22] insight: library → Search for sources
+  ├─ [2026-03-23] briefing: @dukhovskoy2015 → Combine with IIEE
+  └─ [2026-03-23] briefing: @author2022 → Arctic-specific methodology
+```
+
+Тропинка показывает, как ваше исследование развивалось через осознанные решения, а не случайный дрифт.
+
+### Рекомендуемый workflow с Guided Serendipity
+
+1. **Загрузили новый PDF** → `klemma acquire <url>` → `klemma briefing <citekey>`
+2. **Выбрали развилку** → решение сохранено, влияет на следующие briefings
+3. **Периодически** → `klemma insights` (раз в неделю или после 5+ новых источников)
+4. **Перед написанием** → `klemma decisions trail` — вспомнить свои решения
+
+---
+
 ## 6. Рекомендуемый ежедневный workflow
 
 ### Утро

--- a/prompts/CLAUDE.md
+++ b/prompts/CLAUDE.md
@@ -17,6 +17,7 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 | `outline.md` | `skills/outliner.py` | Project outline generation |
 | `outline_incremental.md` | `skills/outliner.py` | Incremental outline update |
 | `section_draft.md` | `skills/drafter.py` | Section draft generation from research context |
+| `insight_curator.md` | `skills/insights.py` | LLM curation of raw insight candidates (multi-objective ranking) |
 | `analyst.md` | `evaluation/reconstruction.py` | Extract ground truth citation map from paper PDF |
 | `reconstruct.md` | `evaluation/reconstruction.py` | AI citation recommendation (blind to paper text) |
 
@@ -51,6 +52,9 @@ Jinja2 templates rendered by skills via `ai.render_prompt()`. Each template rece
 
 ### section_draft.md
 `dissertation_context`, `dissertation_context_title`, `section`, `chapter_num`, `chapter_name`, `section_title` (from outline), `research_report` (full research briefing text), `existing_draft` (current section text — expand, don't rewrite), `fragments` (list of section-level fragment dicts — fallback/supplementary), `rag_fragments` (list of per-block RAG fragment groups — each with `block_order`, `block_title`, `fragments` with `source`, `text`, `type`, `similarity`; He et al. 2010 context-aware retrieval), `source_summaries` (list of source metadata dicts with citekey, quality, priority, summary), `language`, `prev_ending` (last paragraph of previous section — continuity bridge; empty string if first section), `outline_context` (dict: `description`, `scientific_contributions`, `current_chapter_desc`, `current_section_desc` — from KLEMMA.md frontmatter + `## Outline`; empty dict if no outline), `custom_prompt`
+
+### insight_curator.md
+`language`, `dissertation_context`, `candidates` (formatted text of raw candidates with index numbers), `candidate_count` (int), `feedback_summary` (formatted researcher preferences — liked/disliked types, recent notes)
 
 ### analyst.md
 `pdf_text`, `library_entries`, `paper_citekey`, `paper_title`

--- a/prompts/insight_curator.md
+++ b/prompts/insight_curator.md
@@ -1,0 +1,70 @@
+You are a research insight curator. Your task is to select the most valuable insights from a list of raw candidates detected in the researcher's library, rank them by multi-objective criteria, and present only the top 3-5 that deserve the researcher's attention.
+
+Respond entirely in {{ language }}.
+
+## Project Context
+
+{{ dissertation_context }}
+
+## Raw Candidates ({{ candidate_count }} total)
+
+{{ candidates }}
+
+## Researcher Preferences (from feedback)
+
+{{ feedback_summary }}
+
+## Evaluation Criteria
+
+Rank each candidate on these dimensions (0.0–1.0):
+
+1. **Novelty** — how surprising or non-obvious is this insight? (Nadkarni et al. 2025)
+2. **Actionability** — can the researcher act on this within a week? (McNee et al. 2006)
+3. **Trajectory** — does this connect to a larger research direction? (Hummon & Doreian 1989)
+4. **Diversity** — does this cover a different aspect than other selected insights? (Si et al. 2024)
+
+## Diversity Tags
+
+Assign exactly one tag to each insight:
+- `methodology` — gap in methods coverage or methodological connection
+- `bridge` — hidden link between sections or cross-disciplinary connection
+- `gap` — missing coverage, underrepresented topic
+- `anomaly` — unexpected pattern, contradiction, or outlier
+
+**Constraint**: maximum 2 insights per diversity_tag.
+
+## Your Task
+
+Select the top 3-5 insights (never more than 5). For each:
+- Explain WHY this matters to the researcher (Kastrin et al. 2025)
+- Project WHERE this leads — what research direction it opens (Hummon & Doreian 1989)
+- Suggest a concrete action the researcher can take
+
+```json
+{
+  "insights": [
+    {
+      "candidate_index": 1,
+      "title": "Short, descriptive title",
+      "explanation": "WHY this matters — 1-2 sentences connecting to the research goals",
+      "trajectory": "WHERE this leads — what investigating this could reveal or change",
+      "diversity_tag": "methodology|bridge|gap|anomaly",
+      "novelty_score": 0.8,
+      "actionability_score": 0.7,
+      "sections": ["3.2"],
+      "action_title": "Concrete action verb phrase",
+      "action_description": "Specific next step the researcher should take"
+    }
+  ]
+}
+```
+
+Rules:
+- `candidate_index`: 1-based index from the candidates list above
+- Select 3-5 insights maximum (Paterno et al. 2009: tiered alerts reduce overload)
+- Maximum 2 insights per `diversity_tag` (Si et al. 2024: structural diversity enforcement)
+- Every insight MUST have `explanation` (WHY) and `trajectory` (WHERE)
+- Prefer insights the researcher hasn't already dismissed (check feedback)
+- If researcher notes mention specific topics, prioritize related insights
+
+Respond ONLY with the JSON block. No commentary before or after.

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -28,6 +28,9 @@ Click CLI entry point. Defines 18 commands + hidden aliases.
 - `coach` command: methodology-driven research advisor (zero AI calls). Default: project-wide health check. `-s X.X`: section focus. `--json`: structured output. Calls `_sync_sections()` before reading (ADR-010)
 - `_coach_section_hint(state, section, project_root)` — generates 1-line hint for inline use; called from `add`, `draft -s`, `research -s`
 - `reassign` command: suggest fragment-to-section reassignments via embedding similarity. Optional `CITEKEY` arg filters to one source. `-s SECTION` + `--apply` directly reassigns. Dry-run shows per-suggestion runnable commands. No batch apply — each reassignment is an explicit user decision.
+- `insights` command: 3-stage pipeline (generate → suppress → curate) for blind spots and hidden clusters. Default: LLM-curated top 3-5. `--raw`: unfiltered (no AI). `--model`: override AI model. Blocking: refuses to generate new if pending insight decisions exist.
+- `decisions` group: `list` (default), `show <ID>`, `trail`, `note <ID> "text"` (research note), `like <ID>` (useful feedback), `dislike <ID>` (not useful feedback). `decide <ID> A|B|C` (top-level command).
+- `briefing` command: AI briefing for a source. `--pending`: process top unbriefed sources. `--model`: override.
 
 ### context.py (47 lines)
 `KlemmaContext` dataclass — single object per CLI command invocation.
@@ -76,7 +79,7 @@ Semantic section vocabulary — cross-project labels for dissertation/paper sect
 - `get_writing_order(sections, type_map, drafts_dir?)` — compute results-first writing order, detect existing drafts
 
 ### state.py (~965 lines)
-SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v10), auto-migrates via `_migrate_schema()`. All 70+ public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
+SQLite state manager — **facade** over 8 domain repositories in `repositories/`. Schema versioned via `PRAGMA user_version` (currently v14), auto-migrates via `_migrate_schema()`. All 70+ public methods delegate to repos; repos accessible via `state.sources`, `state.fragments`, `state.benchmarks`, etc. See [Repositories](repositories/CLAUDE.md).
 
 **Three-tier library (ADR-014):** Shared `library.db` replaces the old parent-child DB inheritance (#55). Papers and fragments are stored globally in `~/.klemma/library.db` via `LocalPaperStore` + `LocalUserLibrary`; per-project data (sections, gaps, plans) lives in `project/.klemma/data/project.db` via `LocalProjectStore`. StateManager is a pure facade over domain repositories with no cross-DB merging.
 
@@ -95,6 +98,7 @@ Tables:
 - `benchmark_runs` — benchmark run history (run_id, timestamp, metrics JSON, paper_citekey, git_commit, klemma_version, config_snapshot, duration)
 - `section_embeddings` — section centroid embeddings (section × embedding_model composite PK, BLOB float32, source_count, updated_at)
 - `reassign_skips` — persisted skip decisions (legacy, unused since batch --apply removed)
+- `decisions` — Guided Serendipity branching points (trigger_type, trigger_source, context_json, options_json, chosen_option, rationale, sections, influenced_by, `note` TEXT for research notes, `feedback` TEXT for like/dislike retrospective feedback)
 
 Key methods: `register_sources()`, `update_source_info()`, `get_by_section(section, section_type?)` (JOIN on `source_sections`), `get_coverage_stats()` (includes `section_types` dict), `get_gap_summary()`, `save_plan()`, `save_citation_links()`, `get_citation_graph()`, `save_embedding()`, `get_embeddings()`, `save_section_embedding()`, `get_section_embedding()`, `get_all_section_embeddings()`, `get_section_embedding_stats()`, `save_prune_verdicts()`, `get_prune_verdicts()`, `save_benchmark_run()`, `get_benchmark_runs()`, `compare_benchmark_runs()`, `sync_section_types(config)`.
 

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -54,12 +54,15 @@ def decisions_list(ctx, section, pending, show_all, limit):
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("ID", style="dim", width=4)
+    table.add_column("Date", width=10)
     table.add_column("Type", width=9)
-    table.add_column("Summary", width=50)
+    table.add_column("Summary", width=40)
     table.add_column("Choice", width=8)
     table.add_column("Sections", width=12)
 
     for d in items:
+        date = d["created_at"][:10] if d.get("created_at") else ""
+
         # Build summary: for insights show first option title, for briefings show citekey
         summary = ""
         if d.get("trigger_source"):
@@ -68,8 +71,8 @@ def decisions_list(ctx, section, pending, show_all, limit):
             options = d.get("options_json", [])
             if isinstance(options, list) and options:
                 summary = options[0].get("title", "")
-        if len(summary) > 50:
-            summary = summary[:47] + "..."
+        if len(summary) > 40:
+            summary = summary[:37] + "..."
 
         choice = d.get("chosen_option")
         if choice is None:
@@ -84,6 +87,7 @@ def decisions_list(ctx, section, pending, show_all, limit):
 
         table.add_row(
             str(d["id"]),
+            date,
             d.get("trigger_type", ""),
             summary,
             choice_str,

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -10,11 +10,12 @@ from ..cli import _get_context, _init_ai, console, main
 
 
 @main.group(invoke_without_command=True)
+@click.option("--pending", is_flag=True, help="Show only pending decisions")
 @click.pass_context
-def decisions(ctx):
+def decisions(ctx, pending):
     """View and manage research decisions (Guided Serendipity)."""
     if ctx.invoked_subcommand is None:
-        ctx.invoke(decisions_list)
+        ctx.invoke(decisions_list, pending=pending)
 
 
 @decisions.command("list")

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -360,6 +360,74 @@ def _interactive_decide(state, decision_id, result):
         console.print(f"[red]Invalid choice. Saved as pending (decide later: klemma decide {decision_id} {keys_str})[/red]")
 
 
+@main.command()
+@click.pass_context
+def insights(ctx):
+    """Analyze your library for blind spots and hidden connections.
+
+    Detects:
+    - Blind spots: sections with significantly fewer sources than average
+    - Hidden clusters: semantically similar sources in different sections
+
+    No AI calls — uses SQL stats and embeddings only.
+    """
+    from ..skills.insights import generate_insights, save_insights_as_decisions
+
+    kctx = _get_context(ctx)
+    state = kctx.state
+
+    console.print("[dim]Scanning library for patterns...[/dim]\n")
+    result = generate_insights(state, kctx.project_store)
+
+    if not result.blind_spots and not result.hidden_clusters:
+        console.print("[green]No issues found. Library looks balanced.[/green]")
+        return
+
+    # Display blind spots
+    if result.blind_spots:
+        console.print(f"[bold]Blind Spots[/bold] ({len(result.blind_spots)} sections)\n")
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Section", width=10)
+        table.add_column("Sources", width=8, justify="right")
+        table.add_column("Average", width=8, justify="right")
+        table.add_column("Gaps", width=6, justify="right")
+        table.add_column("Severity", width=8)
+
+        for spot in result.blind_spots:
+            sev_style = {"high": "[red]high[/red]", "medium": "[yellow]medium[/yellow]"}.get(
+                spot.severity, spot.severity
+            )
+            table.add_row(
+                spot.section,
+                str(spot.source_count),
+                str(spot.average_count),
+                str(spot.gap_count),
+                sev_style,
+            )
+        console.print(table)
+
+    # Display hidden clusters
+    if result.hidden_clusters:
+        console.print(f"\n[bold]Hidden Clusters[/bold] ({len(result.hidden_clusters)} pairs)\n")
+        for c in result.hidden_clusters:
+            console.print(
+                f"  @{c.citekey_a} ({c.section_a}) ↔ @{c.citekey_b} ({c.section_b})"
+                f"  [dim]similarity: {c.similarity}[/dim]"
+            )
+            if c.title_a and c.title_b:
+                console.print(f"    {c.title_a[:60]}")
+                console.print(f"    {c.title_b[:60]}")
+            console.print()
+
+    # Save as decisions
+    decision_ids = save_insights_as_decisions(result, state)
+    if decision_ids:
+        console.print(
+            f"\n[yellow]{len(decision_ids)} insight(s) saved as pending decisions.[/yellow]"
+            f"\nReview: klemma decisions --pending"
+        )
+
+
 @decisions.command("trail")
 @click.pass_context
 def decisions_trail(ctx):

--- a/src/klemma/commands/decisions.py
+++ b/src/klemma/commands/decisions.py
@@ -54,17 +54,22 @@ def decisions_list(ctx, section, pending, show_all, limit):
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("ID", style="dim", width=4)
-    table.add_column("Date", width=10)
     table.add_column("Type", width=9)
-    table.add_column("Source", width=20)
+    table.add_column("Summary", width=50)
     table.add_column("Choice", width=8)
-    table.add_column("Sections", width=10)
+    table.add_column("Sections", width=12)
 
     for d in items:
-        date = d["created_at"][:10] if d.get("created_at") else ""
-        source = d.get("trigger_source") or ""
-        if len(source) > 20:
-            source = source[:17] + "..."
+        # Build summary: for insights show first option title, for briefings show citekey
+        summary = ""
+        if d.get("trigger_source"):
+            summary = f"@{d['trigger_source']}"
+        else:
+            options = d.get("options_json", [])
+            if isinstance(options, list) and options:
+                summary = options[0].get("title", "")
+        if len(summary) > 50:
+            summary = summary[:47] + "..."
 
         choice = d.get("chosen_option")
         if choice is None:
@@ -79,9 +84,8 @@ def decisions_list(ctx, section, pending, show_all, limit):
 
         table.add_row(
             str(d["id"]),
-            date,
             d.get("trigger_type", ""),
-            source,
+            summary,
             choice_str,
             sections_str,
         )
@@ -114,6 +118,21 @@ def decisions_show(ctx, decision_id):
         )
     )
 
+    # Curated insight fields (WHY / WHERE / tag)
+    context = d.get("context_json", {})
+    if isinstance(context, dict):
+        if context.get("title"):
+            console.print(f"\n[bold]{context['title']}[/bold]")
+        if context.get("explanation"):
+            console.print(f"\n[bold]Why:[/bold] {context['explanation']}")
+        if context.get("trajectory"):
+            console.print(f"[bold]Where this leads:[/bold] {context['trajectory']}")
+        if context.get("diversity_tag"):
+            tag = context["diversity_tag"]
+            tag_colors = {"methodology": "blue", "bridge": "magenta", "gap": "yellow", "anomaly": "red"}
+            tc = tag_colors.get(tag, "white")
+            console.print(f"[bold]Tag:[/bold] [{tc}]{tag}[/{tc}]")
+
     # Options
     options = d.get("options_json", [])
     if isinstance(options, list):
@@ -132,8 +151,16 @@ def decisions_show(ctx, decision_id):
     if d.get("rationale"):
         console.print(f"\n[bold]Rationale:[/bold] {d['rationale']}")
 
-    # Context summary
-    context = d.get("context_json", {})
+    # Research note
+    if d.get("note"):
+        console.print(f"\n[bold]Research note:[/bold] {d['note']}")
+
+    # Feedback
+    if d.get("feedback"):
+        fb_style = "[green]useful[/green]" if d["feedback"] == "like" else "[yellow]not useful[/yellow]"
+        console.print(f"\n[bold]Feedback:[/bold] {fb_style}")
+
+    # Context summary (briefing key_claims)
     if isinstance(context, dict) and context.get("key_claims"):
         console.print("\n[bold]Key claims:[/bold]")
         for claim in context["key_claims"]:
@@ -362,29 +389,149 @@ def _interactive_decide(state, decision_id, result):
 
 
 @main.command()
+@click.option("--raw", is_flag=True, help="Show all raw candidates without LLM curation")
+@click.option("--model", default=None, help="Override AI model for curation")
 @click.pass_context
-def insights(ctx):
+def insights(ctx, raw, model):
     """Analyze your library for blind spots and hidden connections.
 
-    Detects:
-    - Blind spots: sections with significantly fewer sources than average
-    - Hidden clusters: semantically similar sources in different sections
+    Default: LLM-curated top 3-5 insights with trajectories.
+    Use --raw for unfiltered candidates (old behavior, no AI).
 
-    No AI calls — uses SQL stats and embeddings only.
+    Pipeline: generate broadly → suppress heuristically → curate with LLM.
     """
-    from ..skills.insights import generate_insights, save_insights_as_decisions
+    from ..skills.insights import (
+        generate_curated_insights,
+        generate_insights,
+        save_insights_as_decisions,
+    )
 
     kctx = _get_context(ctx)
     state = kctx.state
+    cfg = kctx.config
+
+    if raw:
+        # Raw mode — old behavior, no AI
+        console.print("[dim]Scanning library for patterns...[/dim]\n")
+        result = generate_insights(state, kctx.project_store)
+
+        if not result.blind_spots and not result.hidden_clusters:
+            console.print("[green]No issues found. Library looks balanced.[/green]")
+            return
+
+        _display_raw_insights(result)
+
+        decision_ids = save_insights_as_decisions(result, state)
+        if decision_ids:
+            console.print(
+                f"\n[yellow]{len(decision_ids)} insight(s) saved as pending decisions.[/yellow]"
+                f"\nReview: klemma decisions --pending"
+            )
+        return
+
+    # Curated mode
+    if model:
+        cfg.ai.model = model
+
+    ai = None
+    try:
+        ai = _init_ai(cfg)
+    except Exception:
+        pass
 
     console.print("[dim]Scanning library for patterns...[/dim]\n")
-    result = generate_insights(state, kctx.project_store)
+    result = generate_curated_insights(
+        state,
+        config=cfg,
+        ai=ai,
+        project_store=kctx.project_store,
+        dissertation_context=kctx.dissertation_context,
+        klemma_home=kctx.klemma_home,
+        project_root=kctx.project_root,
+        project_chain=getattr(kctx, "project_chain", []),
+        language=getattr(cfg.dissertation, "language", "Russian") if cfg.dissertation else "Russian",
+        raw_mode=False,
+    )
 
-    if not result.blind_spots and not result.hidden_clusters:
+    if result.blocked:
+        console.print(
+            f"[yellow]{result.pending_count} pending insight(s) — "
+            f"resolve them before generating new ones.[/yellow]"
+            f"\nReview: klemma decisions --pending"
+        )
+        return
+
+    if result.raw_count == 0:
         console.print("[green]No issues found. Library looks balanced.[/green]")
         return
 
-    # Display blind spots
+    if not result.insights:
+        # No curated insights (maybe no AI or all suppressed)
+        console.print(
+            f"[dim]Found {result.raw_count} raw candidates, "
+            f"suppressed {result.suppressed_count}.[/dim]"
+        )
+        if result.curated_count > 0:
+            console.print(
+                f"\n[yellow]{result.curated_count} insight(s) saved as pending decisions.[/yellow]"
+                f"\nReview: klemma decisions --pending"
+            )
+        return
+
+    # Display curated insights as Rich panels
+    console.print(
+        f"[bold]Curated Insights[/bold] — {len(result.insights)} of "
+        f"{result.raw_count} candidates "
+        f"[dim]({result.suppressed_count} suppressed)[/dim]\n"
+    )
+
+    for i, insight in enumerate(result.insights):
+        tag_colors = {
+            "methodology": "blue",
+            "bridge": "magenta",
+            "gap": "yellow",
+            "anomaly": "red",
+        }
+        tag_color = tag_colors.get(insight.diversity_tag, "white")
+
+        # Get the real decision ID
+        did = result.decision_ids[i] if i < len(result.decision_ids) else "?"
+
+        body_lines = []
+        if insight.explanation:
+            body_lines.append(f"[bold]Why:[/bold] {insight.explanation}")
+        if insight.trajectory:
+            body_lines.append(f"[bold]Where this leads:[/bold] {insight.trajectory}")
+
+        sections_str = ", ".join(insight.sections) if insight.sections else ""
+        if sections_str:
+            body_lines.append(f"[dim]Sections: {sections_str}[/dim]")
+
+        # Options
+        for opt in insight.options:
+            body_lines.append(
+                f"  [{opt['key']}] [bold]{opt['title']}[/bold] — {opt.get('description', '')}"
+            )
+
+        body_lines.append(f"\n[dim]klemma decide {did} A|B|C[/dim]")
+
+        panel_content = "\n".join(body_lines)
+        console.print(Panel(
+            panel_content,
+            title=f"Decision #{did} — {insight.title}",
+            subtitle=f"[{tag_color}]{insight.diversity_tag}[/{tag_color}]",
+            border_style=tag_color,
+        ))
+
+    if result.curated_count > 0:
+        console.print(
+            f"\n[yellow]{result.curated_count} insight(s) saved as pending decisions.[/yellow]"
+            f"\nDecide: klemma decide <ID> A|B|C"
+        )
+
+
+def _display_raw_insights(result):
+    """Display raw insights (old behavior for --raw mode)."""
     if result.blind_spots:
         console.print(f"[bold]Blind Spots[/bold] ({len(result.blind_spots)} sections)\n")
         table = Table(show_header=True, header_style="bold")
@@ -407,7 +554,6 @@ def insights(ctx):
             )
         console.print(table)
 
-    # Display hidden clusters
     if result.hidden_clusters:
         console.print(f"\n[bold]Hidden Clusters[/bold] ({len(result.hidden_clusters)} pairs)\n")
         for c in result.hidden_clusters:
@@ -420,13 +566,80 @@ def insights(ctx):
                 console.print(f"    {c.title_b[:60]}")
             console.print()
 
-    # Save as decisions
-    decision_ids = save_insights_as_decisions(result, state)
-    if decision_ids:
-        console.print(
-            f"\n[yellow]{len(decision_ids)} insight(s) saved as pending decisions.[/yellow]"
-            f"\nReview: klemma decisions --pending"
-        )
+
+@decisions.command("note")
+@click.argument("decision_id", type=int)
+@click.argument("text", type=str)
+@click.pass_context
+def decisions_note(ctx, decision_id, text):
+    """Add a research note to a decision.
+
+    Captures the researcher's thinking — ideas, experiments, hypotheses
+    that arise from an insight. These notes feed into future briefings
+    and insights.
+
+    Usage:
+      klemma decisions note 5 "сопоставить IIEE с SPS, эксперимент: 5 кейсов"
+    """
+    kctx = _get_context(ctx)
+    repo = kctx.state.decisions
+
+    d = repo.get_decision(decision_id)
+    if not d:
+        console.print(f"[red]Decision #{decision_id} not found[/red]")
+        return
+
+    if repo.add_note(decision_id, text):
+        console.print(f"[green]✓ Note added to decision #{decision_id}[/green]")
+        console.print(f"  [dim]{text}[/dim]")
+    else:
+        console.print(f"[red]Failed to add note to decision #{decision_id}[/red]")
+
+
+@decisions.command("like")
+@click.argument("decision_id", type=int)
+@click.pass_context
+def decisions_like(ctx, decision_id):
+    """Mark an insight as useful (retrospective feedback).
+
+    Usage:
+      klemma decisions like 5
+    """
+    kctx = _get_context(ctx)
+    repo = kctx.state.decisions
+
+    d = repo.get_decision(decision_id)
+    if not d:
+        console.print(f"[red]Decision #{decision_id} not found[/red]")
+        return
+
+    if repo.set_feedback(decision_id, "like"):
+        console.print(f"[green]✓ Decision #{decision_id} marked as useful[/green]")
+    else:
+        console.print(f"[red]Failed to update decision #{decision_id}[/red]")
+
+
+@decisions.command("dislike")
+@click.argument("decision_id", type=int)
+@click.pass_context
+def decisions_dislike(ctx, decision_id):
+    """Mark an insight as not useful (retrospective feedback).
+
+    Usage:
+      klemma decisions dislike 5
+    """
+    kctx = _get_context(ctx)
+    repo = kctx.state.decisions
+
+    d = repo.get_decision(decision_id)
+    if not d:
+        console.print(f"[red]Decision #{decision_id} not found[/red]")
+        return
+
+    if repo.set_feedback(decision_id, "dislike"):
+        console.print(f"[yellow]✗ Decision #{decision_id} marked as not useful[/yellow]")
+    else:
+        console.print(f"[red]Failed to update decision #{decision_id}[/red]")
 
 
 @decisions.command("trail")

--- a/src/klemma/repositories/CLAUDE.md
+++ b/src/klemma/repositories/CLAUDE.md
@@ -17,7 +17,8 @@ StateManager (facade)
     ├── CitationsRepository   — citation links, graph stats, co-citation, author groups
     ├── PlansRepository       — daily plans, reading queue, writing streak
     ├── PruneRepository       — prune verdicts, protection logic
-    └── BenchmarkRepository   — benchmark run history, comparison
+    ├── BenchmarkRepository   — benchmark run history, comparison
+    └── DecisionsRepository   — Guided Serendipity decisions, notes, feedback
 ```
 
 All repos receive `StateManager._conn` as their connection factory via `BaseRepository.__init__`.
@@ -95,6 +96,19 @@ Benchmark run history persistence and comparison.
 - `compare_runs(id_a, id_b)` — delta for shared summary metric keys
 - `get_benchmarked_citekeys()` — set of all benchmarked paper citekeys
 - `compute_dataset_hash(path)` — SHA256 of dataset file for reproducibility
+
+### decisions.py (~260 lines)
+Guided Serendipity decisions: branching points, research notes, retrospective feedback.
+- `save_decision()` — create a new branching point (trigger_type, context, options, sections)
+- `decide()` — record researcher's choice (chosen_option, rationale)
+- `skip_decision()` — mark as skipped
+- `get_decision()`, `get_pending_decisions()`, `get_decisions()` — query with filters
+- `get_trail()` — chronological decided-only for graph construction
+- `get_decisions_for_context()` — compact summaries for prompt injection
+- `count_decisions()` — counts by status (total, pending, decided, skipped)
+- `add_note(decision_id, note)` — add/update research note on a decision
+- `set_feedback(decision_id, feedback)` — set 'like' or 'dislike' retrospective feedback
+- `get_feedback_summary()` — aggregate feedback for prompt injection (liked_types, disliked_types, recent_notes)
 
 ## Cross-repo dependencies
 

--- a/src/klemma/repositories/decisions.py
+++ b/src/klemma/repositories/decisions.py
@@ -183,6 +183,83 @@ class DecisionsRepository(BaseRepository):
             ).fetchone()
             return dict(row)
 
+    def add_note(self, decision_id: int, note: str) -> bool:
+        """Add or update a research note on a decision.
+
+        Returns True if the decision was updated.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE decisions SET note = ? WHERE id = ?",
+                (note, decision_id),
+            )
+            return cur.rowcount > 0
+
+    def set_feedback(self, decision_id: int, feedback: str) -> bool:
+        """Set retrospective feedback ('like' or 'dislike') on a decision.
+
+        Returns True if the decision was updated.
+        """
+        if feedback not in ("like", "dislike"):
+            raise ValueError(f"feedback must be 'like' or 'dislike', got '{feedback}'")
+        with self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE decisions SET feedback = ? WHERE id = ?",
+                (feedback, decision_id),
+            )
+            return cur.rowcount > 0
+
+    def get_feedback_summary(self) -> dict:
+        """Aggregate researcher feedback for prompt injection.
+
+        Returns:
+            {
+                "liked_types": {"blind_spot": 3, "hidden_cluster": 1},
+                "disliked_types": {"blind_spot": 0, "hidden_cluster": 2},
+                "recent_notes": ["note1", "note2", ...],
+                "total_liked": 4,
+                "total_disliked": 2,
+            }
+        """
+        with self._conn() as conn:
+            # Count likes/dislikes by insight context type
+            liked_types: dict[str, int] = {}
+            disliked_types: dict[str, int] = {}
+
+            rows = conn.execute(
+                """SELECT context_json, feedback FROM decisions
+                   WHERE feedback IS NOT NULL AND trigger_type = 'insight'"""
+            ).fetchall()
+            for row in rows:
+                ctx_raw = row["context_json"]
+                try:
+                    ctx = json.loads(ctx_raw) if isinstance(ctx_raw, str) else ctx_raw
+                except (json.JSONDecodeError, TypeError):
+                    ctx = {}
+                itype = ctx.get("type", "unknown") if isinstance(ctx, dict) else "unknown"
+                fb = row["feedback"]
+                if fb == "like":
+                    liked_types[itype] = liked_types.get(itype, 0) + 1
+                elif fb == "dislike":
+                    disliked_types[itype] = disliked_types.get(itype, 0) + 1
+
+            # Recent notes (last 10)
+            note_rows = conn.execute(
+                """SELECT note FROM decisions
+                   WHERE note IS NOT NULL AND note != ''
+                   ORDER BY COALESCE(decided_at, created_at) DESC
+                   LIMIT 10"""
+            ).fetchall()
+            recent_notes = [r["note"] for r in note_rows]
+
+            return {
+                "liked_types": liked_types,
+                "disliked_types": disliked_types,
+                "recent_notes": recent_notes,
+                "total_liked": sum(liked_types.values()),
+                "total_disliked": sum(disliked_types.values()),
+            }
+
     @staticmethod
     def _row_to_dict(row) -> dict:
         """Convert a sqlite3.Row to a dict with parsed JSON fields."""

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -112,6 +112,27 @@ Dynamic work context builder — replaces hardcoded DISSERTATION_CONTEXT constan
 - `get_current_deadline(project, language)` — returns (deadline_str, days_remaining) for current focus chapter
 - Multi-language labels (ru/en) for chapter headings, deadlines, etc.
 
+### insights.py (~480 lines)
+Guided Serendipity insights — 3-stage pipeline: generate → suppress → curate.
+- `BlindSpot`, `HiddenCluster`, `InsightsResult` — Stage 1 dataclasses (SQL + embeddings, no LLM)
+- `RawCandidate`, `CuratedInsight`, `CuratedInsightsResult` — Stage 2-3 dataclasses
+- `detect_blind_spots(state, project_store?)` — sections with fewer sources than average (pure SQL)
+- `detect_hidden_clusters(state, threshold?, max_pairs?)` — cross-section similar sources (embeddings, no LLM)
+- `generate_insights(state, project_store?)` — combined Stage 1 result
+- `save_insights_as_decisions(insights, state)` — save raw insights as 2-option decisions
+- `suppress_candidates(candidates, state)` — Stage 2: heuristic suppression (already-decided, trivial clusters <0.80, duplicate section pairs, same-chapter redundant blind spots). ~36% reduction per Phansalkar 2013
+- `check_insights_blocked(state)` — returns (is_blocked, pending_count, pending_list)
+- `curate_insights(candidates, config, ai, state, ...)` — Stage 3: LLM curation via `prompts/insight_curator.md`. Multi-objective ranking (novelty × actionability × trajectory × diversity). Max 5 insights, max 2 per diversity_tag. Injects researcher feedback history.
+- `generate_curated_insights(state, config, ai?, ...)` — full pipeline orchestrator. Checks blocking → generates broadly → suppresses → curates (or raw mode with `raw_mode=True`)
+- `save_curated_insights_as_decisions(insights, state)` — save curated insights as 3-option decisions (Act/Bookmark/Dismiss)
+- Academic grounding: Nadkarni 2025 (LLM-as-judge), Paterno 2009 (tiered alerts), Phansalkar 2013 (suppression-first), McNee 2006 (multi-objective), Si 2024 (diversity enforcement), Hummon & Doreian 1989 (trajectories), Kastrin 2025 (interpretability)
+
+### briefer.py (~200 lines)
+Guided Serendipity briefing — analyzes new sources, finds connections, generates branching points.
+- `BriefingResult` — dataclass: source info, key_claims, connections, niches, forks
+- `generate_briefing(source_citekey, config, state, ai, ...)` — renders `prompts/briefing.md` → AI → parse JSON
+- `save_briefing_as_decision(result, state)` — save forks as pending decision
+
 ### coach.py (~170 lines)
 Contextual research advisor — methodology-driven heuristics (zero AI calls). Thresholds from 21 methodology papers (Pautasso 2013, Cohan 2019, Kallestinova 2011).
 - `CoachFinding` — dataclass: category, section, message, severity

--- a/src/klemma/skills/insights.py
+++ b/src/klemma/skills/insights.py
@@ -1,0 +1,248 @@
+"""Guided Serendipity insights — detect blind spots and hidden clusters in the library."""
+
+import logging
+from dataclasses import dataclass, field
+
+from ..embeddings import cosine_similarity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BlindSpot:
+    """A section with significantly fewer sources than average."""
+
+    section: str
+    source_count: int
+    average_count: float
+    gap_count: int = 0
+    severity: str = "low"  # low | medium | high
+
+
+@dataclass
+class HiddenCluster:
+    """A pair of sources from different sections that are semantically close."""
+
+    citekey_a: str
+    citekey_b: str
+    similarity: float
+    section_a: str
+    section_b: str
+    title_a: str = ""
+    title_b: str = ""
+
+
+@dataclass
+class InsightsResult:
+    """Combined insights from library analysis."""
+
+    blind_spots: list[BlindSpot] = field(default_factory=list)
+    hidden_clusters: list[HiddenCluster] = field(default_factory=list)
+    total_sources: int = 0
+    total_sections: int = 0
+
+
+def detect_blind_spots(state, project_store=None) -> list[BlindSpot]:
+    """Find sections with significantly fewer sources than average.
+
+    Pure SQL — no LLM calls.
+    """
+    # Get coverage stats
+    ps = project_store
+    cov = (
+        ps.get_coverage_stats()
+        if ps and ps.count_sources() > 0
+        else state.get_coverage_stats()
+    )
+
+    by_section = cov.get("sections", cov.get("by_section", {}))
+    if not by_section:
+        return []
+
+    counts = list(by_section.values())
+    if not counts:
+        return []
+
+    avg = sum(counts) / len(counts)
+    if avg < 2:
+        return []
+
+    # Get ref-gap counts per section
+    gap_summary = {}
+    try:
+        gaps = state.gaps.get_reference_gaps()
+        for g in gaps:
+            sections_raw = g.get("dissertation_sections", "")
+            if sections_raw:
+                for sec in str(sections_raw).split(","):
+                    sec = sec.strip().strip('"').strip("'")
+                    if sec:
+                        gap_summary[sec] = gap_summary.get(sec, 0) + 1
+    except Exception:
+        pass
+
+    spots = []
+    for section, count in by_section.items():
+        ratio = count / avg if avg > 0 else 0
+        if ratio < 0.5:
+            severity = "high" if ratio < 0.25 else "medium"
+            gaps_in_section = gap_summary.get(section, 0)
+            spots.append(BlindSpot(
+                section=section,
+                source_count=count,
+                average_count=round(avg, 1),
+                gap_count=gaps_in_section,
+                severity=severity,
+            ))
+
+    spots.sort(key=lambda s: s.source_count)
+    return spots
+
+
+def detect_hidden_clusters(
+    state,
+    similarity_threshold: float = 0.75,
+    max_pairs: int = 10,
+) -> list[HiddenCluster]:
+    """Find semantically similar sources assigned to different sections.
+
+    Uses source embeddings — no LLM calls.
+    """
+    all_embeddings = state.get_all_embeddings()
+    if not all_embeddings or len(all_embeddings) < 2:
+        return []
+
+    # Build section map: citekey → primary section
+    section_map = {}
+    for citekey in all_embeddings:
+        source = state.get_source(citekey)
+        if source:
+            section_map[citekey] = source.get("primary_section", "")
+
+    # Pairwise comparison (O(n²) but only on sources with embeddings)
+    citekeys = list(all_embeddings.keys())
+    pairs = []
+
+    for i in range(len(citekeys)):
+        for j in range(i + 1, len(citekeys)):
+            ck_a, ck_b = citekeys[i], citekeys[j]
+            sec_a = section_map.get(ck_a, "")
+            sec_b = section_map.get(ck_b, "")
+
+            # Only interested in cross-section pairs
+            if not sec_a or not sec_b or sec_a == sec_b:
+                continue
+
+            sim = cosine_similarity(all_embeddings[ck_a], all_embeddings[ck_b])
+            if sim >= similarity_threshold:
+                src_a = state.get_source(ck_a)
+                src_b = state.get_source(ck_b)
+                pairs.append(HiddenCluster(
+                    citekey_a=ck_a,
+                    citekey_b=ck_b,
+                    similarity=round(sim, 3),
+                    section_a=sec_a,
+                    section_b=sec_b,
+                    title_a=src_a.get("title", "") if src_a else "",
+                    title_b=src_b.get("title", "") if src_b else "",
+                ))
+
+    pairs.sort(key=lambda p: p.similarity, reverse=True)
+    return pairs[:max_pairs]
+
+
+def generate_insights(state, project_store=None) -> InsightsResult:
+    """Run all insight detectors and return combined results."""
+    blind_spots = detect_blind_spots(state, project_store)
+    hidden_clusters = detect_hidden_clusters(state)
+
+    stats = state.get_stats()
+    cov = state.get_coverage_stats()
+    sections = cov.get("sections", cov.get("by_section", {}))
+
+    return InsightsResult(
+        blind_spots=blind_spots,
+        hidden_clusters=hidden_clusters,
+        total_sources=stats.get("completed", 0) + stats.get("pending", 0),
+        total_sections=len(sections),
+    )
+
+
+def save_insights_as_decisions(insights: InsightsResult, state) -> list[int]:
+    """Save notable insights as pending decisions in the Branch Store.
+
+    Returns list of created decision IDs.
+    """
+    decision_ids = []
+
+    # Blind spots → decisions
+    for spot in insights.blind_spots:
+        if spot.severity not in ("medium", "high"):
+            continue
+
+        context = {
+            "type": "blind_spot",
+            "section": spot.section,
+            "source_count": spot.source_count,
+            "average_count": spot.average_count,
+            "gap_count": spot.gap_count,
+        }
+        options = [
+            {
+                "key": "A",
+                "title": "Search for sources",
+                "description": f"Use 'klemma suggest' to find papers for section {spot.section}",
+            },
+            {
+                "key": "B",
+                "title": "Intentional gap",
+                "description": "This section intentionally has fewer sources — skip",
+            },
+        ]
+
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context=context,
+            options=options,
+            sections=[spot.section],
+        )
+        decision_ids.append(did)
+
+    # Hidden clusters → decisions
+    for cluster in insights.hidden_clusters[:5]:
+        context = {
+            "type": "hidden_cluster",
+            "citekey_a": cluster.citekey_a,
+            "citekey_b": cluster.citekey_b,
+            "similarity": cluster.similarity,
+            "section_a": cluster.section_a,
+            "section_b": cluster.section_b,
+            "title_a": cluster.title_a,
+            "title_b": cluster.title_b,
+        }
+        options = [
+            {
+                "key": "A",
+                "title": "Explore connection",
+                "description": (
+                    f"@{cluster.citekey_a} ({cluster.section_a}) and "
+                    f"@{cluster.citekey_b} ({cluster.section_b}) may have an "
+                    f"undiscovered link — investigate"
+                ),
+            },
+            {
+                "key": "B",
+                "title": "Not relevant",
+                "description": "The similarity is coincidental — skip",
+            },
+        ]
+
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context=context,
+            options=options,
+            sections=[cluster.section_a, cluster.section_b],
+        )
+        decision_ids.append(did)
+
+    return decision_ids

--- a/src/klemma/skills/insights.py
+++ b/src/klemma/skills/insights.py
@@ -2,7 +2,10 @@
 
 import logging
 from dataclasses import dataclass, field
+from typing import Optional
 
+from ..ai import AIProvider
+from ..config import KlemmaConfig, resolve_prompt
 from ..embeddings import cosine_similarity
 
 logger = logging.getLogger(__name__)
@@ -245,4 +248,532 @@ def save_insights_as_decisions(insights: InsightsResult, state) -> list[int]:
         )
         decision_ids.append(did)
 
+    return decision_ids
+
+
+# ── Stage 2-3: Curated insights pipeline ─────────────────────────────────
+
+
+@dataclass
+class RawCandidate:
+    """A raw insight candidate from Stage 1 (blind spot or hidden cluster)."""
+
+    candidate_type: str  # "blind_spot" | "hidden_cluster"
+    section: str  # primary section
+    sections: list[str] = field(default_factory=list)
+    severity: str = ""  # high | medium (blind spots only)
+    source_count: int = 0
+    average_count: float = 0.0
+    gap_count: int = 0
+    # Hidden cluster fields
+    citekey_a: str = ""
+    citekey_b: str = ""
+    similarity: float = 0.0
+    section_a: str = ""
+    section_b: str = ""
+    title_a: str = ""
+    title_b: str = ""
+
+
+@dataclass
+class CuratedInsight:
+    """An LLM-curated insight with trajectory and actionable options."""
+
+    title: str
+    explanation: str  # WHY this matters
+    trajectory: str  # WHERE this leads
+    diversity_tag: str  # methodology | bridge | gap | anomaly
+    novelty_score: float = 0.0  # 0-1
+    actionability_score: float = 0.0  # 0-1
+    candidate_type: str = ""  # blind_spot | hidden_cluster
+    sections: list[str] = field(default_factory=list)
+    options: list[dict] = field(default_factory=list)
+    context: dict = field(default_factory=dict)
+
+
+@dataclass
+class CuratedInsightsResult:
+    """Result of the curated insights pipeline."""
+
+    insights: list[CuratedInsight] = field(default_factory=list)
+    decision_ids: list[int] = field(default_factory=list)
+    raw_count: int = 0
+    suppressed_count: int = 0
+    curated_count: int = 0
+    blocked: bool = False
+    pending_count: int = 0
+
+
+def _candidates_from_insights(result: InsightsResult) -> list[RawCandidate]:
+    """Convert InsightsResult into a flat list of RawCandidates."""
+    candidates = []
+    for spot in result.blind_spots:
+        if spot.severity not in ("medium", "high"):
+            continue
+        candidates.append(RawCandidate(
+            candidate_type="blind_spot",
+            section=spot.section,
+            sections=[spot.section],
+            severity=spot.severity,
+            source_count=spot.source_count,
+            average_count=spot.average_count,
+            gap_count=spot.gap_count,
+        ))
+    for cluster in result.hidden_clusters:
+        candidates.append(RawCandidate(
+            candidate_type="hidden_cluster",
+            section=cluster.section_a,
+            sections=[cluster.section_a, cluster.section_b],
+            similarity=cluster.similarity,
+            citekey_a=cluster.citekey_a,
+            citekey_b=cluster.citekey_b,
+            section_a=cluster.section_a,
+            section_b=cluster.section_b,
+            title_a=cluster.title_a,
+            title_b=cluster.title_b,
+        ))
+    return candidates
+
+
+def suppress_candidates(
+    candidates: list[RawCandidate],
+    state,
+) -> list[RawCandidate]:
+    """Stage 2: Heuristic suppression — no LLM calls.
+
+    Removes:
+    - Already-decided sections (insight decisions already resolved for that section)
+    - Trivial clusters (similarity < 0.80)
+    - Duplicate section pairs (keep highest similarity)
+    - Same-chapter redundant blind spots (keep worst per chapter)
+
+    Based on Phansalkar et al. 2013 — suppression-first reduces ~36%.
+    """
+    # Get sections that already have actively decided insight decisions
+    # (skipped decisions do NOT suppress — only real choices A/B/C)
+    decided_sections: set[str] = set()
+    try:
+        decided = state.decisions.get_decisions(
+            trigger_type="insight", include_skipped=False
+        )
+        for d in decided:
+            if d.get("chosen_option") is not None:
+                secs = d.get("sections", [])
+                if isinstance(secs, list):
+                    decided_sections.update(secs)
+    except Exception:
+        pass
+
+    survivors = []
+    seen_section_pairs: set[tuple[str, str]] = set()
+    seen_chapter_blind_spots: dict[str, RawCandidate] = {}
+
+    for c in candidates:
+        # Rule 1: Skip already-decided sections
+        if all(s in decided_sections for s in c.sections):
+            logger.debug("Suppressed: all sections already decided: %s", c.sections)
+            continue
+
+        # Rule 2: Trivial clusters (< 0.80 similarity)
+        if c.candidate_type == "hidden_cluster" and c.similarity < 0.80:
+            logger.debug(
+                "Suppressed: trivial cluster %.3f < 0.80: %s ↔ %s",
+                c.similarity, c.citekey_a, c.citekey_b,
+            )
+            continue
+
+        # Rule 3: Duplicate section pairs (keep highest similarity)
+        if c.candidate_type == "hidden_cluster":
+            pair = tuple(sorted([c.section_a, c.section_b]))
+            if pair in seen_section_pairs:
+                logger.debug("Suppressed: duplicate section pair %s", pair)
+                continue
+            seen_section_pairs.add(pair)
+
+        # Rule 4: Same-chapter redundant blind spots (keep worst per chapter)
+        if c.candidate_type == "blind_spot":
+            chapter = c.section.split(".")[0] if "." in c.section else c.section
+            existing = seen_chapter_blind_spots.get(chapter)
+            if existing is not None:
+                # Keep the one with fewer sources (worse)
+                if c.source_count < existing.source_count:
+                    # Replace — remove existing from survivors, add new
+                    survivors = [s for s in survivors if s is not existing]
+                    seen_chapter_blind_spots[chapter] = c
+                else:
+                    logger.debug(
+                        "Suppressed: redundant blind spot %s (chapter %s)",
+                        c.section, chapter,
+                    )
+                    continue
+            else:
+                seen_chapter_blind_spots[chapter] = c
+
+        survivors.append(c)
+
+    logger.info(
+        "Suppression: %d → %d candidates (%.0f%% reduction)",
+        len(candidates), len(survivors),
+        (1 - len(survivors) / len(candidates)) * 100 if candidates else 0,
+    )
+    return survivors
+
+
+def check_insights_blocked(state) -> tuple[bool, int, list[dict]]:
+    """Check if pending insight decisions exist (blocking new generation).
+
+    Returns (is_blocked, pending_count, pending_decisions).
+    """
+    pending = state.decisions.get_pending_decisions(trigger_type="insight")
+    return len(pending) > 0, len(pending), pending
+
+
+def curate_insights(
+    candidates: list[RawCandidate],
+    *,
+    config: KlemmaConfig,
+    ai: AIProvider,
+    state,
+    dissertation_context: str = "",
+    klemma_home=None,
+    project_root=None,
+    project_chain=None,
+    language: str = "Russian",
+) -> list[CuratedInsight]:
+    """Stage 3: LLM curation — one call, multi-objective ranking.
+
+    Based on:
+    - Nadkarni et al. 2025: LLM-as-a-judge for LBD filtering
+    - McNee et al. 2006: multi-objective (novelty + diversity + actionability)
+    - Si et al. 2024: enforce diversity via structural constraint
+    - Hummon & Doreian 1989: trajectory in every insight
+    - Kastrin et al. 2025: every insight must explain WHY and project WHERE
+    """
+    if not candidates:
+        return []
+
+    # Gather feedback history for prompt injection
+    feedback_summary = state.decisions.get_feedback_summary()
+
+    # Build candidates text for prompt
+    candidates_text = _format_candidates_for_prompt(candidates)
+
+    # Resolve prompt template
+    prompt_path = resolve_prompt(
+        "insight_curator.md",
+        klemma_home or "",
+        project_chain or [],
+    )
+    if not prompt_path:
+        logger.error("insight_curator.md prompt not found")
+        return []
+
+    prompt_text = ai.render_prompt(
+        prompt_path,
+        dissertation_context=dissertation_context,
+        candidates=candidates_text,
+        candidate_count=len(candidates),
+        feedback_summary=_format_feedback_for_prompt(feedback_summary),
+        language=language,
+    )
+
+    response = ai.call_json(
+        prompt_text,
+        "Select and rank the top 3-5 insights. Respond with JSON only.",
+        max_tokens=4096,
+    )
+    if not response:
+        logger.error("LLM curation returned empty response")
+        return []
+
+    return _parse_curated_insights(response, candidates)
+
+
+def _format_candidates_for_prompt(candidates: list[RawCandidate]) -> str:
+    """Format raw candidates as text for the LLM prompt."""
+    lines = []
+    for i, c in enumerate(candidates, 1):
+        if c.candidate_type == "blind_spot":
+            lines.append(
+                f"{i}. BLIND SPOT: section {c.section} has {c.source_count} sources "
+                f"(average: {c.average_count}), {c.gap_count} reference gaps, "
+                f"severity: {c.severity}"
+            )
+        elif c.candidate_type == "hidden_cluster":
+            lines.append(
+                f"{i}. HIDDEN CLUSTER: @{c.citekey_a} ({c.section_a}) ↔ "
+                f"@{c.citekey_b} ({c.section_b}), similarity: {c.similarity:.3f}"
+            )
+            if c.title_a:
+                lines.append(f"   A: {c.title_a[:80]}")
+            if c.title_b:
+                lines.append(f"   B: {c.title_b[:80]}")
+    return "\n".join(lines)
+
+
+def _format_feedback_for_prompt(feedback: dict) -> str:
+    """Format feedback summary for prompt injection."""
+    parts = []
+    if feedback.get("total_liked") or feedback.get("total_disliked"):
+        liked = feedback.get("liked_types", {})
+        disliked = feedback.get("disliked_types", {})
+        if liked:
+            items = ", ".join(f"{v} {k}" for k, v in liked.items())
+            parts.append(f"- Liked: {items}")
+        if disliked:
+            items = ", ".join(f"{v} {k}" for k, v in disliked.items())
+            parts.append(f"- Disliked: {items}")
+
+    notes = feedback.get("recent_notes", [])
+    if notes:
+        for note in notes[:5]:
+            parts.append(f"- Recent note: \"{note}\"")
+
+    return "\n".join(parts) if parts else "No feedback yet."
+
+
+def _parse_curated_insights(
+    response: dict,
+    candidates: list[RawCandidate],
+) -> list[CuratedInsight]:
+    """Parse LLM JSON response into CuratedInsight objects."""
+    raw_insights = response.get("insights", [])
+    if not isinstance(raw_insights, list):
+        logger.error("LLM response 'insights' is not a list")
+        return []
+
+    # Build candidate lookup by index (1-based in prompt)
+    candidate_map = {i + 1: c for i, c in enumerate(candidates)}
+
+    curated = []
+    seen_tags: dict[str, int] = {}
+
+    for item in raw_insights[:5]:  # Max 5 per Paterno 2009
+        if not isinstance(item, dict):
+            continue
+
+        tag = item.get("diversity_tag", "unknown")
+
+        # Enforce max 2 per diversity_tag (Si 2024)
+        if seen_tags.get(tag, 0) >= 2:
+            logger.debug("Diversity cap: skipping extra '%s' insight", tag)
+            continue
+        seen_tags[tag] = seen_tags.get(tag, 0) + 1
+
+        # Resolve source candidate
+        candidate_idx = item.get("candidate_index", 0)
+        source_candidate = candidate_map.get(candidate_idx)
+
+        # Build options (3-tier: Act / Bookmark / Dismiss per Paterno 2009)
+        sections = item.get("sections", [])
+        if source_candidate:
+            sections = sections or source_candidate.sections
+
+        options = [
+            {
+                "key": "A",
+                "title": item.get("action_title", "Act on this"),
+                "description": item.get("action_description", "Investigate this insight"),
+            },
+            {
+                "key": "B",
+                "title": "Bookmark",
+                "description": "Save for later — interesting but not urgent",
+            },
+            {
+                "key": "C",
+                "title": "Dismiss",
+                "description": "Not relevant — suppress similar insights",
+            },
+        ]
+
+        context = {}
+        if source_candidate:
+            context["candidate_type"] = source_candidate.candidate_type
+            if source_candidate.candidate_type == "blind_spot":
+                context["type"] = "blind_spot"
+                context["section"] = source_candidate.section
+                context["source_count"] = source_candidate.source_count
+                context["average_count"] = source_candidate.average_count
+                context["gap_count"] = source_candidate.gap_count
+            elif source_candidate.candidate_type == "hidden_cluster":
+                context["type"] = "hidden_cluster"
+                context["citekey_a"] = source_candidate.citekey_a
+                context["citekey_b"] = source_candidate.citekey_b
+                context["similarity"] = source_candidate.similarity
+                context["section_a"] = source_candidate.section_a
+                context["section_b"] = source_candidate.section_b
+                context["title_a"] = source_candidate.title_a
+                context["title_b"] = source_candidate.title_b
+
+        curated.append(CuratedInsight(
+            title=item.get("title", "Untitled insight"),
+            explanation=item.get("explanation", ""),
+            trajectory=item.get("trajectory", ""),
+            diversity_tag=tag,
+            novelty_score=float(item.get("novelty_score", 0)),
+            actionability_score=float(item.get("actionability_score", 0)),
+            candidate_type=source_candidate.candidate_type if source_candidate else "",
+            sections=sections,
+            options=options,
+            context=context,
+        ))
+
+    return curated
+
+
+def save_curated_insights_as_decisions(
+    insights: list[CuratedInsight], state
+) -> list[int]:
+    """Save curated insights as pending decisions with 3-tier options."""
+    decision_ids = []
+    for insight in insights:
+        context = {
+            **insight.context,
+            "title": insight.title,
+            "explanation": insight.explanation,
+            "trajectory": insight.trajectory,
+            "diversity_tag": insight.diversity_tag,
+        }
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context=context,
+            options=insight.options,
+            sections=insight.sections,
+        )
+        decision_ids.append(did)
+    return decision_ids
+
+
+def generate_curated_insights(
+    state,
+    *,
+    config: KlemmaConfig,
+    ai: Optional[AIProvider] = None,
+    project_store=None,
+    dissertation_context: str = "",
+    klemma_home=None,
+    project_root=None,
+    project_chain=None,
+    language: str = "Russian",
+    raw_mode: bool = False,
+) -> CuratedInsightsResult:
+    """Full pipeline: generate → suppress → curate (or raw mode).
+
+    Args:
+        raw_mode: If True, skip curation and return all raw candidates (old behavior).
+    """
+    # Check blocking first
+    is_blocked, pending_count, pending = check_insights_blocked(state)
+    if is_blocked:
+        return CuratedInsightsResult(
+            blocked=True,
+            pending_count=pending_count,
+        )
+
+    # Stage 1: Generate broadly
+    raw_result = generate_insights(state, project_store)
+    all_candidates = _candidates_from_insights(raw_result)
+
+    if not all_candidates:
+        return CuratedInsightsResult(raw_count=0)
+
+    # Raw mode — save all as decisions (old behavior)
+    if raw_mode:
+        decision_ids = save_insights_as_decisions(raw_result, state)
+        return CuratedInsightsResult(
+            raw_count=len(all_candidates),
+            suppressed_count=0,
+            curated_count=len(decision_ids),
+        )
+
+    # Stage 2: Heuristic suppression
+    survivors = suppress_candidates(all_candidates, state)
+
+    if not survivors:
+        return CuratedInsightsResult(
+            raw_count=len(all_candidates),
+            suppressed_count=len(all_candidates),
+        )
+
+    # Stage 3: LLM curation (requires AI)
+    if not ai:
+        # Fallback: save suppressed candidates as decisions without curation
+        # Convert survivors back to InsightsResult for save_insights_as_decisions
+        logger.warning("No AI backend — saving suppressed candidates without curation")
+        decision_ids = _save_raw_candidates_as_decisions(survivors, state)
+        return CuratedInsightsResult(
+            raw_count=len(all_candidates),
+            suppressed_count=len(all_candidates) - len(survivors),
+            curated_count=len(decision_ids),
+        )
+
+    curated = curate_insights(
+        survivors,
+        config=config,
+        ai=ai,
+        state=state,
+        dissertation_context=dissertation_context,
+        klemma_home=klemma_home,
+        project_root=project_root,
+        project_chain=project_chain,
+        language=language,
+    )
+
+    # Save curated insights as decisions
+    decision_ids = save_curated_insights_as_decisions(curated, state)
+
+    return CuratedInsightsResult(
+        insights=curated,
+        decision_ids=decision_ids,
+        raw_count=len(all_candidates),
+        suppressed_count=len(all_candidates) - len(survivors),
+        curated_count=len(curated),
+    )
+
+
+def _save_raw_candidates_as_decisions(
+    candidates: list[RawCandidate], state
+) -> list[int]:
+    """Save raw candidates as decisions (fallback when no AI)."""
+    decision_ids = []
+    for c in candidates:
+        if c.candidate_type == "blind_spot":
+            context = {
+                "type": "blind_spot",
+                "section": c.section,
+                "source_count": c.source_count,
+                "average_count": c.average_count,
+                "gap_count": c.gap_count,
+            }
+            options = [
+                {"key": "A", "title": "Search for sources",
+                 "description": f"Use 'klemma suggest' for section {c.section}"},
+                {"key": "B", "title": "Intentional gap",
+                 "description": "Skip — fewer sources is intentional"},
+            ]
+        else:
+            context = {
+                "type": "hidden_cluster",
+                "citekey_a": c.citekey_a,
+                "citekey_b": c.citekey_b,
+                "similarity": c.similarity,
+                "section_a": c.section_a,
+                "section_b": c.section_b,
+                "title_a": c.title_a,
+                "title_b": c.title_b,
+            }
+            options = [
+                {"key": "A", "title": "Explore connection",
+                 "description": f"@{c.citekey_a} ↔ @{c.citekey_b} — investigate"},
+                {"key": "B", "title": "Not relevant",
+                 "description": "Similarity is coincidental"},
+            ]
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context=context,
+            options=options,
+            sections=c.sections,
+        )
+        decision_ids.append(did)
     return decision_ids

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -185,7 +185,7 @@ class StateManager:
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 13  # bump this when adding new migrations
+        target = 14  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -458,6 +458,15 @@ class StateManager:
                 """CREATE INDEX IF NOT EXISTS idx_decisions_source
                    ON decisions(trigger_source) WHERE trigger_source IS NOT NULL"""
             )
+
+        if version < 14:
+            existing_dec = {
+                row[1] for row in conn.execute("PRAGMA table_info(decisions)")
+            }
+            if "note" not in existing_dec:
+                conn.execute("ALTER TABLE decisions ADD COLUMN note TEXT")
+            if "feedback" not in existing_dec:
+                conn.execute("ALTER TABLE decisions ADD COLUMN feedback TEXT")
 
         conn.execute(f"PRAGMA user_version = {target}")
 

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -126,7 +126,7 @@ class TestMigration:
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 13
+        assert version == 14
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -18,7 +18,7 @@ class TestMigrationV3:
     def test_schema_version_is_four(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 13
+        assert version == 14
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -13,7 +13,7 @@ def state(tmp_path):
 
 
 class TestDecisionsMigration:
-    """Verify v13 migration creates the decisions table."""
+    """Verify v14 migration creates the decisions table with note/feedback."""
 
     def test_decisions_table_exists(self, state):
         with state._conn() as conn:
@@ -25,10 +25,10 @@ class TestDecisionsMigration:
             }
             assert "decisions" in tables
 
-    def test_db_version_is_13(self, state):
+    def test_db_version_is_14(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-            assert version == 13
+            assert version == 14
 
     def test_decisions_columns(self, state):
         with state._conn() as conn:
@@ -47,6 +47,8 @@ class TestDecisionsMigration:
                 "rationale",
                 "sections",
                 "influenced_by",
+                "note",
+                "feedback",
             }
             assert expected == cols
 
@@ -274,3 +276,119 @@ class TestDecisionsRepository:
     def test_nonexistent_decision(self, state):
         assert state.decisions.get_decision(999) is None
         assert state.decisions.decide(999, "A") is False
+
+    def test_add_note(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[{"key": "A", "title": "Act"}],
+        )
+        result = state.decisions.add_note(decision_id, "сопоставить IIEE с SPS")
+        assert result is True
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["note"] == "сопоставить IIEE с SPS"
+
+    def test_add_note_overwrites(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight", context={}, options=[]
+        )
+        state.decisions.add_note(decision_id, "first note")
+        state.decisions.add_note(decision_id, "updated note")
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["note"] == "updated note"
+
+    def test_add_note_nonexistent(self, state):
+        result = state.decisions.add_note(999, "note")
+        assert result is False
+
+    def test_set_feedback_like(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "hidden_cluster"},
+            options=[],
+        )
+        result = state.decisions.set_feedback(decision_id, "like")
+        assert result is True
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["feedback"] == "like"
+
+    def test_set_feedback_dislike(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight", context={}, options=[]
+        )
+        result = state.decisions.set_feedback(decision_id, "dislike")
+        assert result is True
+
+        d = state.decisions.get_decision(decision_id)
+        assert d["feedback"] == "dislike"
+
+    def test_set_feedback_invalid(self, state):
+        decision_id = state.decisions.save_decision(
+            trigger_type="insight", context={}, options=[]
+        )
+        with pytest.raises(ValueError, match="feedback must be"):
+            state.decisions.set_feedback(decision_id, "neutral")
+
+    def test_set_feedback_nonexistent(self, state):
+        result = state.decisions.set_feedback(999, "like")
+        assert result is False
+
+    def test_get_feedback_summary_empty(self, state):
+        summary = state.decisions.get_feedback_summary()
+        assert summary["total_liked"] == 0
+        assert summary["total_disliked"] == 0
+        assert summary["recent_notes"] == []
+
+    def test_get_feedback_summary(self, state):
+        # Create insight decisions with different types and feedback
+        id1 = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[],
+        )
+        id2 = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[],
+        )
+        id3 = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "hidden_cluster"},
+            options=[],
+        )
+        id4 = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "hidden_cluster"},
+            options=[],
+        )
+
+        state.decisions.set_feedback(id1, "like")
+        state.decisions.set_feedback(id2, "like")
+        state.decisions.set_feedback(id3, "dislike")
+        state.decisions.set_feedback(id4, "like")
+
+        # Add a note
+        state.decisions.add_note(id1, "interesting IIEE pattern")
+
+        summary = state.decisions.get_feedback_summary()
+        assert summary["total_liked"] == 3
+        assert summary["total_disliked"] == 1
+        assert summary["liked_types"]["blind_spot"] == 2
+        assert summary["liked_types"]["hidden_cluster"] == 1
+        assert summary["disliked_types"]["hidden_cluster"] == 1
+        assert "interesting IIEE pattern" in summary["recent_notes"]
+
+    def test_feedback_summary_ignores_non_insight(self, state):
+        """Feedback summary only counts insight decisions, not briefings."""
+        id1 = state.decisions.save_decision(
+            trigger_type="briefing",
+            context={"type": "briefing_ctx"},
+            options=[],
+        )
+        state.decisions.set_feedback(id1, "like")
+
+        summary = state.decisions.get_feedback_summary()
+        assert summary["total_liked"] == 0

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -248,6 +248,27 @@ class TestSuppression:
         assert len(survivors) == 1
         assert survivors[0].section == "4.1"
 
+    def test_skipped_sections_not_suppressed(self, state):
+        """Skipped decisions do NOT suppress sections — only real choices do."""
+        # Create and skip an insight for section 3.1
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[{"key": "A", "title": "Act"}],
+            sections=["3.1"],
+        )
+        state.decisions.skip_decision(did)
+
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="3.1", sections=["3.1"],
+                source_count=1, average_count=10.0, severity="high",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 1  # NOT suppressed
+
     def test_preserves_valid_candidates(self, state):
         """Valid candidates pass through suppression."""
         candidates = [

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,152 @@
+"""Tests for Guided Serendipity insights — blind spots and hidden clusters."""
+
+import pytest
+
+from klemma.skills.insights import (
+    BlindSpot,
+    HiddenCluster,
+    InsightsResult,
+    detect_blind_spots,
+    detect_hidden_clusters,
+    generate_insights,
+    save_insights_as_decisions,
+)
+from klemma.state import StateManager
+
+
+@pytest.fixture
+def state(tmp_path):
+    db_path = tmp_path / "test.db"
+    sm = StateManager(db_path)
+    for i, (citekey, section, chapter) in enumerate([
+        ("paper_a1", "1.1", 1), ("paper_a2", "1.1", 1), ("paper_a3", "1.1", 1),
+        ("paper_a4", "1.1", 1), ("paper_a5", "1.1", 1), ("paper_a6", "1.1", 1),
+        ("paper_a7", "1.1", 1), ("paper_a8", "1.1", 1), ("paper_a9", "1.1", 1),
+        ("paper_a10", "1.1", 1),
+        ("paper_b1", "2.1", 2), ("paper_b2", "2.1", 2), ("paper_b3", "2.1", 2),
+        ("paper_b4", "2.1", 2), ("paper_b5", "2.1", 2), ("paper_b6", "2.1", 2),
+        ("paper_b7", "2.1", 2), ("paper_b8", "2.1", 2),
+        ("paper_c1", "3.1", 3),
+        ("paper_d1", "4.1", 4), ("paper_d2", "4.1", 4),
+    ]):
+        sm.register_sources([citekey])
+        sm.mark_completed(
+            citekey, note_path=f"@{citekey}.md",
+            primary_chapter=chapter, primary_section=section,
+        )
+        sm.update_source_info(citekey, title=f"Paper {citekey}", authors=f"Author {i}")
+        sm.sources.set_source_sections(citekey, [section], [chapter])
+    return sm
+
+
+class TestBlindSpots:
+    def test_detects_weak_sections(self, state):
+        spots = detect_blind_spots(state)
+        sections = {s.section for s in spots}
+        assert "3.1" in sections
+
+    def test_severity_assignment(self, state):
+        spots = detect_blind_spots(state)
+        spot_31 = next((s for s in spots if s.section == "3.1"), None)
+        assert spot_31 is not None
+        assert spot_31.severity == "high"
+
+    def test_empty_library(self, tmp_path):
+        sm = StateManager(tmp_path / "empty.db")
+        spots = detect_blind_spots(sm)
+        assert spots == []
+
+    def test_balanced_library(self, tmp_path):
+        sm = StateManager(tmp_path / "balanced.db")
+        for i in range(5):
+            ck = f"s{i}"
+            sm.register_sources([ck])
+            sm.mark_completed(ck, note_path=f"@{ck}.md")
+            sm.sources.set_source_sections(ck, ["1.1"], [1])
+        spots = detect_blind_spots(sm)
+        assert spots == []
+
+
+class TestHiddenClusters:
+    def test_finds_cross_section_similar_pairs(self, state):
+        vec_a = [1.0, 0.0, 0.0] * 10
+        vec_b = [0.99, 0.1, 0.0] * 10
+
+        state.save_embedding("paper_a1", vec_a, "test")
+        state.save_embedding("paper_b1", vec_b, "test")
+
+        clusters = detect_hidden_clusters(state, similarity_threshold=0.9)
+        assert len(clusters) >= 1
+        pair = clusters[0]
+        assert {pair.citekey_a, pair.citekey_b} == {"paper_a1", "paper_b1"}
+        assert pair.section_a != pair.section_b
+
+    def test_ignores_same_section_pairs(self, state):
+        vec = [1.0, 0.0, 0.0] * 10
+        state.save_embedding("paper_a1", vec, "test")
+        state.save_embedding("paper_a2", vec, "test")
+
+        clusters = detect_hidden_clusters(state)
+        same_section = [c for c in clusters if c.section_a == c.section_b]
+        assert same_section == []
+
+    def test_empty_embeddings(self, state):
+        clusters = detect_hidden_clusters(state)
+        assert clusters == []
+
+    def test_respects_max_pairs(self, state):
+        vec = [1.0, 0.0, 0.0] * 10
+        for ck in ["paper_a1", "paper_b1", "paper_c1", "paper_d1"]:
+            state.save_embedding(ck, vec, "test")
+
+        clusters = detect_hidden_clusters(state, similarity_threshold=0.5, max_pairs=2)
+        assert len(clusters) <= 2
+
+
+class TestGenerateInsights:
+    def test_returns_combined_result(self, state):
+        result = generate_insights(state)
+        assert isinstance(result, InsightsResult)
+        assert len(result.blind_spots) > 0
+
+
+class TestSaveInsightsAsDecisions:
+    def test_saves_blind_spot_decisions(self, state):
+        result = InsightsResult(
+            blind_spots=[
+                BlindSpot(section="3.1", source_count=1, average_count=10.0, severity="high"),
+                BlindSpot(section="4.1", source_count=3, average_count=10.0, severity="medium"),
+                BlindSpot(section="5.1", source_count=8, average_count=10.0, severity="low"),
+            ],
+        )
+        ids = save_insights_as_decisions(result, state)
+        assert len(ids) == 2
+
+        d = state.decisions.get_decision(ids[0])
+        assert d["trigger_type"] == "insight"
+        assert d["context_json"]["type"] == "blind_spot"
+        assert d["sections"] == ["3.1"]
+
+    def test_saves_cluster_decisions(self, state):
+        result = InsightsResult(
+            hidden_clusters=[
+                HiddenCluster(
+                    citekey_a="a2020", citekey_b="b2021",
+                    similarity=0.92, section_a="1.1", section_b="3.2",
+                    title_a="Paper A", title_b="Paper B",
+                ),
+            ],
+        )
+        ids = save_insights_as_decisions(result, state)
+        assert len(ids) == 1
+
+        d = state.decisions.get_decision(ids[0])
+        assert d["trigger_type"] == "insight"
+        assert d["context_json"]["type"] == "hidden_cluster"
+        assert "1.1" in d["sections"]
+        assert "3.2" in d["sections"]
+
+    def test_empty_insights_no_decisions(self, state):
+        result = InsightsResult()
+        ids = save_insights_as_decisions(result, state)
+        assert ids == []

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -6,10 +6,18 @@ from klemma.skills.insights import (
     BlindSpot,
     HiddenCluster,
     InsightsResult,
+    RawCandidate,
+    _candidates_from_insights,
+    _format_candidates_for_prompt,
+    _format_feedback_for_prompt,
+    _parse_curated_insights,
+    check_insights_blocked,
     detect_blind_spots,
     detect_hidden_clusters,
+    generate_curated_insights,
     generate_insights,
     save_insights_as_decisions,
+    suppress_candidates,
 )
 from klemma.state import StateManager
 
@@ -150,3 +158,324 @@ class TestSaveInsightsAsDecisions:
         result = InsightsResult()
         ids = save_insights_as_decisions(result, state)
         assert ids == []
+
+
+# ── Suppression tests ────────────────────────────────────────────────────
+
+
+class TestSuppression:
+    def test_removes_trivial_clusters(self, state):
+        """Clusters with similarity < 0.80 are suppressed."""
+        candidates = [
+            RawCandidate(
+                candidate_type="hidden_cluster",
+                section="1.1", sections=["1.1", "2.1"],
+                similarity=0.75, section_a="1.1", section_b="2.1",
+                citekey_a="a", citekey_b="b",
+            ),
+            RawCandidate(
+                candidate_type="hidden_cluster",
+                section="1.1", sections=["1.1", "3.1"],
+                similarity=0.90, section_a="1.1", section_b="3.1",
+                citekey_a="c", citekey_b="d",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 1
+        assert survivors[0].similarity == 0.90
+
+    def test_removes_duplicate_section_pairs(self, state):
+        """Only the first cluster per section pair survives."""
+        candidates = [
+            RawCandidate(
+                candidate_type="hidden_cluster",
+                section="1.1", sections=["1.1", "2.1"],
+                similarity=0.85, section_a="1.1", section_b="2.1",
+                citekey_a="a", citekey_b="b",
+            ),
+            RawCandidate(
+                candidate_type="hidden_cluster",
+                section="2.1", sections=["1.1", "2.1"],
+                similarity=0.82, section_a="2.1", section_b="1.1",
+                citekey_a="c", citekey_b="d",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 1
+
+    def test_removes_same_chapter_redundant_blind_spots(self, state):
+        """Keep only worst blind spot per chapter."""
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="1.1", sections=["1.1"],
+                source_count=3, average_count=10.0, severity="medium",
+            ),
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="1.2", sections=["1.2"],
+                source_count=1, average_count=10.0, severity="high",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 1
+        assert survivors[0].section == "1.2"  # worse (fewer sources)
+
+    def test_removes_already_decided_sections(self, state):
+        """Sections with existing decided insights are suppressed."""
+        # Create and decide an insight for section 3.1
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[{"key": "A", "title": "Act"}],
+            sections=["3.1"],
+        )
+        state.decisions.decide(did, "A")
+
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="3.1", sections=["3.1"],
+                source_count=1, average_count=10.0, severity="high",
+            ),
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="4.1", sections=["4.1"],
+                source_count=2, average_count=10.0, severity="medium",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 1
+        assert survivors[0].section == "4.1"
+
+    def test_preserves_valid_candidates(self, state):
+        """Valid candidates pass through suppression."""
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="3.1", sections=["3.1"],
+                source_count=1, average_count=10.0, severity="high",
+            ),
+            RawCandidate(
+                candidate_type="hidden_cluster",
+                section="1.1", sections=["1.1", "2.1"],
+                similarity=0.92, section_a="1.1", section_b="2.1",
+                citekey_a="a", citekey_b="b",
+            ),
+        ]
+        survivors = suppress_candidates(candidates, state)
+        assert len(survivors) == 2
+
+    def test_empty_candidates(self, state):
+        """Empty input returns empty output."""
+        survivors = suppress_candidates([], state)
+        assert survivors == []
+
+
+# ── Blocking tests ───────────────────────────────────────────────────────
+
+
+class TestBlocking:
+    def test_not_blocked_when_no_pending(self, state):
+        blocked, count, pending = check_insights_blocked(state)
+        assert blocked is False
+        assert count == 0
+
+    def test_blocked_when_pending_exist(self, state):
+        state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[],
+        )
+        blocked, count, pending = check_insights_blocked(state)
+        assert blocked is True
+        assert count == 1
+
+    def test_not_blocked_after_deciding(self, state):
+        did = state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[{"key": "A", "title": "Act"}],
+        )
+        state.decisions.decide(did, "A")
+
+        blocked, count, pending = check_insights_blocked(state)
+        assert blocked is False
+
+
+# ── Curation tests ───────────────────────────────────────────────────────
+
+
+class TestCuration:
+    def test_parse_curated_insights_basic(self):
+        """Parse a valid LLM response."""
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="3.1", sections=["3.1"],
+                source_count=1, average_count=10.0, severity="high",
+            ),
+        ]
+        response = {
+            "insights": [
+                {
+                    "candidate_index": 1,
+                    "title": "Section 3.1 needs attention",
+                    "explanation": "Very few sources for methodology",
+                    "trajectory": "Could reveal methodology gap",
+                    "diversity_tag": "gap",
+                    "novelty_score": 0.8,
+                    "actionability_score": 0.9,
+                    "sections": ["3.1"],
+                    "action_title": "Search for papers",
+                    "action_description": "Run klemma suggest for section 3.1",
+                },
+            ],
+        }
+        result = _parse_curated_insights(response, candidates)
+        assert len(result) == 1
+        assert result[0].title == "Section 3.1 needs attention"
+        assert result[0].diversity_tag == "gap"
+        assert result[0].context["type"] == "blind_spot"
+        assert len(result[0].options) == 3  # Act/Bookmark/Dismiss
+
+    def test_diversity_cap_enforced(self):
+        """Max 2 insights per diversity_tag."""
+        candidates = [
+            RawCandidate(candidate_type="blind_spot", section=f"{i}.1",
+                         sections=[f"{i}.1"], source_count=1, average_count=10.0)
+            for i in range(5)
+        ]
+        response = {
+            "insights": [
+                {"candidate_index": i + 1, "title": f"Insight {i}",
+                 "explanation": "x", "trajectory": "y",
+                 "diversity_tag": "gap", "novelty_score": 0.5,
+                 "actionability_score": 0.5, "sections": [f"{i}.1"],
+                 "action_title": "Act", "action_description": "Do"}
+                for i in range(5)
+            ],
+        }
+        result = _parse_curated_insights(response, candidates)
+        # Only 2 should survive the diversity cap
+        assert len(result) == 2
+
+    def test_max_five_insights(self):
+        """Never more than 5 insights."""
+        candidates = [
+            RawCandidate(candidate_type="blind_spot", section=f"{i}.1",
+                         sections=[f"{i}.1"], source_count=1, average_count=10.0)
+            for i in range(8)
+        ]
+        tags = ["gap", "bridge", "methodology", "anomaly", "gap", "bridge", "methodology", "anomaly"]
+        response = {
+            "insights": [
+                {"candidate_index": i + 1, "title": f"Insight {i}",
+                 "explanation": "x", "trajectory": "y",
+                 "diversity_tag": tags[i], "novelty_score": 0.5,
+                 "actionability_score": 0.5, "sections": [f"{i}.1"],
+                 "action_title": "Act", "action_description": "Do"}
+                for i in range(8)
+            ],
+        }
+        result = _parse_curated_insights(response, candidates)
+        assert len(result) <= 5
+
+    def test_empty_response(self):
+        """Empty LLM response returns empty list."""
+        result = _parse_curated_insights({}, [])
+        assert result == []
+
+    def test_invalid_response_format(self):
+        """Non-list 'insights' field returns empty list."""
+        result = _parse_curated_insights({"insights": "not a list"}, [])
+        assert result == []
+
+
+class TestCandidateConversion:
+    def test_candidates_from_insights(self):
+        result = InsightsResult(
+            blind_spots=[
+                BlindSpot(section="3.1", source_count=1, average_count=10.0, severity="high"),
+                BlindSpot(section="5.1", source_count=8, average_count=10.0, severity="low"),
+            ],
+            hidden_clusters=[
+                HiddenCluster(
+                    citekey_a="a", citekey_b="b",
+                    similarity=0.9, section_a="1.1", section_b="2.1",
+                ),
+            ],
+        )
+        candidates = _candidates_from_insights(result)
+        # Only medium/high blind spots + all clusters
+        assert len(candidates) == 2
+        assert candidates[0].candidate_type == "blind_spot"
+        assert candidates[1].candidate_type == "hidden_cluster"
+
+
+class TestFormatting:
+    def test_format_candidates_for_prompt(self):
+        candidates = [
+            RawCandidate(
+                candidate_type="blind_spot",
+                section="3.1", sections=["3.1"],
+                source_count=1, average_count=10.0, gap_count=5, severity="high",
+            ),
+        ]
+        text = _format_candidates_for_prompt(candidates)
+        assert "BLIND SPOT" in text
+        assert "3.1" in text
+
+    def test_format_feedback_for_prompt_empty(self):
+        text = _format_feedback_for_prompt({"total_liked": 0, "total_disliked": 0, "recent_notes": []})
+        assert text == "No feedback yet."
+
+    def test_format_feedback_for_prompt_with_data(self):
+        text = _format_feedback_for_prompt({
+            "total_liked": 2, "total_disliked": 1,
+            "liked_types": {"gap": 2},
+            "disliked_types": {"bridge": 1},
+            "recent_notes": ["test note"],
+        })
+        assert "Liked" in text
+        assert "Disliked" in text
+        assert "test note" in text
+
+
+# ── Integration tests ────────────────────────────────────────────────────
+
+
+class TestGenerateCuratedInsights:
+    def test_blocked_returns_early(self, state):
+        """If pending insights exist, returns blocked result."""
+        state.decisions.save_decision(
+            trigger_type="insight",
+            context={"type": "blind_spot"},
+            options=[],
+        )
+        from klemma.config import KlemmaConfig
+        cfg = KlemmaConfig()
+
+        result = generate_curated_insights(state, config=cfg)
+        assert result.blocked is True
+        assert result.pending_count == 1
+
+    def test_raw_mode_skips_curation(self, state):
+        """Raw mode saves all candidates without LLM."""
+        from klemma.config import KlemmaConfig
+        cfg = KlemmaConfig()
+
+        result = generate_curated_insights(state, config=cfg, raw_mode=True)
+        # With the fixture data, there should be blind spots
+        assert result.raw_count > 0
+        assert result.suppressed_count == 0
+
+    def test_empty_library_returns_zero(self, tmp_path):
+        """Empty library returns no insights."""
+        sm = StateManager(tmp_path / "empty.db")
+        from klemma.config import KlemmaConfig
+        cfg = KlemmaConfig()
+
+        result = generate_curated_insights(sm, config=cfg)
+        assert result.raw_count == 0
+        assert result.blocked is False

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -217,6 +217,13 @@ TEMPLATE_CONTEXTS = {
         "similar_sources": [],
         "previous_decisions": [],
     },
+    "insight_curator.md": {
+        "language": "Russian",
+        "dissertation_context": "Test dissertation context",
+        "candidates": "1. BLIND SPOT: section 3.1 has 1 sources (average: 10.0), severity: high",
+        "candidate_count": 1,
+        "feedback_summary": "No feedback yet.",
+    },
     "reconstruct.md": {
         "paper_title": "Test Paper",
         "abstract": "An abstract",

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 13
+    assert version == 14
     conn.close()
 
 


### PR DESCRIPTION
## Summary

- Replace raw SQL dump (57 candidates) with **generate → suppress → curate** pipeline
- Stage 2: heuristic suppression (~36% reduction, no LLM) — already-decided sections, trivial clusters (<0.80), duplicate pairs, same-chapter redundancy
- Stage 3: LLM curation via `insight_curator.md` — multi-objective ranking (novelty × actionability × trajectory × diversity), max 5 insights, max 2 per diversity_tag
- **Blocking**: refuses to generate new insights when pending exist
- **Feedback loop**: `decisions note/like/dislike` subcommands, injected into next curation prompt
- **3-tier options** per insight (Act/Bookmark/Dismiss) per Paterno 2009
- Migration v14: `note` + `feedback` columns on decisions table
- `--raw` flag preserves old behavior for debugging

Part of #231

## Release Note

### Problem
`klemma insights` dumped ALL raw SQL/embedding candidates (57 for a 335-source library) as pending decisions, creating inbox anxiety instead of helping the researcher. No filtering between detection and presentation.

### Academic Foundation
8 papers ground the design: Nadkarni et al. 2025 (LLM-as-a-judge for LBD filtering), Paterno et al. 2009 (tiered severity → 10%→29% compliance), Phansalkar et al. 2013 (suppression-first → 36% reduction), McNee et al. 2006 (multi-objective ranking), Si et al. 2024 (LLMs bad at diversity → structural enforcement), Eppler & Mengis 2004 (inverted U-curve, 3-5 clean insights), Hummon & Doreian 1989 (trajectory scoring), Kastrin et al. 2025 (interpretability filters false positives).

### Implementation
3-stage pipeline in `skills/insights.py`: generate broadly (existing SQL+embeddings) → suppress heuristically (4 rules, no LLM) → curate with LLM (1 call, `prompts/insight_curator.md`). New dataclasses `RawCandidate`, `CuratedInsight`, `CuratedInsightsResult`. Feedback loop via `DecisionsRepository.add_note()`, `set_feedback()`, `get_feedback_summary()` — aggregated and injected into curation prompt. CLI: `--raw`/`--model` flags, Rich panels with diversity-tag coloring, `decisions note/like/dislike` subcommands.

### Results
1512 tests pass (59 new: 26 decisions + 33 insights). Lint clean. Manually verified on 335-source dissertation library: 33 raw → suppressed → 3 curated insights with trajectories. Blocking, feedback, and `--raw` all verified.

## Test plan
- [x] `python -m pytest tests/test_insights.py tests/test_decisions.py -q` — 59 pass
- [x] `python -m pytest tests/ -q` — 1512 pass
- [x] `ruff check src/ tests/` — clean
- [x] Manual: `klemma insights` shows 3-5 Rich panels
- [x] Manual: `klemma insights --raw` shows old behavior
- [x] Manual: blocking works on second run
- [x] Manual: `klemma decide <ID> A` resolves insight
- [x] Manual: `klemma decisions show <ID>` shows WHY/WHERE/options

🤖 Generated with [Claude Code](https://claude.com/claude-code)