### PR TITLE
feat(draft): ADR-016 canonical draft/ file structure

### DIFF
--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -74,7 +74,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
             repo_data = {"git_url": f"{base}/git/{namespaced}.git", "access_token": ""}
             # Look up dashboard_project_id for this git project
             try:
-                lookup = client.get(f"/sync/dashboard-project", params={"project_id": namespaced})
+                lookup = client.get("/sync/dashboard-project", params={"project_id": namespaced})
                 repo_data["dashboard_project_id"] = lookup.json().get("dashboard_project_id", "")
             except Exception:
                 pass  # Non-fatal — draft push will be skipped until re-linked
@@ -105,7 +105,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
     write_gitignore(project_root)
 
     # 7. Initial commit + push
-    add_files(project_root, ["KLEMMA.md", "notes/", ".gitignore"])
+    add_files(project_root, ["KLEMMA.md", "draft/", "notes/", ".gitignore"])
     commit_hash = commit(project_root, f"sync: initial link — {datetime.now(timezone.utc).strftime('%Y-%m-%d')}")
     if commit_hash:
         click.echo(f"Initial commit: {commit_hash[:8]}")
@@ -145,7 +145,7 @@ def push() -> None:
     click.echo("Pushing files...")
     add_files(project_root, [
         "KLEMMA.md",
-        "notes/drafts/",
+        "draft/",
         "notes/research/",
         ".gitignore",
     ])
@@ -186,7 +186,7 @@ def push() -> None:
                     f"{draft_result['words']} words"
                 )
             else:
-                click.echo("No draft files found (notes/drafts/ is empty or missing).")
+                click.echo("No draft files found (draft/ is empty or missing — run migrate_drafts.py).")
         except Exception as exc:
             click.echo(f"Draft push failed: {exc}", err=True)
     else:

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -196,10 +196,11 @@ def push_library(client: KlemmaClient, project_root: Path) -> dict:
 def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: str) -> dict:
     """Push local draft .md files to server's /projects/{id}/drafts API.
 
-    Reads all .md files from notes/drafts/ and uploads each one via PUT.
+    Reads all .md files from draft/ (ADR-016 canonical location) and uploads each
+    via PUT /projects/{id}/drafts/{filename}.
     Returns summary dict with 'files' and 'words' counts.
     """
-    drafts_dir = project_root / "notes" / "drafts"
+    drafts_dir = project_root / "draft"
     result: dict = {"files": 0, "words": 0}
 
     if not drafts_dir.exists():

--- a/saas/dashboard/src/views/MapView.vue
+++ b/saas/dashboard/src/views/MapView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
-import { userProjects, projects as apiProjects, drafts, computeSectionWordCounts, type DraftHeading, type OutlineSection } from '@/api/client'
+import { userProjects, projects as apiProjects, drafts, type OutlineSection } from '@/api/client'
 
 const router = useRouter()
 const route = useRoute()
@@ -234,22 +234,19 @@ const DEMO_CHAPTERS: Chapter[] = [
 const loading = ref(false)
 const error = ref<string | null>(null)
 const projectName = ref('')
-const draftHeadings = ref<DraftHeading[]>([])
-const draftContent = ref('')
-const draftHasContent = ref(false)
+const draftFiles = ref<import('@/api/client').DraftFile[]>([])
 const dbOutline = ref<OutlineSection[] | null>(null)
 const sectionSourceCounts = ref<Record<string, number>>({})
-const sectionWordCounts = ref<Record<string, number>>({})
 
 async function loadMapData() {
   if (isDemoMode.value) return
   loading.value = true
   error.value = null
   try {
-    const [projectsData, coverageResult, draftData] = await Promise.all([
+    const [projectsData, coverageResult, draftListData] = await Promise.all([
       userProjects.list(),
       apiProjects.coverage().catch(() => ({ total_sources: 0, sections: {} as Record<string, number>, chapters: {} as Record<string, number> })),
-      drafts.init(projectId.value!).catch(() => null),
+      drafts.list(projectId.value!).catch(() => null),
     ])
     const project = projectsData.projects.find(p => p.project_id === projectId.value)
     if (project) {
@@ -257,11 +254,8 @@ async function loadMapData() {
       dbOutline.value = project.outline
     }
     sectionSourceCounts.value = coverageResult.sections
-    if (draftData) {
-      draftHeadings.value = draftData.headings
-      draftContent.value = draftData.content
-      draftHasContent.value = draftData.word_count > 0
-      sectionWordCounts.value = computeSectionWordCounts(draftData.content, draftData.headings)
+    if (draftListData) {
+      draftFiles.value = draftListData.files
     }
   } catch (e: any) {
     error.value = (e as Error).message ?? 'Ошибка загрузки'
@@ -272,44 +266,62 @@ async function loadMapData() {
 
 /** Draft status per section: has word count > 0. */
 function sectionDraftStatus(sectionId: string): 'draft' | 'empty' {
-  return (sectionWordCounts.value[sectionId] ?? 0) > 0 ? 'draft' : 'empty'
+  // Find word count for this section across all draft files
+  for (const file of draftFiles.value) {
+    const heading = file.headings.find(h => h.section_id === sectionId)
+    if (heading) {
+      // Approximate: if any heading matches and file has content, it's a draft
+      return file.word_count > 0 ? 'draft' : 'empty'
+    }
+  }
+  return 'empty'
 }
 
 onMounted(loadMapData)
 
-// Build chapters from draft headings (level-2 = chapter, level-3+ = sections under that chapter)
+/** Derive chapter sort order from filename: abstract=-1, intro=0, chapter_N=N, appendix=95, conclusion=99, other=50 */
+function _fileOrder(filename: string): number {
+  const id = filename.replace('.md', '')
+  if (id === 'abstract') return -1
+  if (id === 'intro') return 0
+  const m = id.match(/^chapter_(\d+)$/)
+  if (m) return parseInt(m[1]!)
+  if (id === 'appendix') return 95
+  if (id === 'conclusion') return 99
+  return 50
+}
+
+// Build chapters from draft files (ADR-016: each file = one chapter/intro/conclusion)
 const realChapters = computed((): Chapter[] => {
-  // Primary source: draft file headings
-  if (draftHeadings.value.length) {
-    // Only level-2 (##) headings without dots are chapters.
-    // level-1 (#) headings produce slug IDs that cause artifact text.
-    const chapterHeadings = draftHeadings.value.filter(h => h.level === 2 && !h.section_id.includes('.'))
-    const sectionMap = new Map<string, DraftHeading[]>()
-    for (const h of draftHeadings.value) {
-      if (!h.section_id.includes('.')) continue
-      const chKey = h.section_id.split('.')[0]!
-      if (!sectionMap.has(chKey)) sectionMap.set(chKey, [])
-      sectionMap.get(chKey)!.push(h)
-    }
-    return chapterHeadings
-      // Sort by line position to preserve file order (non-numeric IDs like 'введение' sort correctly)
-      .sort((a, b) => a.line - b.line)
-      .map(ch => ({
-        number: parseInt(ch.section_id) || 0,
-        name: ch.full_title,
-        thesis: '',
-        task: '',
-        sections: (sectionMap.get(ch.section_id) ?? []).map(s => ({
-          id: s.section_id,
-          name: s.full_title.replace(/^\d[\d.]*\s*/, ''),
-          thesis: undefined,
-          blocks: [],
-          sourceCount: sectionSourceCounts.value[s.section_id] ?? 0,
-          fragmentCount: 0,
-          insightCount: 0,
-          wordCount: sectionWordCounts.value[s.section_id] ?? 0,
-        })),
-      }))
+  // Primary source: draft file list (ADR-016)
+  if (draftFiles.value.length) {
+    return [...draftFiles.value]
+      .sort((a, b) => _fileOrder(a.name) - _fileOrder(b.name))
+      .map(file => {
+        const fileId = file.name.replace('.md', '')
+        // Chapter title = first ## heading; fallback to filename
+        const chapterHeading = file.headings.find(h => h.level === 2)
+        // Sections = all ### headings (level 3) within the file
+        const sections: Section[] = file.headings
+          .filter(h => h.level === 3)
+          .map(h => ({
+            id: h.section_id,
+            name: h.full_title.replace(/^[\d.]+\s*/, ''),
+            thesis: undefined,
+            blocks: [],
+            sourceCount: sectionSourceCounts.value[h.section_id] ?? 0,
+            fragmentCount: 0,
+            insightCount: 0,
+            wordCount: 0,
+          }))
+        return {
+          number: _fileOrder(file.name),
+          name: chapterHeading?.full_title ?? fileId,
+          thesis: '',
+          task: '',
+          sections,
+        }
+      })
   }
 
   // Fallback: DB outline (sections array from project)
@@ -340,7 +352,7 @@ const realChapters = computed((): Chapter[] => {
         sourceCount: sectionSourceCounts.value[s.id] ?? 0,
         fragmentCount: 0,
         insightCount: 0,
-        wordCount: sectionWordCounts.value[s.id] ?? 0,
+        wordCount: 0,
       })),
     }))
 })

--- a/scripts/migrate_drafts.py
+++ b/scripts/migrate_drafts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Migrate notes/drafts/*.md → draft/chapter_N.md (ADR-016).
+
+Usage:
+    python scripts/migrate_drafts.py [project_root]
+
+If project_root is omitted, uses the current directory.
+
+Strategy:
+  - Scan notes/drafts/*.md
+  - Group files by chapter number detected from filename
+    Draft_1.md, Draft_1.1.md, Draft_1.1_newest.md, Draft_1.2_v2.md → chapter 1
+    Draft_2.md, Draft_2.1.md → chapter 2
+    intro.md, введение.md → intro.md
+    conclusion.md, заключение.md → conclusion.md
+  - Within each chapter, pick the largest file (most content = canonical version)
+  - Write merged output to draft/chapter_N.md (or draft/intro.md, draft/conclusion.md)
+  - Leave originals in notes/drafts/ untouched
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _detect_chapter(filename: str) -> str:
+    """Return canonical file id for a notes/drafts filename.
+
+    Examples:
+      Draft_1.md         → chapter_1
+      Draft_1.1.md       → chapter_1
+      Draft_1.1_newest   → chapter_1
+      Draft_2.3_v2.md    → chapter_2
+      intro.md           → intro
+      введение.md        → intro
+      conclusion.md      → conclusion
+      заключение.md      → conclusion
+    """
+    stem = Path(filename).stem.lower()
+
+    # Unnumbered special sections
+    if re.search(r"(intro|введени)", stem):
+        return "intro"
+    if re.search(r"(conclusion|заключени|выводы)", stem):
+        return "conclusion"
+
+    # Draft_N or Draft_N.M... → chapter N
+    m = re.search(r"draft[_\s]*(\d+)", stem)
+    if m:
+        return f"chapter_{m.group(1)}"
+
+    # Bare numeric: 1.md, 1.1.md, 2_3.md
+    m = re.match(r"^(\d+)", stem)
+    if m:
+        return f"chapter_{m.group(1)}"
+
+    return stem  # unknown — use stem as-is
+
+
+def migrate(project_root: Path) -> None:
+    source_dir = project_root / "notes" / "drafts"
+    target_dir = project_root / "draft"
+
+    if not source_dir.exists():
+        print(f"No notes/drafts/ directory found in {project_root}")
+        return
+
+    md_files = list(source_dir.glob("*.md"))
+    if not md_files:
+        print("notes/drafts/ is empty — nothing to migrate.")
+        return
+
+    # Group by chapter id, tracking largest file per group
+    groups: dict[str, list[Path]] = {}
+    for f in md_files:
+        chapter_id = _detect_chapter(f.name)
+        groups.setdefault(chapter_id, []).append(f)
+
+    target_dir.mkdir(exist_ok=True)
+    print(f"Migrating {len(md_files)} file(s) from {source_dir} → {target_dir}\n")
+
+    for chapter_id, files in sorted(groups.items()):
+        # Pick largest file as canonical
+        canonical = max(files, key=lambda f: f.stat().st_size)
+        target = target_dir / f"{chapter_id}.md"
+
+        if target.exists():
+            print(f"  SKIP  {chapter_id}.md (already exists — delete manually to re-migrate)")
+            continue
+
+        content = canonical.read_text(encoding="utf-8")
+        target.write_text(content, encoding="utf-8")
+
+        skipped = [f.name for f in files if f != canonical]
+        print(f"  OK    {canonical.name} → {chapter_id}.md ({len(content.split())} words)")
+        if skipped:
+            print(f"        Skipped older versions: {', '.join(skipped)}")
+
+    print("\nDone. Original files in notes/drafts/ are untouched.")
+    print("Run 'klemma-cli push' to sync draft/ to the server.")
+
+
+if __name__ == "__main__":
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    migrate(root)

--- a/src/klemma/api/routes/drafts.py
+++ b/src/klemma/api/routes/drafts.py
@@ -1,8 +1,12 @@
 """Draft endpoints: Markdown-first file management with section extraction.
 
-Files are stored at KLEMMA_DATA_DIR/drafts/{project_id}/ (shared git repo with blocks).
-Scheme 'single': one file (dissertation.md / paper.md), ## headings per chapter,
-### headings per section.
+Files are stored at KLEMMA_DATA_DIR/drafts/{project_id}/draft/ (ADR-016).
+Git repo root: KLEMMA_DATA_DIR/drafts/{project_id}/
+Draft files:   KLEMMA_DATA_DIR/drafts/{project_id}/draft/
+
+Convention (ADR-016):
+  dissertation: intro.md, chapter_1.md, chapter_2.md, ..., conclusion.md
+  paper:        paper.md (single file, all sections as ## headings)
 
 Routes mounted under /projects in app.py:
   GET  /projects/{id}/drafts                              → list files + parsed headings
@@ -59,8 +63,14 @@ def _data_dir() -> Path:
     return Path(os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma")))
 
 
-def _drafts_dir(project_id: str) -> Path:
+def _project_dir(project_id: str) -> Path:
+    """Git repo root for a project's drafts."""
     return _data_dir() / "drafts" / project_id
+
+
+def _drafts_dir(project_id: str) -> Path:
+    """Directory where draft .md files live (inside the git repo)."""
+    return _data_dir() / "drafts" / project_id / "draft"
 
 
 def _validate_filename(name: str) -> str:
@@ -90,6 +100,8 @@ def _ensure_git_repo(project_dir: Path) -> None:
 
 
 def _git_commit(project_dir: Path, filepath: Path, message: str) -> str:
+    # project_dir = git repo root; filepath is absolute, e.g. .../drafts/{id}/draft/chapter_1.md
+    # rel becomes "draft/chapter_1.md" — the path git needs to stage
     rel = filepath.relative_to(project_dir)
     subprocess.run(["git", "-C", str(project_dir), "add", str(rel)],
                    capture_output=True, check=True, timeout=10)
@@ -282,10 +294,10 @@ def list_draft_files(
 ) -> FileListResponse:
     """List all .md draft files for a project with parsed headings."""
     _assert_project_owner(project_id, user)
-    project_dir = _drafts_dir(project_id)
+    draft_dir = _drafts_dir(project_id)
     files = []
-    if project_dir.exists():
-        for md in sorted(project_dir.glob("*.md")):
+    if draft_dir.exists():
+        for md in sorted(draft_dir.glob("*.md")):
             content = md.read_text(encoding="utf-8")
             headings = [HeadingInfo(**h) for h in parse_headings(content)]
             wc = len(content.split())
@@ -328,9 +340,11 @@ def save_draft_file(
     _validate_filename(filename)
     _assert_project_owner(project_id, user)
 
-    project_dir = _drafts_dir(project_id)
+    project_dir = _project_dir(project_id)
+    draft_dir = _drafts_dir(project_id)
     _ensure_git_repo(project_dir)
-    path = project_dir / filename
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    path = draft_dir / filename
     path.write_text(body.content, encoding="utf-8")
 
     wc = len(body.content.split())
@@ -361,9 +375,11 @@ def init_draft_file(
     filename = body.filename or _DEFAULT_FILENAME.get(project_type, "draft.md")
     _validate_filename(filename)
 
-    project_dir = _drafts_dir(project_id)
+    project_dir = _project_dir(project_id)
+    draft_dir = _drafts_dir(project_id)
     _ensure_git_repo(project_dir)
-    path = project_dir / filename
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    path = draft_dir / filename
 
     if path.exists():
         content = path.read_text(encoding="utf-8")
@@ -396,9 +412,11 @@ def upsert_draft_section(
     _validate_filename(filename)
     _assert_project_owner(project_id, user)
 
-    project_dir = _drafts_dir(project_id)
+    project_dir = _project_dir(project_id)
+    draft_dir = _drafts_dir(project_id)
     _ensure_git_repo(project_dir)
-    path = project_dir / filename
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    path = draft_dir / filename
 
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
     updated = upsert_section(existing, section_id, body.body, body.heading_title)


### PR DESCRIPTION
Closes #251

## Summary

- **Server** (`routes/drafts.py`): `_drafts_dir()` now points to `.../drafts/{id}/draft/` subdirectory. Added `_project_dir()` returning the git repo root. All write endpoints use `draft_dir.mkdir(parents=True, exist_ok=True)`. Git commit path computation correctly yields `draft/chapter_1.md` relative to repo root.
- **CLI** (`cli/sync.py`, `cli/main.py`): `push_drafts()` scans `project_root/draft/*.md` instead of `notes/drafts/`. `git add` targets `draft/` directory. Explicit "run migrate_drafts.py" message when `draft/` is empty.
- **Frontend** (`MapView.vue`): Replaced single-file `draftHeadings` model with multi-file `draftFiles` from `drafts.list()`. `_fileOrder()` sorts `abstract→intro→chapter_N→appendix→conclusion`. One card per file, chapter title from first `##` heading, sections from `###` headings.
- **Migration** (`scripts/migrate_drafts.py`): One-time migration from `notes/drafts/Draft_N.M_*.md` → `draft/chapter_N.md`. Detects chapter number from filename, picks largest file per chapter group (most content = canonical version). Leaves originals untouched.

## Test plan

- [ ] `python -m pytest tests/test_api_sync.py -q` — 16/16 pass
- [ ] `ruff check src/ tests/ cli/ scripts/` — clean
- [ ] Run migration: `python scripts/migrate_drafts.py ~/research/dissertation/` — verify `draft/chapter_N.md` files created
- [ ] `klemma-cli push` with populated `draft/` — verify files reach server
- [ ] `GET /projects/{id}/drafts` returns `[{name: "chapter_1.md", headings: [...], word_count: N}]`
- [ ] MapView shows one card per `draft/*.md` file sorted by chapter order
- [ ] `klemma-cli push` with empty `draft/` — verify "No draft files found ... run migrate_drafts.py" message

## Release Note

### Problem
The Klemma CLI accumulated draft content in `notes/drafts/Draft_N.M_*.md` — arbitrary filenames, multiple versions per chapter, no naming convention. The SaaS server stored a single `dissertation.md`. These formats are fundamentally incompatible: `klemma-cli push` sent files with names the server didn't recognize; MapView couldn't show local draft content at all. Every researcher using both the CLI and the SaaS dashboard faced a broken sync.

### Academic Foundation
The design follows the principle of separation between *working files* (researcher's notes, intermediate drafts) and *canonical output* (the document proper). This mirrors IMRAD structure and chapter-based dissertation organization described in Kallestinova (2011) and Swales & Feak (2004): each chapter is a discrete intellectual unit with its own thesis and supporting structure, not a section of one large blob.

### Implementation
ADR-016 defines a `draft/` directory managed by klemma — users never create files manually in it. Dissertation projects get `draft/intro.md`, `draft/chapter_N.md`, `draft/conclusion.md`; paper projects get `draft/paper.md`. The `##` heading is always the top-level (chapter title), `###` for subsections. The server's `_drafts_dir()` now points to a `draft/` subdirectory inside the git repo root, keeping git commits and file storage cleanly separated. The frontend's MapView loads the file list directly from the API and builds one chapter card per file.

### Results
- 5 files changed: `routes/drafts.py` (server), `cli/sync.py`, `cli/main.py`, `MapView.vue`, `scripts/migrate_drafts.py` (new)
- 16/16 sync API tests pass; ruff lint clean
- Migration script handles `notes/drafts/Draft_1.md`, `Draft_1.1_newest.md`, `Draft_1.2_v2.md` → `draft/chapter_1.md` (picks largest file as canonical)
- MapView sort order: `abstract(-1) → intro(0) → chapter_N → appendix(95) → conclusion(99)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)