### PR TITLE
feat(saas): Wire BlockView to real API (#239)

### DIFF
--- a/saas/dashboard/index.html
+++ b/saas/dashboard/index.html
@@ -34,10 +34,10 @@
       })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=108182650', 'ym');
       ym(108182650, 'init', {ssr:true, webvisor:true, trackHash:true, clickmap:true, ecommerce:"dataLayer", referrer: document.referrer, url: location.href, accurateTrackBounce:true, trackLinks:true});
     </script>
-    <noscript><div><img src="https://mc.yandex.ru/watch/108182650" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     <!-- /Yandex.Metrika counter -->
   </head>
   <body>
+    <noscript><div><img src="https://mc.yandex.ru/watch/108182650" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -249,6 +249,20 @@ export const write = {
     }),
 }
 
+// Block drafts (MD files on disk)
+export const blocks = {
+  get: (projectId: string, sectionId: string, blockId: string) =>
+    request<{ section_id: string; block_id: string; text: string; word_count: number }>(
+      `/projects/${projectId}/blocks/${sectionId}/${blockId}`
+    ),
+
+  save: (projectId: string, sectionId: string, blockId: string, text: string) =>
+    request<{ section_id: string; block_id: string; text: string; word_count: number }>(
+      `/projects/${projectId}/blocks/${sectionId}/${blockId}`,
+      { method: 'PUT', body: JSON.stringify({ text }) }
+    ),
+}
+
 // Research (literature review generation + stored reports)
 export const research = {
   generate: (section: string, projectId?: string) =>

--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -240,6 +240,15 @@ export const usage = {
     }>('/usage/me'),
 }
 
+// Write (draft generation)
+export const write = {
+  draft: (section: string, projectId?: string) =>
+    request<{ job_id: string; status: string; section: string; task_type: string }>('/write/draft', {
+      method: 'POST',
+      body: JSON.stringify({ section, project_id: projectId }),
+    }),
+}
+
 // Research (literature review generation + stored reports)
 export const research = {
   generate: (section: string, projectId?: string) =>

--- a/saas/dashboard/src/assets/main.css
+++ b/saas/dashboard/src/assets/main.css
@@ -50,6 +50,9 @@
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }
 
+/* Clickable elements */
+button, [role="button"] { cursor: pointer; }
+
 /* Base */
 body {
   font-family: var(--font-body);

--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -18,11 +18,11 @@ function switchProject(projectId: string) {
     // Navigate to same module within new project
     const modules = ['map', 'feed', 'library', 'health', 'outline', 'coverage', 'research']
     const suffix = route.path.slice(currentParam.length + 2) // strip /projectId/
-    const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'health'
+    const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'map'
     router.push(`/${projectId}/${module}`)
   } else {
-    // Currently on global page — go to health of new project
-    router.push(`/${projectId}/health`)
+    // Currently on global page — go to map of new project
+    router.push(`/${projectId}/map`)
   }
 }
 

--- a/saas/dashboard/src/views/BlockView.vue
+++ b/saas/dashboard/src/views/BlockView.vue
@@ -78,26 +78,32 @@ async function loadSectionData() {
     section.value.id = sectionId.value
     block.value.id = blockIdParam.value
 
-    const sectionData = await apiProjects.sectionSources(sectionId.value)
+    // Fire sectionSources + project list in parallel
+    const [sectionData, projectsData] = await Promise.all([
+      apiProjects.sectionSources(sectionId.value),
+      userProjects.list(),
+    ])
 
-    const fragments: Fragment[] = []
-    for (const citekey of sectionData.citekeys.slice(0, 8)) {
-      try {
-        const src = await apiLibrary.get(citekey)
-        for (const f of (src.fragments || []).slice(0, 2)) {
-          fragments.push({ source: citekey, sourceTitle: src.title || citekey, year: src.year || null, text: f.text || '', intent: f.citation_intent || 'background', page: f.page_number || null })
-        }
-      } catch { /* skip unavailable sources */ }
-    }
-    block.value.fragments = fragments
-
-    // Resolve section name from project outline
-    const projectsData = await userProjects.list()
+    // Resolve section name immediately (no extra wait)
     const project = projectsData.projects.find(p => p.project_id === projectId.value)
     const outlineSection = project?.outline?.find(s => s.id === sectionId.value)
     section.value.name = outlineSection?.name || `Раздел ${sectionId.value}`
     block.value.title = outlineSection?.name || `Раздел ${sectionId.value}`
-    if (fragments.length > 0) block.value.status = 'empty'
+
+    // Fetch all source details in parallel
+    const citekeys = sectionData.citekeys.slice(0, 8)
+    const sourceResults = await Promise.allSettled(citekeys.map(k => apiLibrary.get(k)))
+
+    const fragments: Fragment[] = []
+    for (let i = 0; i < citekeys.length; i++) {
+      const result = sourceResults[i]
+      if (result?.status !== 'fulfilled') continue
+      const src = result.value
+      for (const f of (src.fragments || []).slice(0, 2)) {
+        fragments.push({ source: citekeys[i]!, sourceTitle: src.title || citekeys[i]!, year: src.year || null, text: f.text || '', intent: f.citation_intent || 'background', page: f.page_number || null })
+      }
+    }
+    block.value.fragments = fragments
 
   } catch (e: any) {
     loadError.value = e.message || 'Ошибка загрузки данных'

--- a/saas/dashboard/src/views/BlockView.vue
+++ b/saas/dashboard/src/views/BlockView.vue
@@ -54,20 +54,36 @@ function startEditing() {
   editText.value = currentText.value
   isEditing.value = true
   nextTick(() => {
-    const el = document.querySelector('.draft-editor') as HTMLTextAreaElement
-    if (el) { el.focus(); el.selectionStart = el.value.length }
+    const el = editorEl.value
+    if (!el) return
+    el.innerText = currentText.value
+    el.focus()
+    moveCursorToEnd(el)
   })
 }
 
-function saveEdit() {
+function commitText() {
+  // editText is always ghost-free — updated by onEditorInput before ghost appears
   block.value.generatedText = editText.value
   block.value.draftText = editText.value
   block.value.status = 'draft'
+}
+
+function autoSave() {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    commitText()
+    saveStatus.value = 'saved'
+    setTimeout(() => { if (saveStatus.value === 'saved') saveStatus.value = 'idle' }, 2500)
+  }, 800)
+}
+
+function closeEditor() {
+  clearGhost() // removes ghost from DOM, editText stays clean
+  if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+  commitText() // reads editText.value — always safe
+  saveStatus.value = 'idle'
   isEditing.value = false
-  pushAssistantMessage('Текст сохранён. Проверяю цитирование...')
-  setTimeout(() => {
-    pushAssistantMessage('Все 5 ссылок валидны. [@olhovikINFORMATIONMODELMARITIME2018] используется как method — корректно для аргумента о нефиксированности трассы.')
-  }, 1500)
 }
 
 async function generateDraft() {
@@ -90,6 +106,156 @@ async function generateDraft() {
   generating.value = false
   generatingProgress.value = ''
   pushAssistantMessage(`Готово — ${block.value.generatedText.split(/\s+/).length} слов, ${block.value.fragments.length} источников. Нажмите на текст чтобы отредактировать.`)
+}
+
+// ── Ghost text (inline AI continuation) ──────────────────────────────────
+
+const editorEl = ref<HTMLElement>()
+const ghostText = ref('')
+const isSpinning = ref(false)
+let ghostTimer: ReturnType<typeof setTimeout> | null = null
+let streamingTimer: ReturnType<typeof setTimeout> | null = null
+let spinInterval: ReturnType<typeof setInterval> | null = null
+
+const saveStatus = ref<'idle' | 'saving' | 'saved'>('idle')
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function moveCursorToEnd(el: HTMLElement) {
+  const range = document.createRange()
+  const sel = window.getSelection()
+  range.selectNodeContents(el)
+  range.collapse(false)
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+function clearGhost() {
+  ghostText.value = ''
+  isSpinning.value = false
+  if (streamingTimer) { clearTimeout(streamingTimer); streamingTimer = null }
+  if (ghostTimer) { clearTimeout(ghostTimer); ghostTimer = null }
+  if (spinInterval) { clearInterval(spinInterval); spinInterval = null }
+  editorEl.value?.querySelectorAll('.ghost-text, .ghost-spinner').forEach(s => s.remove())
+}
+
+function acceptGhost() {
+  const el = editorEl.value
+  if (!el || !ghostText.value) return
+  el.querySelectorAll('.ghost-text').forEach(ghost => {
+    ghost.replaceWith(document.createTextNode(ghost.textContent || ''))
+  })
+  editText.value = el.innerText
+  ghostText.value = ''
+  if (streamingTimer) { clearTimeout(streamingTimer); streamingTimer = null }
+  moveCursorToEnd(el)
+  autoSave()
+  pushAssistantMessage('Предложение принято. Продолжайте.')
+}
+
+function getMockSuggestion(text: string): string {
+  const lower = text.toLowerCase()
+  if (lower.includes('грузопоток') || lower.includes('арктик спг') || lower.includes('ямал')) {
+    return ' По прогнозу Министерства транспорта РФ, к 2030 году объём перевозок по СМП должен достичь 150 млн тонн, что потребует существенного расширения ледокольного флота и инфраструктуры навигационно-гидрографического обеспечения.'
+  }
+  if (lower.includes('ледов') || lower.includes('лёд') || lower.includes('концентрац')) {
+    return ' Систематические наблюдения ведёт Арктический и антарктический научно-исследовательский институт (ААНИИ), однако точность краткосрочных прогнозов снижается в периоды активной циклонической деятельности.'
+  }
+  if (lower.includes('прогноз') || lower.includes('точност') || lower.includes('нейросет')) {
+    return ' Применение нейросетевых моделей позволяет повысить точность прогнозирования концентрации морского льда на 15–25% по сравнению с детерминированными численными методами [@bidenkoGeoinformacionnayaProceduraOcenki2022].'
+  }
+  if (lower.includes('навигац') || lower.includes('судоходств') || lower.includes('маршрут')) {
+    return ' Критическим периодом для безопасной навигации являются сентябрь–октябрь: первый осенний ледостав в Восточно-Сибирском море создаёт трудно предсказуемые условия для транзитных рейсов.'
+  }
+  return ' Данный аспект имеет принципиальное значение для разработки методики оценки качества нейросетевых прогнозов ледовой обстановки в акватории Северного морского пути [@bidenkoGeoinformacionnayaProceduraOcenki2022].'
+}
+
+function fetchGhostSuggestion() {
+  const text = editText.value.trim()
+  if (text.length < 30) return
+
+  const suggestion = getMockSuggestion(text)
+  const el = editorEl.value
+  if (!el) return
+
+  // Phase 1: spinner  · ·· ···
+  isSpinning.value = true
+  const spinnerSpan = document.createElement('span')
+  spinnerSpan.className = 'ghost-spinner'
+  spinnerSpan.style.color = 'var(--color-ink-muted)'
+  spinnerSpan.style.opacity = '0.7'
+  spinnerSpan.style.pointerEvents = 'none'
+  spinnerSpan.style.userSelect = 'none'
+  spinnerSpan.style.marginLeft = '6px'
+  spinnerSpan.style.letterSpacing = '3px'
+  spinnerSpan.style.fontSize = '11px'
+  spinnerSpan.style.border = '1px solid var(--color-rule)'
+  spinnerSpan.style.borderRadius = '999px'
+  spinnerSpan.style.padding = '1px 7px 2px'
+  spinnerSpan.style.verticalAlign = 'middle'
+  spinnerSpan.style.display = 'inline-block'
+  el.appendChild(spinnerSpan)
+
+  let dots = 1
+  spinnerSpan.textContent = '·'
+  spinInterval = setInterval(() => {
+    if (!el.contains(spinnerSpan)) { clearInterval(spinInterval!); spinInterval = null; return }
+    dots = dots >= 3 ? 1 : dots + 1
+    spinnerSpan.textContent = '·'.repeat(dots)
+  }, 200)
+
+  // Phase 2: after one full dot cycle (600ms) — replace with full text at once
+  streamingTimer = setTimeout(() => {
+    if (spinInterval) { clearInterval(spinInterval); spinInterval = null }
+    if (!el.contains(spinnerSpan)) return
+    spinnerSpan.remove()
+    isSpinning.value = false
+
+    const ghostSpan = document.createElement('span')
+    ghostSpan.className = 'ghost-text'
+    ghostSpan.style.color = 'var(--color-ink-muted)'
+    ghostSpan.style.opacity = '0.4'
+    ghostSpan.style.pointerEvents = 'none'
+    ghostSpan.style.userSelect = 'none'
+    ghostSpan.textContent = suggestion
+    el.appendChild(ghostSpan)
+    ghostText.value = suggestion
+  }, 600)
+}
+
+function onEditorInput() {
+  clearGhost()
+  editText.value = editorEl.value?.innerText || ''
+  autoSave()
+  if (editText.value.trim().length < 30) return
+  ghostTimer = setTimeout(fetchGhostSuggestion, 700)
+}
+
+function onEditorKeydown(e: KeyboardEvent) {
+  if (e.key === 'Tab' && ghostText.value) {
+    e.preventDefault()
+    acceptGhost()
+    return
+  }
+  if (e.key === 'Escape') {
+    clearGhost()
+    return
+  }
+  if (e.metaKey && e.key === 'Enter') {
+    e.preventDefault()
+    closeEditor()
+  }
+}
+
+function onEditorPaste(e: ClipboardEvent) {
+  e.preventDefault()
+  const text = e.clipboardData?.getData('text/plain') || ''
+  const sel = window.getSelection()
+  if (!sel?.rangeCount) return
+  sel.deleteFromDocument()
+  const node = document.createTextNode(text)
+  sel.getRangeAt(0).insertNode(node)
+  sel.collapseToEnd()
+  editText.value = editorEl.value?.innerText || ''
 }
 
 // ── Fragment search ──────────────────────────────────────────────────────
@@ -165,6 +331,11 @@ async function sendUserMessage() {
   await new Promise(r => setTimeout(r, 1000))
   pushAssistantMessage(`В библиотеке есть 2 дополнительных источника по этой теме. Попробуйте найти их через поиск справа: «грузопоток 2024» или «арктик спг».`)
 }
+
+// Hide "Сохранено" badge the moment ghost spinner kicks in
+watch(isSpinning, (spinning) => {
+  if (spinning) saveStatus.value = 'idle'
+})
 
 // Watch text edits to trigger AI reactions
 watch(isEditing, (editing) => {
@@ -254,16 +425,33 @@ function timeAgo(d: Date): string {
 
             <!-- Editing mode -->
             <div v-else-if="isEditing">
-              <textarea
-                v-model="editText"
-                class="draft-editor w-full px-8 py-6 text-[15px] text-[var(--color-ink)] leading-[1.8] bg-transparent focus:outline-none resize-none font-[var(--font-body)]"
-                style="min-height: 40vh;"
-                @keydown.meta.enter="saveEdit"
-              />
-              <div class="flex items-center gap-2 border-t border-[var(--color-rule-light)] px-6 py-2.5">
-                <button @click="saveEdit" class="rounded-md bg-[var(--color-accent)] px-4 py-1.5 text-sm font-medium text-white hover:bg-[var(--color-accent-deep)] transition-colors">Сохранить</button>
-                <button @click="isEditing = false" class="rounded-md px-3 py-1.5 text-sm text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Отмена</button>
-                <span class="ml-auto font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)]">{{ editWordCount }} слов &middot; &#8984;Enter</span>
+              <div class="relative">
+                <div
+                  ref="editorEl"
+                  contenteditable="true"
+                  spellcheck="false"
+                  class="draft-editor w-full px-8 py-6 text-[15px] text-[var(--color-ink)] leading-[1.8] focus:outline-none font-[var(--font-body)]"
+                  style="min-height: 40vh; white-space: pre-wrap; word-break: break-word;"
+                  @input="onEditorInput"
+                  @keydown="onEditorKeydown"
+                  @paste.prevent="onEditorPaste"
+                />
+                <transition name="ghost-hint">
+                  <div v-if="ghostText && !isSpinning"
+                    class="absolute bottom-3 right-3 flex items-center gap-1.5 rounded-md bg-[var(--color-paper-warm)] border border-[var(--color-rule)] px-2.5 py-1 text-xs text-[var(--color-ink-muted)] shadow-sm pointer-events-none select-none">
+                    <kbd class="font-[var(--font-mono)] text-[var(--color-accent)] font-semibold">Tab</kbd>
+                    <span>принять</span>
+                  </div>
+                </transition>
+              </div>
+              <div class="flex items-center gap-3 border-t border-[var(--color-rule-light)] px-6 py-2.5">
+                <!-- Autosave status -->
+                <transition name="ghost-hint">
+                  <span v-if="saveStatus === 'saved'" class="text-xs text-[var(--color-ok)]">Сохранено ✓</span>
+                </transition>
+                <div class="flex-1" />
+                <span class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)]">{{ editWordCount }} слов</span>
+                <button @click="closeEditor" class="rounded-md px-3 py-1.5 text-sm text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Закрыть</button>
               </div>
             </div>
 
@@ -393,3 +581,25 @@ function timeAgo(d: Date): string {
     </div>
   </AppLayout>
 </template>
+
+<style scoped>
+.ghost-text {
+  color: var(--color-ink-muted);
+  opacity: 0.38;
+  pointer-events: none;
+  user-select: none;
+}
+
+[contenteditable]:focus {
+  outline: none;
+}
+
+.ghost-hint-enter-active,
+.ghost-hint-leave-active {
+  transition: opacity 0.15s ease;
+}
+.ghost-hint-enter-from,
+.ghost-hint-leave-to {
+  opacity: 0;
+}
+</style>

--- a/saas/dashboard/src/views/BlockView.vue
+++ b/saas/dashboard/src/views/BlockView.vue
@@ -3,40 +3,108 @@ import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
 import { formatMarkdown } from '@/utils/markdown'
+import { projects as apiProjects, library as apiLibrary, userProjects, process as apiProcess, write as apiWrite } from '@/api/client'
 
 const route = useRoute()
 const router = useRouter()
 
-// ── Mock data ────────────────────────────────────────────────────────────
+// ── Route params ─────────────────────────────────────────────────────────
+const projectId = computed(() => route.params.projectId as string | undefined)
+const sectionId = computed(() => (route.params.sectionId as string) || '1.1')
+const blockIdParam = computed(() => (route.params.blockId as string) || 'b1')
+const isDemoMode = computed(() => !route.params.projectId)
 
-const section = ref({
-  id: '1.1',
-  name: 'Потребности пользователей НГГМИ',
-  thesis: 'Рост грузопотока по СМП создаёт потребность в оперативных ледовых прогнозах',
-})
+// ── Fragment type ─────────────────────────────────────────────────────────
+interface Fragment {
+  source: string
+  sourceTitle: string
+  year: number | null
+  text: string
+  intent: string
+  page: number | null
+}
+
+// ── Section / block / chapter state ──────────────────────────────────────
+const section = ref({ id: '1.1', name: '', thesis: '' })
 
 const block = ref({
-  id: 'b1.1.1',
-  title: 'Стратегическое значение СМП и рост грузопотока',
+  id: 'b1',
+  title: '',
   wordTarget: 350,
-  status: 'draft' as 'draft' | 'outlined' | 'empty',
-  draftText: 'Северный морской путь (СМП) является исторически сложившейся транспортной артерией России в Арктике. Транспортная стратегия РФ до 2035 года определяет СМП как «единую национальную транспортную коммуникацию», а план развития инфраструктуры предусматривает увеличение грузопотока до 80 млн тонн к 2024 году и 150 млн тонн к 2030 году.',
+  status: 'empty' as 'draft' | 'outlined' | 'empty',
+  draftText: '',
   generatedText: '',
-  fragments: [
-    { source: 'zhuravelSevernyyMorckoyPut2020', sourceTitle: 'Северный морской путь: проблемы, возможности, решения', year: 2020, text: 'Грузопоток по СМП вырос с 7,5 млн тонн в 2016 г. до 34,9 млн тонн в 2022 г., что связано с развитием проектов «Ямал СПГ» и «Арктик СПГ-2».', intent: 'background', page: 12 },
-    { source: 'kuvatovPotencialSevernogoMorskogo2014', sourceTitle: 'Потенциал Северного морского пути', year: 2014, text: 'Экономический потенциал СМП определяется сокращением длины маршрута из Европы в Восточную Азию на 30-40% по сравнению с маршрутом через Суэцкий канал.', intent: 'background', page: 45 },
-    { source: 'Angudovich2025', sourceTitle: 'Перспективы развития арктического судоходства', year: 2025, text: 'Несмотря на рост грузоперевозок, навигационные риски остаются основным сдерживающим фактором: ледовые условия в переходные сезоны создают наибольшую неопределённость для планирования маршрутов.', intent: 'background', page: 3 },
-    { source: 'olhovikINFORMATIONMODELMARITIME2018', sourceTitle: 'Information Model of Maritime Activities in the Arctic Zone', year: 2018, text: 'The non-fixed nature of the Northern Sea Route necessitates real-time monitoring of ice conditions — unlike fixed waterways, vessels must continuously adapt routes based on current ice situation.', intent: 'method', page: 8 },
-    { source: 'RasporyazheniePravitelstvaRossiyskoy', sourceTitle: 'Транспортная стратегия РФ до 2035 года', year: 2021, text: 'СМП определяется как «единая национальная транспортная коммуникация в Арктике»; предусматривается круглогодичная навигация к 2030 году.', intent: 'background', page: null },
-  ],
+  fragments: [] as Fragment[],
   prevBlock: null as { id: string; title: string } | null,
-  nextBlock: { id: 'b1.1.2', title: 'Потребности навигации в ледовой информации' },
+  nextBlock: null as { id: string; title: string } | null,
 })
 
-const chapter = ref({
-  number: 1,
-  thesis: 'Существующие системы НГО не обеспечивают достаточную точность прогнозов',
-})
+const chapter = ref({ number: 1, thesis: '' })
+
+// ── Loading state ─────────────────────────────────────────────────────────
+const loading = ref(false)
+const loadError = ref('')
+
+// ── Static mock data (demo mode only) ─────────────────────────────────────
+const MOCK_FRAGMENTS: Fragment[] = [
+  { source: 'zhuravelSevernyyMorckoyPut2020', sourceTitle: 'Северный морской путь: проблемы, возможности, решения', year: 2020, text: 'Грузопоток по СМП вырос с 7,5 млн тонн в 2016 г. до 34,9 млн тонн в 2022 г., что связано с развитием проектов «Ямал СПГ» и «Арктик СПГ-2».', intent: 'background', page: 12 },
+  { source: 'kuvatovPotencialSevernogoMorskogo2014', sourceTitle: 'Потенциал Северного морского пути', year: 2014, text: 'Экономический потенциал СМП определяется сокращением длины маршрута из Европы в Восточную Азию на 30-40% по сравнению с маршрутом через Суэцкий канал.', intent: 'background', page: 45 },
+  { source: 'Angudovich2025', sourceTitle: 'Перспективы развития арктического судоходства', year: 2025, text: 'Несмотря на рост грузоперевозок, навигационные риски остаются основным сдерживающим фактором: ледовые условия в переходные сезоны создают наибольшую неопределённость для планирования маршрутов.', intent: 'background', page: 3 },
+  { source: 'olhovikINFORMATIONMODELMARITIME2018', sourceTitle: 'Information Model of Maritime Activities in the Arctic Zone', year: 2018, text: 'The non-fixed nature of the Northern Sea Route necessitates real-time monitoring of ice conditions.', intent: 'method', page: 8 },
+  { source: 'RasporyazheniePravitelstvaRossiyskoy', sourceTitle: 'Транспортная стратегия РФ до 2035 года', year: 2021, text: 'СМП определяется как «единая национальная транспортная коммуникация в Арктике»; предусматривается круглогодичная навигация к 2030 году.', intent: 'background', page: null },
+]
+
+const MOCK_LIBRARY: Fragment[] = [
+  { source: 'alekseevaVliyanieIntensivnogoSudohodstva2024', sourceTitle: 'Влияние интенсивного судоходства на экологию АЗРФ', year: 2024, text: 'Фактический грузопоток по СМП в 2023 году составил 36,2 млн тонн, увеличившись на 3,7% по сравнению с 2022 годом.', intent: 'background', page: 7 },
+  { source: 'butakovRezultatyPrognozaGidrometeorologicheskih2025', sourceTitle: 'Результаты прогноза гидрометеорологических условий', year: 2025, text: 'Прогноз грузопотока по СМП на 2025 год — свыше 40 млн тонн при условии ввода в эксплуатацию третьей линии «Арктик СПГ-2».', intent: 'background', page: 15 },
+  { source: 'massonnet2012', sourceTitle: 'A model study of the impact of sea ice on Arctic climate', year: 2012, text: 'Баренцево море демонстрирует аномально высокую предсказуемость (skill score 0.7 на горизонте 4 мес).', intent: 'result_comparison', page: 1204 },
+  { source: 'smirnovMonitoringFizikomehanicheskogoSostoyaniya2020', sourceTitle: 'Мониторинг физико-механического состояния ледяного покрова', year: 2020, text: 'Существующая сеть гидрометеорологических наблюдений на побережье АЗРФ включает 48 станций, из которых 12 оснащены автоматическими средствами.', intent: 'background', page: 33 },
+  { source: 'bidenkoGeoinformacionnayaProceduraOcenki2022', sourceTitle: 'Геоинформационная процедура оценки ледовой обстановки', year: 2022, text: 'Предлагается процедура валидации, включающая три этапа: предобработку спутниковых данных, пространственное сопоставление и расчёт метрик.', intent: 'method', page: 89 },
+]
+
+// ── Data loading ──────────────────────────────────────────────────────────
+async function loadSectionData() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    if (isDemoMode.value) {
+      section.value = { id: sectionId.value, name: 'Потребности пользователей НГГМИ', thesis: 'Рост грузопотока по СМП создаёт потребность в оперативных ледовых прогнозах' }
+      block.value = { id: blockIdParam.value, title: 'Стратегическое значение СМП и рост грузопотока', wordTarget: 350, status: 'draft', draftText: 'Северный морской путь (СМП) является исторически сложившейся транспортной артерией России в Арктике. Транспортная стратегия РФ до 2035 года определяет СМП как «единую национальную транспортную коммуникацию», а план развития инфраструктуры предусматривает увеличение грузопотока до 80 млн тонн к 2024 году и 150 млн тонн к 2030 году.', generatedText: '', fragments: [...MOCK_FRAGMENTS], prevBlock: null, nextBlock: { id: 'b1.1.2', title: 'Потребности навигации в ледовой информации' } }
+      chapter.value = { number: 1, thesis: 'Существующие системы НГО не обеспечивают достаточную точность прогнозов' }
+      return
+    }
+
+    // Real API: load section sources + fragment details
+    section.value.id = sectionId.value
+    block.value.id = blockIdParam.value
+
+    const sectionData = await apiProjects.sectionSources(sectionId.value)
+
+    const fragments: Fragment[] = []
+    for (const citekey of sectionData.citekeys.slice(0, 8)) {
+      try {
+        const src = await apiLibrary.get(citekey)
+        for (const f of (src.fragments || []).slice(0, 2)) {
+          fragments.push({ source: citekey, sourceTitle: src.title || citekey, year: src.year || null, text: f.text || '', intent: f.citation_intent || 'background', page: f.page_number || null })
+        }
+      } catch { /* skip unavailable sources */ }
+    }
+    block.value.fragments = fragments
+
+    // Resolve section name from project outline
+    const projectsData = await userProjects.list()
+    const project = projectsData.projects.find(p => p.project_id === projectId.value)
+    const outlineSection = project?.outline?.find(s => s.id === sectionId.value)
+    section.value.name = outlineSection?.name || `Раздел ${sectionId.value}`
+    block.value.title = outlineSection?.name || `Раздел ${sectionId.value}`
+    if (fragments.length > 0) block.value.status = 'empty'
+
+  } catch (e: any) {
+    loadError.value = e.message || 'Ошибка загрузки данных'
+  } finally {
+    loading.value = false
+  }
+}
 
 // ── Writing ──────────────────────────────────────────────────────────────
 
@@ -88,24 +156,67 @@ function closeEditor() {
 
 async function generateDraft() {
   generating.value = true
-  generatingProgress.value = 'Собираю контекст цепочки...'
-  pushAssistantMessage('Начинаю генерацию. Контекст: тезис главы 1, тезис раздела 1.1, 5 привязанных фрагментов.')
-  await new Promise(r => setTimeout(r, 800))
+  generatingProgress.value = 'Собираю контекст...'
+  pushAssistantMessage(`Начинаю генерацию. ${block.value.fragments.length} фрагментов в контексте.`)
+
+  if (isDemoMode.value) {
+    await _generateDraftMock()
+    return
+  }
+
+  // Real API: POST /write/draft + poll
+  try {
+    generatingProgress.value = 'Ставлю задачу...'
+    const job = await apiWrite.draft(sectionId.value, projectId.value)
+    generatingProgress.value = 'Задача в очереди, жду результат...'
+
+    for (let attempt = 0; attempt < 30; attempt++) {
+      await new Promise(r => setTimeout(r, 2000))
+      const status = await apiProcess.jobStatus(job.job_id)
+      if (status.status === 'finished') {
+        const result = status.result || {}
+        if (result.text) {
+          block.value.generatedText = result.text
+          block.value.status = 'draft'
+          generating.value = false
+          generatingProgress.value = ''
+          pushAssistantMessage(`Черновик готов — ${block.value.generatedText.split(/\s+/).length} слов.`)
+          return
+        }
+        // Stub task returned — graceful fallback
+        pushAssistantMessage('Генератор черновиков ещё не подключён к SaaS API. Показываю демо-текст.')
+        await _generateDraftMock()
+        return
+      }
+      if (status.status === 'failed') {
+        pushAssistantMessage('Генерация завершилась ошибкой. Показываю демо-текст.')
+        await _generateDraftMock()
+        return
+      }
+      generatingProgress.value = `Генерирую... (${(attempt + 1) * 2}с)`
+    }
+    pushAssistantMessage('Таймаут. Показываю демо-текст.')
+    await _generateDraftMock()
+  } catch (e: any) {
+    pushAssistantMessage(`Ошибка API: ${e.message}. Показываю демо-текст.`)
+    await _generateDraftMock()
+  }
+}
+
+async function _generateDraftMock() {
   generatingProgress.value = `Анализирую ${block.value.fragments.length} фрагментов...`
   await new Promise(r => setTimeout(r, 600))
   generatingProgress.value = `Генерирую текст (~${block.value.wordTarget} слов)...`
   await new Promise(r => setTimeout(r, 2000))
+  block.value.generatedText = `Северный морской путь (СМП) является исторически сложившейся транспортной артерией России в Арктике, стратегическое значение которой определяется Транспортной стратегией РФ до 2035 года как «единой национальной транспортной коммуникации» [@RasporyazheniePravitelstvaRossiyskoy]. Грузопоток по СМП демонстрирует устойчивый рост: с 7,5 млн тонн в 2016 году до 34,9 млн тонн в 2022 году [@zhuravelSevernyyMorckoyPut2020].
 
-  block.value.generatedText = `Северный морской путь (СМП) является исторически сложившейся транспортной артерией России в Арктике, стратегическое значение которой определяется Транспортной стратегией РФ до 2035 года как «единой национальной транспортной коммуникации» [@RasporyazheniePravitelstvaRossiyskoy]. Грузопоток по СМП демонстрирует устойчивый рост: с 7,5 млн тонн в 2016 году до 34,9 млн тонн в 2022 году, что связано прежде всего с развитием проектов «Ямал СПГ» и «Арктик СПГ-2» [@zhuravelSevernyyMorckoyPut2020]. Фактический грузопоток в 2023 году составил 36,2 млн тонн, что подтверждает устойчивую тенденцию, хотя и с отставанием от плановых показателей [@alekseevaVliyanieIntensivnogoSudohodstva2024].
+Экономический потенциал СМП определяется сокращением длины маршрута из Европы в Восточную Азию на 30–40% по сравнению с маршрутом через Суэцкий канал [@kuvatovPotencialSevernogoMorskogo2014]. Вместе с тем навигационные риски остаются основным сдерживающим фактором развития арктического судоходства: ледовые условия в переходные сезоны создают наибольшую неопределённость для планирования маршрутов [@Angudovich2025].
 
-Экономический потенциал СМП определяется сокращением длины маршрута из Европы в Восточную Азию на 30–40% по сравнению с традиционным маршрутом через Суэцкий канал [@kuvatovPotencialSevernogoMorskogo2014]. Вместе с тем навигационные риски остаются основным сдерживающим фактором развития арктического судоходства: ледовые условия в переходные сезоны (октябрь–ноябрь, май–июнь) создают наибольшую неопределённость для планирования маршрутов [@Angudovich2025].
-
-Принципиальной особенностью СМП, отличающей его от фиксированных водных путей, является нефиксированность трассы: суда вынуждены непрерывно адаптировать маршрут в зависимости от текущей ледовой обстановки [@olhovikINFORMATIONMODELMARITIME2018]. Это обстоятельство формирует потребность в оперативном мониторинге и прогнозировании ледовой обстановки, что является отправной точкой настоящего исследования.`
-
+Принципиальной особенностью СМП является нефиксированность трассы: суда вынуждены непрерывно адаптировать маршрут в зависимости от текущей ледовой обстановки [@olhovikINFORMATIONMODELMARITIME2018]. Это формирует потребность в оперативном мониторинге и прогнозировании ледовой обстановки.`
   block.value.status = 'draft'
   generating.value = false
   generatingProgress.value = ''
-  pushAssistantMessage(`Готово — ${block.value.generatedText.split(/\s+/).length} слов, ${block.value.fragments.length} источников. Нажмите на текст чтобы отредактировать.`)
+  pushAssistantMessage(`Готово — ${block.value.generatedText.split(/\s+/).length} слов, ${block.value.fragments.length} источников.`)
 }
 
 // ── Ghost text (inline AI continuation) ──────────────────────────────────
@@ -261,16 +372,31 @@ function onEditorPaste(e: ClipboardEvent) {
 // ── Fragment search ──────────────────────────────────────────────────────
 
 const searchQuery = ref('')
-const searchResults = ref<typeof block.value.fragments>([])
+const searchResults = ref<Fragment[]>([])
 const searching = ref(false)
+const libraryItems = ref<Fragment[]>([])
 
-const mockLibrary = [
-  { source: 'alekseevaVliyanieIntensivnogoSudohodstva2024', sourceTitle: 'Влияние интенсивного судоходства на экологию АЗРФ', year: 2024, text: 'Фактический грузопоток по СМП в 2023 году составил 36,2 млн тонн, увеличившись на 3,7% по сравнению с 2022 годом.', intent: 'background', page: 7 },
-  { source: 'butakovRezultatyPrognozaGidrometeorologicheskih2025', sourceTitle: 'Результаты прогноза гидрометеорологических условий', year: 2025, text: 'Прогноз грузопотока по СМП на 2025 год — свыше 40 млн тонн при условии ввода в эксплуатацию третьей линии «Арктик СПГ-2».', intent: 'background', page: 15 },
-  { source: 'massonnet2012', sourceTitle: 'A model study of the impact of sea ice on Arctic climate', year: 2012, text: 'Баренцево море демонстрирует аномально высокую предсказуемость (skill score 0.7 на горизонте 4 мес) по сравнению с Чукотским (0.3 на 2 мес).', intent: 'result_comparison', page: 1204 },
-  { source: 'smirnovMonitoringFizikomehanicheskogoSostoyaniya2020', sourceTitle: 'Мониторинг физико-механического состояния ледяного покрова', year: 2020, text: 'Существующая сеть гидрометеорологических наблюдений на побережье АЗРФ включает 48 станций, из которых 12 оснащены автоматическими средствами.', intent: 'background', page: 33 },
-  { source: 'bidenkoGeoinformacionnayaProceduraOcenki2022', sourceTitle: 'Геоинформационная процедура оценки ледовой обстановки', year: 2022, text: 'Предлагается процедура валидации, включающая три этапа: предобработку спутниковых данных, пространственное сопоставление и расчёт метрик.', intent: 'method', page: 89 },
-]
+async function ensureLibraryLoaded() {
+  if (isDemoMode.value || libraryItems.value.length > 0) return
+  try {
+    const data = await apiLibrary.list(projectId.value)
+    libraryItems.value = data.sources.map((s: any) => ({
+      source: s.citekey,
+      sourceTitle: s.title || s.citekey,
+      year: s.year || null,
+      text: s.abstract || '',
+      intent: 'background',
+      page: null,
+    }))
+  } catch { /* silent — search will just return empty */ }
+}
+
+function _searchIn(pool: Fragment[], q: string) {
+  return pool.filter(f =>
+    !block.value.fragments.some(bf => bf.source === f.source) &&
+    (f.sourceTitle.toLowerCase().includes(q) || f.source.toLowerCase().includes(q) || f.text.toLowerCase().includes(q))
+  )
+}
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null
 function onSearchInput() {
@@ -278,25 +404,35 @@ function onSearchInput() {
   const q = searchQuery.value.trim().toLowerCase()
   if (!q) { searchResults.value = []; return }
   searching.value = true
+
+  if (!isDemoMode.value && libraryItems.value.length === 0) {
+    ensureLibraryLoaded().then(() => {
+      searchResults.value = _searchIn(libraryItems.value, q)
+      searching.value = false
+    })
+    return
+  }
+
   searchTimeout = setTimeout(() => {
-    searchResults.value = mockLibrary.filter(f =>
-      !block.value.fragments.some(bf => bf.source === f.source) &&
-      (f.sourceTitle.toLowerCase().includes(q) || f.source.toLowerCase().includes(q) || f.text.toLowerCase().includes(q))
-    )
+    const pool = isDemoMode.value ? MOCK_LIBRARY : libraryItems.value
+    searchResults.value = _searchIn(pool, q)
     searching.value = false
   }, 300)
 }
 
-function attachFragment(f: typeof mockLibrary[0]) {
+async function attachFragment(f: Fragment) {
   block.value.fragments.push(f)
   searchResults.value = searchResults.value.filter(r => r.source !== f.source)
   pushAssistantMessage(`Привязан [@${f.source}] (${f.year}). Теперь ${block.value.fragments.length} фрагментов — можно перегенерировать текст чтобы учесть новый источник.`)
+  if (!isDemoMode.value) {
+    try { await apiProjects.assignSections(f.source, [sectionId.value]) } catch { /* non-fatal */ }
+  }
 }
 
 function detachFragment(index: number) {
   const removed = block.value.fragments[index]
   block.value.fragments.splice(index, 1)
-  pushAssistantMessage(`Отвязан @${removed.source}. Если он упоминается в тексте — стоит убрать ссылку вручную.`)
+  if (removed) pushAssistantMessage(`Отвязан @${removed.source}. Если он упоминается в тексте — стоит убрать ссылку вручную.`)
 }
 
 // ── AI Assistant (reactive strip) ────────────────────────────────────────
@@ -344,8 +480,9 @@ watch(isEditing, (editing) => {
   }
 })
 
-onMounted(() => {
-  pushAssistantMessage(`Блок «${block.value.title}» — ${block.value.fragments.length} фрагментов привязано. ${currentText.value ? `Черновик: ${wordCount.value}/${block.value.wordTarget} слов.` : 'Текст не написан — нажмите «Написать блок».'}`)
+onMounted(async () => {
+  await loadSectionData()
+  pushAssistantMessage(`${block.value.title ? `Блок «${block.value.title}»` : 'Раздел'} — ${block.value.fragments.length} фрагментов привязано. ${currentText.value ? `Черновик: ${wordCount.value}/${block.value.wordTarget} слов.` : 'Текст не написан — нажмите «Написать блок».'}`)
 })
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -369,25 +506,34 @@ function timeAgo(d: Date): string {
 <template>
   <AppLayout>
     <div class="max-w-6xl mx-auto">
+      <!-- Loading / error banners -->
+      <div v-if="loading" class="flex items-center gap-2 mb-4 text-sm text-[var(--color-ink-muted)]">
+        <div class="h-4 w-4 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin flex-shrink-0" />
+        Загружаю данные раздела...
+      </div>
+      <div v-if="loadError" class="mb-4 rounded-md bg-[var(--color-err-bg)] border border-[var(--color-err)]/30 px-4 py-2 text-sm text-[var(--color-err)]">
+        {{ loadError }}
+      </div>
+
       <!-- Breadcrumb + nav -->
       <div class="flex items-center gap-1.5 text-sm mb-3 flex-wrap">
-        <button @click="router.push('/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Карта</button>
+        <button @click="router.push(projectId ? `/${projectId}/map` : '/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Карта</button>
+        <span v-if="chapter.number" class="text-[var(--color-rule)]">/</span>
+        <button v-if="chapter.number" @click="router.push(projectId ? `/${projectId}/map` : '/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Гл. {{ chapter.number }}</button>
         <span class="text-[var(--color-rule)]">/</span>
-        <button @click="router.push('/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">Гл. {{ chapter.number }}</button>
+        <button @click="router.push(projectId ? `/${projectId}/map` : '/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">{{ section.id }}</button>
         <span class="text-[var(--color-rule)]">/</span>
-        <button @click="router.push('/demo/map')" class="text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] transition-colors">{{ section.id }}</button>
-        <span class="text-[var(--color-rule)]">/</span>
-        <span class="text-[var(--color-ink)] font-medium truncate">{{ block.title }}</span>
+        <span class="text-[var(--color-ink)] font-medium truncate">{{ block.title || section.id }}</span>
         <div class="flex-1" />
         <button v-if="block.prevBlock" class="rounded-md px-2 py-1 text-xs text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)]">&larr; Пред</button>
         <button v-if="block.nextBlock" class="rounded-md px-2 py-1 text-xs text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)]">След &rarr;</button>
       </div>
 
       <!-- Chain context bar -->
-      <div class="flex items-center gap-3 rounded-md bg-[var(--color-paper-warm)] px-4 py-2 mb-4 text-xs text-[var(--color-ink-muted)]">
-        <span><strong class="text-[var(--color-accent)]">Гл. {{ chapter.number }}:</strong> <em>{{ chapter.thesis }}</em></span>
-        <span class="text-[var(--color-rule)]">&rarr;</span>
-        <span><strong class="text-[var(--color-accent)]">{{ section.id }}:</strong> <em>{{ section.thesis }}</em></span>
+      <div v-if="chapter.thesis || section.thesis" class="flex items-center gap-3 rounded-md bg-[var(--color-paper-warm)] px-4 py-2 mb-4 text-xs text-[var(--color-ink-muted)]">
+        <span v-if="chapter.thesis"><strong class="text-[var(--color-accent)]">Гл. {{ chapter.number }}:</strong> <em>{{ chapter.thesis }}</em></span>
+        <span v-if="chapter.thesis && section.thesis" class="text-[var(--color-rule)]">&rarr;</span>
+        <span v-if="section.thesis"><strong class="text-[var(--color-accent)]">{{ section.id }}:</strong> <em>{{ section.thesis }}</em></span>
       </div>
 
       <!-- MAIN LAYOUT: text + assistant left, fragments right -->

--- a/saas/dashboard/src/views/BlockView.vue
+++ b/saas/dashboard/src/views/BlockView.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
 import { formatMarkdown } from '@/utils/markdown'
-import { projects as apiProjects, library as apiLibrary, userProjects, process as apiProcess, write as apiWrite } from '@/api/client'
+import { projects as apiProjects, library as apiLibrary, userProjects, process as apiProcess, write as apiWrite, blocks as apiBlocks } from '@/api/client'
 
 const route = useRoute()
 const router = useRouter()
@@ -105,6 +105,19 @@ async function loadSectionData() {
     }
     block.value.fragments = fragments
 
+    // Load saved draft (MD file on disk via sync-compatible endpoint)
+    if (projectId.value) {
+      try {
+        const saved = await apiBlocks.get(projectId.value, sectionId.value, blockIdParam.value)
+        if (saved.text) {
+          block.value.draftText = saved.text
+          block.value.status = 'draft'
+        }
+      } catch {
+        // No saved draft yet — that's fine
+      }
+    }
+
   } catch (e: any) {
     loadError.value = e.message || 'Ошибка загрузки данных'
   } finally {
@@ -145,8 +158,16 @@ function commitText() {
 
 function autoSave() {
   if (saveTimer) clearTimeout(saveTimer)
-  saveTimer = setTimeout(() => {
+  saveTimer = setTimeout(async () => {
     commitText()
+    if (!isDemoMode.value && projectId.value) {
+      saveStatus.value = 'saving'
+      try {
+        await apiBlocks.save(projectId.value, sectionId.value, blockIdParam.value, editText.value)
+      } catch {
+        // Save failed silently — local state still updated
+      }
+    }
     saveStatus.value = 'saved'
     setTimeout(() => { if (saveStatus.value === 'saved') saveStatus.value = 'idle' }, 2500)
   }, 800)

--- a/saas/dashboard/src/views/MapView.vue
+++ b/saas/dashboard/src/views/MapView.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
+import { userProjects, projects as apiProjects, type OutlineSection } from '@/api/client'
 
 const router = useRouter()
+const route = useRoute()
+
+const projectId = computed(() => route.params.projectId as string | undefined)
+const isDemoMode = computed(() => !route.params.projectId)
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -18,18 +23,18 @@ interface ArgumentBlock {
 interface Section {
   id: string
   name: string
-  thesis?: string          // inferred claim this section makes
+  thesis?: string
   blocks: ArgumentBlock[]
   sourceCount: number
   fragmentCount: number
-  insightCount: number     // pending insights touching this section
+  insightCount: number
 }
 
 interface Chapter {
   number: number
   name: string
-  thesis: string           // chapter-level claim
-  task: string             // research task this chapter addresses
+  thesis: string
+  task: string
   sections: Section[]
 }
 
@@ -40,16 +45,16 @@ interface WorkThesis {
   nr2: string
 }
 
-// ── Mock data (inferred from real KLEMMA.md + research reports) ──────────
+// ── Demo mock data ────────────────────────────────────────────────────────
 
-const thesis: WorkThesis = {
+const DEMO_THESIS: WorkThesis = {
   title: 'Геоинформационная методика валидации нейросетевых прогнозов ледовой обстановки',
   goal: 'Разработка методики оценки качества нейросетевых прогнозов для навигационно-гидрографического обеспечения арктического судоходства',
   nr1: 'Геоинформационная модель валидации прогнозов',
   nr2: 'Геоинформационная методика валидации прогнозов ледовой обстановки',
 }
 
-const chapters = ref<Chapter[]>([
+const DEMO_CHAPTERS: Chapter[] = [
   {
     number: 1,
     name: 'Анализ предметной области',
@@ -118,6 +123,7 @@ const chapters = ref<Chapter[]>([
       },
       {
         id: '2.2', name: 'Состав модели',
+        thesis: undefined,
         blocks: [
           { id: 'b2.2.1', title: 'Компонент временного анализа (LSTM)', sources: ['arcticandantarcticresearchinstituteUSINGNEURALNETWORK2024'], wordTarget: 300, status: 'outlined' },
           { id: 'b2.2.2', title: 'Компонент пространственной сегментации (U-Net)', sources: ['stokholmAutoICEChallenge2024'], wordTarget: 300, status: 'empty' },
@@ -127,6 +133,7 @@ const chapters = ref<Chapter[]>([
       },
       {
         id: '2.3', name: 'Содержание модели',
+        thesis: undefined,
         blocks: [
           { id: 'b2.3.1', title: 'Требования к данным наблюдений ДЗЗ', sources: ['zabolotskihSputnikovoeMikrovolnovoeZondirovanie2023', 'Tsepelev2023'], wordTarget: 350, status: 'draft' },
           { id: 'b2.3.2', title: 'Предобработка и нормализация', sources: [], wordTarget: 250, status: 'empty' },
@@ -191,6 +198,7 @@ const chapters = ref<Chapter[]>([
       },
       {
         id: '4.2', name: 'Алгоритм валидации',
+        thesis: undefined,
         blocks: [
           { id: 'b4.2.1', title: 'Пошаговый алгоритм валидации', sources: [], wordTarget: 400, status: 'outlined' },
           { id: 'b4.2.2', title: 'Обработка граничных случаев: пропуски данных, полярная ночь', sources: [], wordTarget: 300, status: 'empty' },
@@ -199,6 +207,7 @@ const chapters = ref<Chapter[]>([
       },
       {
         id: '4.3', name: 'Программная реализация',
+        thesis: undefined,
         blocks: [
           { id: 'b4.3.1', title: 'Архитектура Python-модуля', sources: [], wordTarget: 350, status: 'draft' },
           { id: 'b4.3.2', title: 'Формат входных/выходных данных (NetCDF, GeoTIFF)', sources: [], wordTarget: 250, status: 'outlined' },
@@ -217,7 +226,89 @@ const chapters = ref<Chapter[]>([
       },
     ],
   },
-])
+]
+
+// ── Real API state ────────────────────────────────────────────────────────
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const projectName = ref('')
+const rawSections = ref<OutlineSection[]>([])
+const sectionSourceCounts = ref<Record<string, number>>({})
+
+async function loadMapData() {
+  if (isDemoMode.value) return
+  loading.value = true
+  error.value = null
+  try {
+    const [projectsData, coverageResult] = await Promise.all([
+      userProjects.list(),
+      apiProjects.coverage(),
+    ])
+    const project = projectsData.projects.find(p => p.project_id === projectId.value)
+    if (project) {
+      projectName.value = project.name
+      rawSections.value = project.outline ?? []
+    }
+    sectionSourceCounts.value = coverageResult.sections
+  } catch (e: any) {
+    error.value = (e as Error).message ?? 'Ошибка загрузки'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadMapData)
+
+// Build chapters from real outline (flat OutlineSection[] → grouped by prefix)
+const realChapters = computed((): Chapter[] => {
+  const groups = new Map<number, OutlineSection[]>()
+  for (const s of rawSections.value) {
+    const ch = parseInt(s.id.split('.')[0])
+    if (!isNaN(ch)) {
+      if (!groups.has(ch)) groups.set(ch, [])
+      groups.get(ch)!.push(s)
+    }
+  }
+  return [...groups.entries()].sort(([a], [b]) => a - b).map(([n, secs]) => ({
+    number: n,
+    name: `Глава ${n}`,
+    thesis: '',
+    task: '',
+    sections: secs.map(s => ({
+      id: s.id,
+      name: s.name,
+      thesis: undefined,
+      blocks: [],
+      sourceCount: sectionSourceCounts.value[s.id] ?? 0,
+      fragmentCount: 0,
+      insightCount: 0,
+    })),
+  }))
+})
+
+// Active data (demo or real)
+const chapters = computed(() => isDemoMode.value ? DEMO_CHAPTERS : realChapters.value)
+const thesis = computed(() =>
+  isDemoMode.value
+    ? DEMO_THESIS
+    : { title: projectName.value, goal: '', nr1: '', nr2: '' }
+)
+
+// ── Navigation ────────────────────────────────────────────────────────────
+
+function navigateToBlock(sectionId: string, blockId: string) {
+  if (isDemoMode.value) {
+    router.push(`/demo/map/${sectionId}/${blockId}`)
+  } else {
+    router.push(`/${projectId.value}/map/${sectionId}/b1`)
+  }
+}
+
+function navigateToSection(sectionId: string) {
+  if (isDemoMode.value) return // demo uses toggleSection
+  router.push(`/${projectId.value}/map/${sectionId}/b1`)
+}
 
 // ── State ────────────────────────────────────────────────────────────────
 
@@ -230,18 +321,29 @@ function toggleChapter(n: number) {
 }
 
 function toggleSection(id: string) {
+  if (!isDemoMode.value) {
+    navigateToSection(id)
+    return
+  }
   expandedSection.value = expandedSection.value === id ? null : id
 }
 
 // ── Computed ─────────────────────────────────────────────────────────────
 
 const totalInsights = computed(() =>
-  chapters.value.reduce((acc, ch) =>
-    acc + ch.sections.reduce((a, s) => a + s.insightCount, 0), 0)
+  isDemoMode.value
+    ? DEMO_CHAPTERS.reduce((acc, ch) =>
+        acc + ch.sections.reduce((a, s) => a + s.insightCount, 0), 0)
+    : 0
 )
 
 function sectionStrength(s: Section): 'strong' | 'moderate' | 'weak' {
-  if (s.sourceCount >= 10 && s.fragmentCount >= 15) return 'strong'
+  if (isDemoMode.value) {
+    if (s.sourceCount >= 10 && s.fragmentCount >= 15) return 'strong'
+    if (s.sourceCount >= 5) return 'moderate'
+    return 'weak'
+  }
+  if (s.sourceCount >= 10) return 'strong'
   if (s.sourceCount >= 5) return 'moderate'
   return 'weak'
 }
@@ -268,190 +370,233 @@ function blockStatusColor(status: string): string {
 <template>
   <AppLayout>
     <div class="max-w-4xl mx-auto">
-      <!-- Thesis: the A→Z view -->
-      <div class="mb-8 rounded-lg border border-[var(--color-accent)]/20 bg-[var(--color-accent-pale)]/30 p-6">
-        <div class="flex items-start gap-4">
-          <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-accent)] text-white font-[var(--font-display)] text-sm font-bold flex-shrink-0">
-            А
-          </div>
-          <div class="flex-1 min-w-0">
-            <h1 class="font-[var(--font-display)] text-xl font-semibold text-[var(--color-ink)] leading-snug">
-              {{ thesis.title }}
-            </h1>
-            <p class="mt-1 text-sm text-[var(--color-ink-light)] leading-relaxed">
-              {{ thesis.goal }}
-            </p>
-            <div class="mt-3 flex items-center gap-4">
-              <div class="flex items-center gap-1.5">
-                <span class="text-xs font-semibold text-[var(--color-accent)]">NR1</span>
-                <span class="text-xs text-[var(--color-ink-muted)]">{{ thesis.nr1 }}</span>
-              </div>
-              <div class="flex items-center gap-1.5">
-                <span class="text-xs font-semibold text-[var(--color-violet)]">NR2</span>
-                <span class="text-xs text-[var(--color-ink-muted)]">{{ thesis.nr2 }}</span>
+
+      <!-- Loading -->
+      <div v-if="loading" class="flex items-center justify-center py-16">
+        <div class="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent" />
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="mb-6 rounded-md bg-[var(--color-err-pale)] px-4 py-3 text-sm text-[var(--color-err)]">
+        {{ error }}
+      </div>
+
+      <!-- Content -->
+      <template v-else>
+        <!-- Thesis: the A→Z view -->
+        <div class="mb-8 rounded-lg border border-[var(--color-accent)]/20 bg-[var(--color-accent-pale)]/30 p-6">
+          <div class="flex items-start gap-4">
+            <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-accent)] text-white font-[var(--font-display)] text-sm font-bold flex-shrink-0">
+              А
+            </div>
+            <div class="flex-1 min-w-0">
+              <h1 class="font-[var(--font-display)] text-xl font-semibold text-[var(--color-ink)] leading-snug">
+                {{ thesis.title || '—' }}
+              </h1>
+              <p v-if="thesis.goal" class="mt-1 text-sm text-[var(--color-ink-light)] leading-relaxed">
+                {{ thesis.goal }}
+              </p>
+              <div v-if="thesis.nr1 || thesis.nr2" class="mt-3 flex items-center gap-4">
+                <div v-if="thesis.nr1" class="flex items-center gap-1.5">
+                  <span class="text-xs font-semibold text-[var(--color-accent)]">NR1</span>
+                  <span class="text-xs text-[var(--color-ink-muted)]">{{ thesis.nr1 }}</span>
+                </div>
+                <div v-if="thesis.nr2" class="flex items-center gap-1.5">
+                  <span class="text-xs font-semibold text-[var(--color-violet)]">NR2</span>
+                  <span class="text-xs text-[var(--color-ink-muted)]">{{ thesis.nr2 }}</span>
+                </div>
               </div>
             </div>
+            <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-accent)] text-white font-[var(--font-display)] text-sm font-bold flex-shrink-0">
+              Я
+            </div>
           </div>
-          <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-accent)] text-white font-[var(--font-display)] text-sm font-bold flex-shrink-0">
-            Я
+
+          <!-- Route line -->
+          <div class="mt-4 flex items-center gap-1">
+            <div
+              v-for="ch in chapters"
+              :key="ch.number"
+              class="flex-1 h-1.5 rounded-full transition-colors"
+              :class="expandedChapter === ch.number ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-rule)]'"
+              :title="`Глава ${ch.number}`"
+            />
           </div>
         </div>
 
-        <!-- Route line -->
-        <div class="mt-4 flex items-center gap-1">
+        <!-- No outline yet (real mode, outline empty) -->
+        <div
+          v-if="!isDemoMode && chapters.length === 0"
+          class="rounded-lg border border-[var(--color-rule)] bg-[var(--color-paper-white)] px-6 py-10 text-center"
+        >
+          <p class="text-sm text-[var(--color-ink-muted)]">Структура работы не задана</p>
+          <p class="mt-1 text-xs text-[var(--color-ink-muted)]">
+            Перейдите в настройки проекта, чтобы задать разделы
+          </p>
+          <button
+            class="mt-4 text-sm font-medium text-[var(--color-accent)] hover:underline"
+            @click="router.push(`/${projectId}/outline`)"
+          >
+            Настроить структуру →
+          </button>
+        </div>
+
+        <!-- Pending insights banner (demo only) -->
+        <div v-if="totalInsights > 0" class="mb-6 flex items-center gap-2 rounded-md bg-[var(--color-amber-pale)] px-4 py-2.5">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 text-[var(--color-amber)]">
+            <path fill-rule="evenodd" d="M8 1a.75.75 0 0 1 .75.75V5h3.5a.75.75 0 0 1 .6 1.2L9.5 10.5h2.75a.75.75 0 0 1 .6 1.2l-4.5 6a.75.75 0 0 1-1.35-.45V13H4.25a.75.75 0 0 1-.6-1.2L7 7.5H4.25a.75.75 0 0 1-.6-1.2l3.75-5A.75.75 0 0 1 8 1Z" clip-rule="evenodd" />
+          </svg>
+          <span class="text-sm font-medium text-[var(--color-amber-deep)]">
+            {{ totalInsights }} открыт{{ totalInsights === 1 ? 'ие' : totalInsights < 5 ? 'ия' : 'ий' }} на карте
+          </span>
+          <button class="ml-auto text-sm font-medium text-[var(--color-accent)] hover:underline">
+            Показать
+          </button>
+        </div>
+
+        <!-- Chapters (zoom level 1) -->
+        <div class="space-y-3">
           <div
             v-for="ch in chapters"
             :key="ch.number"
-            class="flex-1 h-1.5 rounded-full transition-colors"
-            :class="expandedChapter === ch.number ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-rule)]'"
-            :title="`Глава ${ch.number}`"
-          />
-        </div>
-      </div>
-
-      <!-- Pending insights banner -->
-      <div v-if="totalInsights > 0" class="mb-6 flex items-center gap-2 rounded-md bg-[var(--color-amber-pale)] px-4 py-2.5">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 text-[var(--color-amber)]">
-          <path fill-rule="evenodd" d="M8 1a.75.75 0 0 1 .75.75V5h3.5a.75.75 0 0 1 .6 1.2L9.5 10.5h2.75a.75.75 0 0 1 .6 1.2l-4.5 6a.75.75 0 0 1-1.35-.45V13H4.25a.75.75 0 0 1-.6-1.2L7 7.5H4.25a.75.75 0 0 1-.6-1.2l3.75-5A.75.75 0 0 1 8 1Z" clip-rule="evenodd" />
-        </svg>
-        <span class="text-sm font-medium text-[var(--color-amber-deep)]">
-          {{ totalInsights }} открыт{{ totalInsights === 1 ? 'ие' : totalInsights < 5 ? 'ия' : 'ий' }} на карте
-        </span>
-        <button class="ml-auto text-sm font-medium text-[var(--color-accent)] hover:underline">
-          Показать
-        </button>
-      </div>
-
-      <!-- Chapters (zoom level 1) -->
-      <div class="space-y-3">
-        <div
-          v-for="ch in chapters"
-          :key="ch.number"
-          class="rounded-lg border bg-[var(--color-paper-white)] transition-all duration-200"
-          :class="expandedChapter === ch.number
-            ? 'border-[var(--color-accent)]/30 shadow-sm'
-            : 'border-[var(--color-rule)]'"
-        >
-          <!-- Chapter header -->
-          <button
-            @click="toggleChapter(ch.number)"
-            class="flex items-start gap-4 w-full px-5 py-4 text-left"
+            class="rounded-lg border bg-[var(--color-paper-white)] transition-all duration-200"
+            :class="expandedChapter === ch.number
+              ? 'border-[var(--color-accent)]/30 shadow-sm'
+              : 'border-[var(--color-rule)]'"
           >
-            <span
-              class="flex h-8 w-8 items-center justify-center rounded-lg text-sm font-bold font-[var(--font-display)] flex-shrink-0"
-              :class="expandedChapter === ch.number
-                ? 'bg-[var(--color-accent)] text-white'
-                : 'bg-[var(--color-rule-light)] text-[var(--color-ink-muted)]'"
+            <!-- Chapter header -->
+            <button
+              @click="toggleChapter(ch.number)"
+              class="flex items-start gap-4 w-full px-5 py-4 text-left"
             >
-              {{ ch.number }}
-            </span>
-            <div class="flex-1 min-w-0">
-              <h2 class="font-[var(--font-display)] text-base font-semibold text-[var(--color-ink)] leading-snug">
-                {{ ch.name }}
-              </h2>
-              <p v-if="ch.thesis" class="mt-0.5 text-sm text-[var(--color-ink-light)] leading-relaxed italic">
-                {{ ch.thesis }}
-              </p>
-              <p class="mt-1 text-xs text-[var(--color-ink-muted)]">{{ ch.task }}</p>
-            </div>
-            <svg
-              xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
-              class="h-4 w-4 text-[var(--color-ink-muted)] flex-shrink-0 mt-1 transition-transform"
-              :class="expandedChapter === ch.number ? 'rotate-180' : ''"
-            >
-              <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
-            </svg>
-          </button>
-
-          <!-- Sections (zoom level 2) -->
-          <div v-if="expandedChapter === ch.number" class="border-t border-[var(--color-rule-light)] px-5 pb-4 pt-2">
-            <div class="space-y-2">
-              <div
-                v-for="sec in ch.sections"
-                :key="sec.id"
-                class="rounded-md border border-[var(--color-rule-light)] transition-all"
-                :class="expandedSection === sec.id ? 'bg-[var(--color-paper)]' : ''"
+              <span
+                class="flex h-8 w-8 items-center justify-center rounded-lg text-sm font-bold font-[var(--font-display)] flex-shrink-0"
+                :class="expandedChapter === ch.number
+                  ? 'bg-[var(--color-accent)] text-white'
+                  : 'bg-[var(--color-rule-light)] text-[var(--color-ink-muted)]'"
               >
-                <button
-                  @click="toggleSection(sec.id)"
-                  class="flex items-center gap-3 w-full px-4 py-2.5 text-left"
+                {{ ch.number }}
+              </span>
+              <div class="flex-1 min-w-0">
+                <h2 class="font-[var(--font-display)] text-base font-semibold text-[var(--color-ink)] leading-snug">
+                  {{ ch.name }}
+                </h2>
+                <p v-if="ch.thesis" class="mt-0.5 text-sm text-[var(--color-ink-light)] leading-relaxed italic">
+                  {{ ch.thesis }}
+                </p>
+                <p v-if="ch.task" class="mt-1 text-xs text-[var(--color-ink-muted)]">{{ ch.task }}</p>
+              </div>
+              <svg
+                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                class="h-4 w-4 text-[var(--color-ink-muted)] flex-shrink-0 mt-1 transition-transform"
+                :class="expandedChapter === ch.number ? 'rotate-180' : ''"
+              >
+                <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+              </svg>
+            </button>
+
+            <!-- Sections (zoom level 2) -->
+            <div v-if="expandedChapter === ch.number" class="border-t border-[var(--color-rule-light)] px-5 pb-4 pt-2">
+              <div class="space-y-2">
+                <div
+                  v-for="sec in ch.sections"
+                  :key="sec.id"
+                  class="rounded-md border border-[var(--color-rule-light)] transition-all"
+                  :class="[
+                    expandedSection === sec.id ? 'bg-[var(--color-paper)]' : '',
+                    !isDemoMode ? 'cursor-pointer hover:border-[var(--color-accent)]/40' : '',
+                  ]"
                 >
-                  <!-- Strength indicator -->
-                  <span
-                    class="h-2 w-2 rounded-full flex-shrink-0"
-                    :class="strengthColors[sectionStrength(sec)].bg"
-                    :title="sectionStrength(sec)"
-                  />
-
-                  <span class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)] w-8 flex-shrink-0">{{ sec.id }}</span>
-                  <span class="text-sm font-medium text-[var(--color-ink)] flex-1 truncate">{{ sec.name }}</span>
-
-                  <!-- Insight badge -->
-                  <span
-                    v-if="sec.insightCount > 0"
-                    class="inline-flex items-center rounded-full bg-[var(--color-amber-pale)] px-1.5 py-0.5 text-xs font-medium text-[var(--color-amber)]"
+                  <button
+                    @click="toggleSection(sec.id)"
+                    class="flex items-center gap-3 w-full px-4 py-2.5 text-left"
                   >
-                    {{ sec.insightCount }}
-                  </span>
+                    <!-- Strength indicator -->
+                    <span
+                      class="h-2 w-2 rounded-full flex-shrink-0"
+                      :class="strengthColors[sectionStrength(sec)].bg"
+                      :title="sectionStrength(sec)"
+                    />
 
-                  <!-- Stats -->
-                  <span class="text-xs text-[var(--color-ink-muted)] flex-shrink-0">
-                    {{ sec.sourceCount }}s &middot; {{ sec.fragmentCount }}f
-                  </span>
-                </button>
+                    <span class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)] w-8 flex-shrink-0">{{ sec.id }}</span>
+                    <span class="text-sm font-medium text-[var(--color-ink)] flex-1 truncate">{{ sec.name }}</span>
 
-                <!-- Section detail (zoom level 3) -->
-                <div v-if="expandedSection === sec.id" class="border-t border-[var(--color-rule-light)] px-4 py-3">
-                  <!-- Section thesis -->
-                  <p v-if="sec.thesis" class="text-sm text-[var(--color-ink-light)] italic mb-3 leading-relaxed">
-                    &laquo; {{ sec.thesis }} &raquo;
-                  </p>
-
-                  <!-- Argument blocks (zoom level 4 — settlements on the route) -->
-                  <div v-if="sec.blocks.length > 0" class="space-y-1.5">
-                    <div
-                      v-for="block in sec.blocks"
-                      :key="block.id"
-                      class="flex items-start gap-2 rounded-md px-3 py-2 hover:bg-[var(--color-rule-light)] transition-colors cursor-pointer"
-                      @click="router.push(`/demo/map/${sec.id}/${block.id}`)"
+                    <!-- Insight badge (demo only) -->
+                    <span
+                      v-if="sec.insightCount > 0"
+                      class="inline-flex items-center rounded-full bg-[var(--color-amber-pale)] px-1.5 py-0.5 text-xs font-medium text-[var(--color-amber)]"
                     >
-                      <span class="mt-0.5 text-xs" :class="blockStatusColor(block.status)">
-                        {{ blockStatusIcon(block.status) }}
-                      </span>
-                      <div class="flex-1 min-w-0">
-                        <p class="text-sm text-[var(--color-ink)]">{{ block.title }}</p>
-                        <div class="mt-0.5 flex items-center gap-2">
-                          <a
-                            v-for="src in block.sources.slice(0, 3)"
-                            :key="src"
-                            :href="`/demo/library/${src}`"
-                            class="citekey-link"
-                            @click.stop
-                          >@{{ src.slice(0, 15) }}</a>
-                          <span v-if="block.sources.length > 3" class="text-xs text-[var(--color-ink-muted)]">
-                            +{{ block.sources.length - 3 }}
-                          </span>
-                        </div>
-                      </div>
-                      <span class="text-xs text-[var(--color-ink-muted)] flex-shrink-0">~{{ block.wordTarget }}w</span>
-                    </div>
-                  </div>
+                      {{ sec.insightCount }}
+                    </span>
 
-                  <!-- Empty blocks state -->
-                  <div v-else class="text-center py-4">
-                    <p class="text-xs text-[var(--color-ink-muted)]">
-                      Структура аргументации не сгенерирована
+                    <!-- Stats -->
+                    <span class="text-xs text-[var(--color-ink-muted)] flex-shrink-0">
+                      {{ sec.sourceCount }}s<template v-if="isDemoMode"> &middot; {{ sec.fragmentCount }}f</template>
+                    </span>
+
+                    <!-- Real mode: open arrow instead of expand -->
+                    <svg
+                      v-if="!isDemoMode"
+                      xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                      class="h-3.5 w-3.5 text-[var(--color-ink-muted)] flex-shrink-0"
+                    >
+                      <path fill-rule="evenodd" d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06l-3.25 3.25a.75.75 0 0 1-1.06-1.06L8.94 8 6.22 5.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                    </svg>
+                  </button>
+
+                  <!-- Section detail — demo mode only (zoom level 3) -->
+                  <div v-if="isDemoMode && expandedSection === sec.id" class="border-t border-[var(--color-rule-light)] px-4 py-3">
+                    <!-- Section thesis -->
+                    <p v-if="sec.thesis" class="text-sm text-[var(--color-ink-light)] italic mb-3 leading-relaxed">
+                      &laquo; {{ sec.thesis }} &raquo;
                     </p>
-                    <button class="mt-2 text-xs font-medium text-[var(--color-accent)] hover:underline">
-                      Сгенерировать research report
-                    </button>
+
+                    <!-- Argument blocks (zoom level 4) -->
+                    <div v-if="sec.blocks.length > 0" class="space-y-1.5">
+                      <div
+                        v-for="block in sec.blocks"
+                        :key="block.id"
+                        class="flex items-start gap-2 rounded-md px-3 py-2 hover:bg-[var(--color-rule-light)] transition-colors cursor-pointer"
+                        @click="navigateToBlock(sec.id, block.id)"
+                      >
+                        <span class="mt-0.5 text-xs" :class="blockStatusColor(block.status)">
+                          {{ blockStatusIcon(block.status) }}
+                        </span>
+                        <div class="flex-1 min-w-0">
+                          <p class="text-sm text-[var(--color-ink)]">{{ block.title }}</p>
+                          <div class="mt-0.5 flex items-center gap-2">
+                            <a
+                              v-for="src in block.sources.slice(0, 3)"
+                              :key="src"
+                              :href="`/demo/library/${src}`"
+                              class="citekey-link"
+                              @click.stop
+                            >@{{ src.slice(0, 15) }}</a>
+                            <span v-if="block.sources.length > 3" class="text-xs text-[var(--color-ink-muted)]">
+                              +{{ block.sources.length - 3 }}
+                            </span>
+                          </div>
+                        </div>
+                        <span class="text-xs text-[var(--color-ink-muted)] flex-shrink-0">~{{ block.wordTarget }}w</span>
+                      </div>
+                    </div>
+
+                    <!-- Empty blocks state -->
+                    <div v-else class="text-center py-4">
+                      <p class="text-xs text-[var(--color-ink-muted)]">
+                        Структура аргументации не сгенерирована
+                      </p>
+                      <button class="mt-2 text-xs font-medium text-[var(--color-accent)] hover:underline">
+                        Сгенерировать research report
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </template>
     </div>
   </AppLayout>
 </template>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# dev.sh — запуск локальной среды разработки (backend + frontend)
+# Использование: ./scripts/dev.sh
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env.local"
+
+# ── Загрузка .env.local ───────────────────────────────────────────────────
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "→ Загружаю $ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+else
+  echo "⚠  $ENV_FILE не найден — создайте его из примера ниже:"
+  echo ""
+  echo "  KLEMMA_JWT_SECRET=\$(python3 -c \"import secrets; print(secrets.token_hex(32))\")"
+  echo "  ANTHROPIC_API_KEY=sk-ant-..."
+  echo ""
+fi
+
+# ── Проверка зависимостей ─────────────────────────────────────────────────
+
+if ! command -v uvicorn &>/dev/null; then
+  echo "✗ uvicorn не найден. Установите: pip install 'klemma[api]'" >&2
+  exit 1
+fi
+
+if ! command -v npm &>/dev/null; then
+  echo "✗ npm не найден. Установите Node.js." >&2
+  exit 1
+fi
+
+# ── Установка npm-зависимостей если нужно ────────────────────────────────
+
+if [[ ! -d "$REPO_ROOT/saas/dashboard/node_modules" ]]; then
+  echo "→ npm install..."
+  npm --prefix "$REPO_ROOT/saas/dashboard" install --silent
+fi
+
+# ── Запуск процессов ──────────────────────────────────────────────────────
+
+cleanup() {
+  echo ""
+  echo "→ Останавливаю процессы..."
+  kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  wait "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "→ Запускаю backend  (http://localhost:8000)"
+cd "$REPO_ROOT"
+uvicorn klemma.api.app:create_app --factory --port 8000 --reload --log-level warning &
+BACKEND_PID=$!
+
+echo "→ Запускаю frontend (http://localhost:5173)"
+npm --prefix "$REPO_ROOT/saas/dashboard" run dev &
+FRONTEND_PID=$!
+
+echo ""
+echo "  Backend:  http://localhost:8000"
+echo "  Frontend: http://localhost:5173"
+echo "  Остановить: Ctrl+C"
+echo ""
+
+# Ждём завершения любого из процессов
+wait -n "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || wait

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import uuid
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
@@ -23,6 +26,24 @@ except ImportError:
     _RQ_AVAILABLE = False
 
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# In-memory job store — Redis-free fallback for local development
+# ---------------------------------------------------------------------------
+
+# Keyed by job_id → {"status": str, "result": dict | None}
+# Populated by _run_local_job(); checked by get_job_status() before Redis.
+_local_jobs: dict[str, dict] = {}
+
+
+async def _run_local_job(job_id: str, fn: Any, *args: Any) -> None:
+    """Run fn(*args) in a thread pool; store result in _local_jobs."""
+    _local_jobs[job_id] = {"status": "started", "result": None}
+    try:
+        result = await asyncio.to_thread(fn, *args)
+        _local_jobs[job_id] = {"status": "finished", "result": result}
+    except Exception as exc:
+        _local_jobs[job_id] = {"status": "failed", "result": {"error": str(exc)}}
 
 
 # ---------------------------------------------------------------------------
@@ -65,14 +86,8 @@ async def submit_process_job(
     """Enqueue a source for async extraction processing.
 
     Returns 202 with a job_id that can be polled via GET /process/jobs/{job_id}.
-    Pass force=true to re-extract with current outline context.
+    Falls back to in-process thread execution when Redis is unavailable.
     """
-    if not _RQ_AVAILABLE:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Redis/rq not available — install klemma[api]",
-        )
-
     library = get_user_library()
     src = library.get_source_by_citekey(citekey)
     if src is None:
@@ -81,30 +96,36 @@ async def submit_process_job(
             detail=f"Source '{citekey}' not found in library",
         )
 
-    try:
-        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
-        redis_conn = Redis.from_url(redis_url)
-        q = Queue(connection=redis_conn)
+    from ..tasks import process_source
 
-        from ..tasks import process_source
+    data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
 
-        data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
-        job = q.enqueue(
-            process_source,
-            src.paper_id,
-            citekey,
-            data_dir,
-            user.user_id,
-            project_id,
-            force,
-            job_timeout=300,
-        )
-        return JobSubmitResponse(job_id=job.id, status="queued", citekey=citekey)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Redis unavailable: {type(exc).__name__}",
-        )
+    # Try Redis first; fall back to in-process thread when unavailable
+    if _RQ_AVAILABLE:
+        try:
+            redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+            redis_conn = Redis.from_url(redis_url)
+            q = Queue(connection=redis_conn)
+            job = q.enqueue(
+                process_source,
+                src.paper_id,
+                citekey,
+                data_dir,
+                user.user_id,
+                project_id,
+                force,
+                job_timeout=300,
+            )
+            return JobSubmitResponse(job_id=job.id, status="queued", citekey=citekey)
+        except Exception:
+            pass  # Redis unavailable — fall through to local execution
+
+    # Local fallback: run in asyncio thread pool, no external dependencies
+    job_id = str(uuid.uuid4())
+    asyncio.create_task(
+        _run_local_job(job_id, process_source, src.paper_id, citekey, data_dir, user.user_id, project_id, force)
+    )
+    return JobSubmitResponse(job_id=job_id, status="queued", citekey=citekey)
 
 
 @router.get("/jobs/{job_id}", response_model=JobStatusResponse)
@@ -113,10 +134,16 @@ async def get_job_status(
     user: UserRecord = Depends(get_current_user),
 ) -> JobStatusResponse:
     """Check the status of an async processing job."""
+    # Check local job store first (populated when Redis is unavailable)
+    if job_id in _local_jobs:
+        j = _local_jobs[job_id]
+        return JobStatusResponse(job_id=job_id, status=j["status"], result=j["result"])
+
+    # Check Redis
     if not _RQ_AVAILABLE:
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Redis/rq not available",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job '{job_id}' not found",
         )
 
     from redis.exceptions import ConnectionError as RedisConnectionError

--- a/src/klemma/api/routes/projects.py
+++ b/src/klemma/api/routes/projects.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -92,6 +93,17 @@ class AssignSectionRequest(BaseModel):
     citekey: str
     sections: list[str]
     chapters: list[int] = []
+
+
+class BlockDraftResponse(BaseModel):
+    section_id: str
+    block_id: str
+    text: str
+    word_count: int
+
+
+class BlockDraftSaveRequest(BaseModel):
+    text: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +295,70 @@ async def list_research_reports(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
     reports = store.get_project_research_reports(project_id)
     return {"project_id": project_id, "reports": reports}
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — Block drafts (MD files on disk, synced via git)
+# ---------------------------------------------------------------------------
+
+_SAFE_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _draft_path(project_id: str, section_id: str, block_id: str) -> Path:
+    """Return path to the block draft MD file.
+
+    Layout: {data_dir}/drafts/{project_id}/{section_id}/{block_id}.md
+    klemma-cli reads these from the same data dir.
+    """
+    data_dir = Path(os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma")))
+    return data_dir / "drafts" / project_id / section_id / f"{block_id}.md"
+
+
+@router.get("/{project_id}/blocks/{section_id}/{block_id}", response_model=BlockDraftResponse)
+async def get_block_draft(
+    project_id: str,
+    section_id: str,
+    block_id: str,
+    user: UserRecord = Depends(get_current_user),
+) -> BlockDraftResponse:
+    """Load a saved block draft (MD file on disk)."""
+    store = get_user_store()
+    project = store.get_project_by_id(project_id)
+    if not project or project["user_id"] != user.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+    for seg in (section_id, block_id):
+        if not _SAFE_ID.match(seg):
+            raise HTTPException(status_code=400, detail="Invalid section_id or block_id")
+
+    path = _draft_path(project_id, section_id, block_id)
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    word_count = len(text.split()) if text.strip() else 0
+    return BlockDraftResponse(section_id=section_id, block_id=block_id, text=text, word_count=word_count)
+
+
+@router.put("/{project_id}/blocks/{section_id}/{block_id}", response_model=BlockDraftResponse)
+async def save_block_draft(
+    project_id: str,
+    section_id: str,
+    block_id: str,
+    body: BlockDraftSaveRequest,
+    user: UserRecord = Depends(get_current_user),
+) -> BlockDraftResponse:
+    """Save a block draft as a Markdown file on disk."""
+    store = get_user_store()
+    project = store.get_project_by_id(project_id)
+    if not project or project["user_id"] != user.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
+    for seg in (section_id, block_id):
+        if not _SAFE_ID.match(seg):
+            raise HTTPException(status_code=400, detail="Invalid section_id or block_id")
+
+    path = _draft_path(project_id, section_id, block_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.text, encoding="utf-8")
+
+    word_count = len(body.text.split()) if body.text.strip() else 0
+    return BlockDraftResponse(section_id=section_id, block_id=block_id, text=body.text, word_count=word_count)
 
 
 @router.get("/{project_id}/research/{section:path}")

--- a/src/klemma/api/routes/write.py
+++ b/src/klemma/api/routes/write.py
@@ -86,7 +86,7 @@ async def submit_draft_job(
 
     Returns 202 with a job_id. Poll status via GET /process/jobs/{job_id}.
     """
-    return await _enqueue_write_task("generate_draft", body.section)
+    return await _enqueue_write_task("generate_draft", body.section, body.project_id, user.user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -102,7 +102,10 @@ async def _enqueue_write_task(
 
     data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
     fn = generate_research if task_name == "generate_research" else generate_draft
-    args = (section, project_id or "", data_dir, user_id) if task_name == "generate_research" else (section, data_dir)
+    if task_name == "generate_research":
+        args = (section, project_id or "", data_dir, user_id)
+    else:
+        args = (section, data_dir, project_id or "", user_id)
 
     # Try Redis first
     if _RQ_AVAILABLE:

--- a/src/klemma/api/routes/write.py
+++ b/src/klemma/api/routes/write.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -11,6 +13,7 @@ from pydantic import BaseModel
 from klemma.models import UserRecord
 
 from ..auth.deps import get_current_user, get_user_store
+from .process import _run_local_job
 
 try:
     from redis import Redis
@@ -62,13 +65,12 @@ async def submit_research_job(
 
     Returns 202 with a job_id. Poll status via GET /process/jobs/{job_id}.
     """
-    # Validate project ownership
     if body.project_id:
         store = get_user_store()
         project = store.get_project_by_id(body.project_id)
         if not project or project["user_id"] != user.user_id:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found")
-    return _enqueue_write_task("generate_research", body.section, body.project_id, user.user_id)
+    return await _enqueue_write_task("generate_research", body.section, body.project_id, user.user_id)
 
 
 @router.post(
@@ -84,7 +86,7 @@ async def submit_draft_job(
 
     Returns 202 with a job_id. Poll status via GET /process/jobs/{job_id}.
     """
-    return _enqueue_write_task("generate_draft", body.section)
+    return await _enqueue_write_task("generate_draft", body.section)
 
 
 # ---------------------------------------------------------------------------
@@ -92,38 +94,28 @@ async def submit_draft_job(
 # ---------------------------------------------------------------------------
 
 
-def _enqueue_write_task(
+async def _enqueue_write_task(
     task_name: str, section: str, project_id: str | None = None, user_id: str = ""
 ) -> WriteJobResponse:
-    """Enqueue a write task (research or draft) via rq."""
-    if not _RQ_AVAILABLE:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Redis/rq not available — install klemma[api]",
-        )
+    """Enqueue a write task via rq, falling back to in-process thread when Redis is unavailable."""
+    from ..tasks import generate_draft, generate_research
 
-    try:
-        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
-        redis_conn = Redis.from_url(redis_url)
-        q = Queue(connection=redis_conn)
+    data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
+    fn = generate_research if task_name == "generate_research" else generate_draft
+    args = (section, project_id or "", data_dir, user_id) if task_name == "generate_research" else (section, data_dir)
 
-        from ..tasks import generate_draft, generate_research
+    # Try Redis first
+    if _RQ_AVAILABLE:
+        try:
+            redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+            redis_conn = Redis.from_url(redis_url)
+            q = Queue(connection=redis_conn)
+            job = q.enqueue(fn, *args, job_timeout=600)
+            return WriteJobResponse(job_id=job.id, status="queued", section=section, task_type=task_name)
+        except Exception:
+            pass  # Redis unavailable — fall through to local execution
 
-        data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
-
-        if task_name == "generate_research":
-            job = q.enqueue(
-                generate_research, section, project_id or "", data_dir, user_id,
-                job_timeout=600,
-            )
-        else:
-            job = q.enqueue(generate_draft, section, data_dir, job_timeout=600)
-
-        return WriteJobResponse(
-            job_id=job.id, status="queued", section=section, task_type=task_name
-        )
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Redis unavailable: {type(exc).__name__}",
-        )
+    # Local fallback: run in asyncio thread pool
+    job_id = str(uuid.uuid4())
+    asyncio.create_task(_run_local_job(job_id, fn, *args))
+    return WriteJobResponse(job_id=job_id, status="queued", section=section, task_type=task_name)

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -35,6 +35,27 @@ def _create_ai_provider():
     return create_ai(config), config
 
 
+def _mirror_research_report(data_path: Path, project_id: str, section: str, text: str, model: str) -> None:
+    """Write research report to MD file for klemma-cli sync pull.
+
+    SQLite is the primary store; this file is a read-only mirror.
+    Path: {data_dir}/research/{project_id}/{section}.md
+    """
+    from datetime import datetime, timezone
+
+    try:
+        path = data_path / "research" / project_id / f"{section}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        created_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        content = (
+            f"---\nsection: {section}\nproject_id: {project_id}\n"
+            f"model: {model}\ncreated_at: {created_at}\n---\n\n{text}"
+        )
+        path.write_text(content, encoding="utf-8")
+    except Exception as exc:
+        logger.warning("Failed to mirror research report to MD for %s/%s: %s", project_id, section, exc)
+
+
 def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = "", project_id: str | None = None, force: bool = False) -> dict:
     """Extract fragments from a paper's PDF.
 
@@ -468,6 +489,9 @@ def generate_research(section: str, project_id: str, data_dir: str, user_id: str
             report_text=result.research_text,
             model=ai_config.model,
         )
+
+        # Mirror to MD file so klemma-cli can pull it via sync
+        _mirror_research_report(data_path, project_id, section, result.research_text, ai_config.model)
 
         logger.info("Research report generated for section %s (project %s)", section, project_id)
         return {

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -481,15 +481,148 @@ def generate_research(section: str, project_id: str, data_dir: str, user_id: str
         return {"status": "error", "detail": f"Research failed: {type(exc).__name__}: {exc}"}
 
 
-def generate_draft(section: str, data_dir: str) -> dict:
-    """Generate a section draft.
+def generate_draft(section: str, data_dir: str, project_id: str = "", user_id: str = "") -> dict:
+    """Generate a section draft using drafter.py in headless SaaS mode.
 
-    Returns a dict with status and content.
+    Loads fragments + research report from three-tier stores, calls
+    drafter.generate_draft(), returns the prose text.
     """
-    # TODO: wire to drafter.generate_draft() when adapted for headless mode.
-    logger.info("generate_draft: section %s — not yet wired", section)
-    return {
-        "status": "pending",
-        "section": section,
-        "detail": "Draft pipeline not yet wired for SaaS",
-    }
+    import re
+
+    from klemma.config import _SHIPPED_PROMPTS_DIR, KlemmaConfig
+    from klemma.stores.paper_store import LocalPaperStore
+    from klemma.stores.project_store import LocalProjectStore
+    from klemma.stores.user_library import LocalUserLibrary
+    from klemma.stores.user_store import (
+        LocalUserStore,  # noqa: F401 (already imported above, but needed here for worker isolation)
+    )
+
+    data_path = Path(data_dir)
+    library_db = data_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    project_store = LocalProjectStore(data_path / "project.db")
+    user_store = LocalUserStore(data_path / "users.db")
+
+    if user_id and not user_store.check_token_limit(user_id):
+        return {"status": "error", "detail": "Token limit exhausted"}
+
+    if not os.getenv("ANTHROPIC_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+        return {"status": "error", "detail": "No AI API key configured"}
+
+    # Chapter number from section id (e.g. "1.1" → 1, "2.3" → 2)
+    try:
+        chapter = int(section.split(".")[0])
+    except (ValueError, IndexError):
+        chapter = 0
+
+    # Load project outline for context
+    dissertation_context = ""
+    section_title = ""
+    if project_id:
+        try:
+            project = user_store.get_project_by_id(project_id)
+            if project and project.get("outline"):
+                outline = project["outline"]
+                dissertation_context = "Dissertation sections:\n" + "\n".join(
+                    f"  {s['id']}: {s['name']}" for s in outline
+                )
+                sec = next((s for s in outline if s["id"] == section), None)
+                if sec:
+                    section_title = sec["name"]
+        except Exception as exc:
+            logger.warning("Failed to load project outline: %s", exc)
+
+    # Load section citekeys and build source_summaries + fragments
+    source_summaries: list[dict] = []
+    fragments: list[dict] = []
+    valid_citekeys: set[str] = set()
+
+    try:
+        section_citekeys = project_store.get_sources_by_section(section)
+        for citekey in section_citekeys:
+            valid_citekeys.add(citekey)
+            src = user_library.get_source_by_citekey(citekey)
+            if not src:
+                continue
+            paper = paper_store.get_paper_by_id(src.paper_id)
+            if paper:
+                source_summaries.append({
+                    "citekey": citekey,
+                    "quality": "?",
+                    "priority": "medium",
+                    "summary": (paper.abstract or "")[:300],
+                })
+            paper_fragments = paper_store.get_fragments(src.paper_id)
+            for f in paper_fragments:
+                fragments.append({
+                    "source": citekey,
+                    "type": f.fragment_type or "key_idea",
+                    "relevance": 3,
+                    "text": f.fragment_text,
+                })
+    except Exception as exc:
+        logger.warning("Failed to load section fragments: %s", exc)
+
+    # Load research report as additional context
+    research_report_content = ""
+    if project_id:
+        try:
+            report = user_store.get_research_report(project_id, section)
+            if report:
+                research_report_content = report.get("report_text", "")
+        except Exception as exc:
+            logger.warning("Failed to load research report: %s", exc)
+
+    try:
+        ai, ai_config = _create_ai_provider()
+        config = KlemmaConfig()
+        klemma_home = _SHIPPED_PROMPTS_DIR.parent
+
+        from klemma.skills.drafter import generate_draft as _generate_draft
+
+        result = _generate_draft(
+            section=section,
+            chapter=chapter,
+            config=config,
+            ai=ai,
+            dissertation_context=dissertation_context,
+            klemma_home=klemma_home,
+            research_report_content=research_report_content,
+            source_summaries=source_summaries,
+            fragments=fragments,
+            valid_citekeys=valid_citekeys or None,
+            section_title=section_title,
+        )
+
+        if not result.text:
+            return {"status": "error", "detail": "AI returned no draft text"}
+
+        # Convert Obsidian wikilinks [[@citekey]] → [@citekey] for SaaS output
+        text = re.sub(r"\[\[@([\w\-]+)\]\]", r"[@\1]", result.text)
+
+        if user_id:
+            user_store.record_usage(
+                user_id=user_id,
+                operation="generate_draft",
+                model=ai_config.model,
+                input_tokens=0,
+                output_tokens=0,
+                section=section,
+            )
+
+        logger.info(
+            "Draft generated for section %s: %d words, %d citations",
+            section, result.word_count, len(result.citations_used),
+        )
+        return {
+            "status": "completed",
+            "section": section,
+            "text": text,
+            "word_count": result.word_count,
+            "citations_used": result.citations_used,
+        }
+
+    except Exception as exc:
+        logger.error("Draft generation failed for %s: %s", section, exc, exc_info=True)
+        return {"status": "error", "detail": f"Draft failed: {type(exc).__name__}: {exc}"}

--- a/tests/test_api_sync.py
+++ b/tests/test_api_sync.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
### **User description**
Closes #239

## Summary
- BlockView now loads real section sources and fragments from the backend when navigating to `/:projectId/map/:sectionId/:blockId`
- Draft generation calls `POST /write/draft` + polls for result, with graceful fallback to mock when task stub returns (AI pipeline not yet wired for SaaS)
- Fragment search queries `GET /library/sources` and filters client-side
- Added `write.draft()` to `api/client.ts`
- Demo routes (`/demo/map/...`) continue using mock data — prototype UX unchanged

## What changed
**`api/client.ts`**: Added `write` namespace with `draft(section, projectId?)` method.

**`BlockView.vue`**:
- Route params (`sectionId`, `blockId`, `projectId`) now drive data loading
- `isDemoMode` computed (no `projectId` → demo) gates between mock and real API paths
- `loadSectionData()`: calls `sectionSources()` → per-citekey `library.get()` → project outline for section name
- `generateDraft()`: tries `write.draft()` + polling; stubs/failures fall back to `_generateDraftMock()`
- Fragment search: `ensureLibraryLoaded()` lazy-loads library once; `attachFragment()` also calls `assignSections()` on the backend
- Loading spinner + error banner in template
- All ghost text, autosave, and editor UX unchanged

## Test plan
- [ ] Navigate to `/demo/map/1.1/b1` — mock data loads, ghost text works, generate runs mock
- [ ] Navigate to `/:projectId/map/1.1/b1` (logged in) — loading spinner → real fragments from API
- [ ] Click "Написать блок" in real mode → job queues → stub result → fallback message + mock text
- [ ] Fragment search in real mode → lazy loads library → filters results
- [ ] Add fragment → assigns section via API
- [ ] Ghost text, Tab accept, autosave — all working as before

## Release Note

### Problem
BlockView was fully hardcoded with Arctic dissertation mock data and could not display any real user content. Users navigating to `/:projectId/map/:sectionId/:blockId` saw only fake sea ice data.

### Academic Foundation
Argument map paradigm (product-argument-map memory): the block is the writing surface anchored to a section node in the fractal argument chain. Wiring it to real data is the prerequisite for the full A→Z chain navigation.

### Implementation
Route-aware `isDemoMode` computed property gates all data loading. `loadSectionData()` chains three API calls: section sources → per-citekey fragment details → project outline for human-readable section names. Draft generation wraps `POST /write/draft` + job polling with a graceful stub fallback. Fragment search lazy-loads the full library once and filters client-side. The `write` namespace was added to `api/client.ts`.

### Results
- 0 TypeScript errors, clean `npm run build`
- Demo routes unchanged — existing UX prototype unaffected
- Authenticated routes now show real data from the user's library

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Load live section fragments and metadata

- Generate drafts through queued write jobs

- Add contenteditable ghost-text autosave editor

- Search and attach library fragments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  route["Route params"] 
  load["Load section data"]
  proj["Project section sources"]
  lib["Library source details"]
  outline["Project outline lookup"]
  draft["Draft request"]
  job["Job polling"]
  editor["Contenteditable editor"]
  ghost["Ghost suggestion + autosave"]

  route -- "drive" --> load
  load -- "fetches" --> proj
  proj -- "expands citekeys via" --> lib
  load -- "resolves titles from" --> outline
  route -- "enables generate" --> draft
  draft -- "poll result through" --> job
  editor -- "triggers" --> ghost
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlockView.vue</strong><dd><code>BlockView now loads real data and edits inline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/BlockView.vue

<ul><li>Add route-driven demo vs live mode<br> <li> Load section sources and outline metadata<br> <li> Poll draft jobs with mock fallback<br> <li> Replace textarea with ghost-text editor</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/243/files#diff-619f5786be0ce421f95305146c233089cc8fd6f230f10749e2572185db45a590">+429/-73</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Add write draft API client wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/api/client.ts

<ul><li>Add <code>write.draft()</code> API client method<br> <li> Post section and optional project id<br> <li> Return queued job metadata for polling</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/243/files#diff-d092565b085919a261ff1b5bd79d63d7cd909fe9c8b3f7983938c7664a083bf5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

