### PR TITLE
feat(cli): pull_drafts — download dashboard edits to local draft/ (ADR-016)

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -28,13 +28,15 @@ Git subprocess wrappers.
 - `log`, `status`, `remote_log`, `revert_last_n`, `force_push`
 - `write_gitignore` — auto-generate .gitignore for klemma projects
 
-### sync.py (~210 lines)
-Library sync — read local SQLite DB and push/pull via API.
+### sync.py (~265 lines)
+Library and draft sync — read local SQLite DB and push/pull via API.
 - `read_local_sources(project_root)` — read from library.db user_sources + papers
 - `read_local_fragments(project_root)` — read from library.db fragments
 - `read_local_embeddings(project_root)` — base64-encode vectors from library.db
 - `push_library(client, project_root)` — push sources + fragments + embeddings
 - `pull_library(client, project_root)` — pull and write to local library.db
+- `push_drafts(client, project_root, dashboard_project_id)` — PUT each `draft/*.md` to server
+- `pull_drafts(client, project_root, dashboard_project_id)` — GET draft file list + contents, write only if changed; `_SAFE_DRAFT_FILENAME` regex guards against path traversal
 
 ### project.py (~50 lines)
 Project discovery — find `.klemma/` directory, parse KLEMMA.md.
@@ -63,14 +65,16 @@ klemma-cli push
 klemma-cli pull
   1. git pull klemma main (conflicts → print instructions)
   2. GET /sync/pull/library → write sources/fragments to local library.db
-  3. Update .klemma/sync_config.json last_pull timestamp
+  3. GET /projects/{id}/drafts → list; GET /projects/{id}/drafts/{name} per file
+     → write to draft/{name} only if content differs (ADR-016)
+  4. Update .klemma/sync_config.json last_pull timestamp
 ```
 
 ## Tests
 
 - `cli/tests/test_gitops.py` — git subprocess wrapper tests
 - `cli/tests/test_project.py` — project discovery tests
-- `cli/tests/test_sync.py` — library DB read tests
+- `cli/tests/test_sync.py` — library DB read tests + pull_drafts tests (5 cases)
 - `tests/test_api_sync.py` — backend sync API endpoint tests (15 tests)
 
 See: [API Routes](../src/klemma/api/routes/CLAUDE.md) | [Root](../CLAUDE.md)

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -201,13 +201,13 @@ def push() -> None:
 def pull() -> None:
     """Pull changes from Klemma SaaS.
 
-    Two phases: git pull (files) + API pull (library data).
+    Three phases: git pull (files) + API pull (library data) + draft files.
     """
     from .client import KlemmaClient
     from .gitops import pull as git_pull
     from .project import ensure_project_root
     from .state import load_sync_config, save_sync_config
-    from .sync import pull_library
+    from .sync import pull_drafts, pull_library
 
     project_root = ensure_project_root()
     config = load_sync_config(project_root)
@@ -235,6 +235,20 @@ def pull() -> None:
         f"Pulled {result['sources']} sources, "
         f"{result['fragments']} fragments"
     )
+
+    # Phase 3: Drafts (dashboard edits → local draft/)
+    if config.dashboard_project_id:
+        click.echo("Pulling draft files...")
+        try:
+            draft_result = pull_drafts(client, project_root, config.dashboard_project_id)
+            if draft_result["files"]:
+                click.echo(f"Updated {draft_result['files']} draft file(s)")
+            else:
+                click.echo("Draft files up to date.")
+        except Exception as exc:
+            click.echo(f"Draft pull failed: {exc}", err=True)
+    else:
+        click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
 
     # Update last_pull timestamp
     config.last_pull = datetime.now(timezone.utc).isoformat()

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import re
 import sqlite3
 from pathlib import Path
 from typing import Optional
@@ -214,6 +215,47 @@ def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: 
             json={"content": content},
         )
         wc = resp.json().get("word_count", 0)
+        result["files"] += 1
+        result["words"] += wc
+
+    return result
+
+
+_SAFE_DRAFT_FILENAME = re.compile(r"^[\w.\-]+\.md$")
+
+
+def pull_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: str) -> dict:
+    """Pull draft .md files from server's /projects/{id}/drafts API to local draft/.
+
+    Only writes a file if its content differs from the local copy (avoids noise).
+    Skips files with unsafe names (path traversal guard).
+    Returns summary dict with 'files' (updated count) and 'words' counts.
+    """
+    resp = client.get(f"/projects/{dashboard_project_id}/drafts")
+    file_list = resp.json().get("files", [])
+    result: dict = {"files": 0, "words": 0}
+
+    if not file_list:
+        return result
+
+    draft_dir = project_root / "draft"
+    draft_dir.mkdir(exist_ok=True)
+
+    for file_info in file_list:
+        name = file_info.get("name", "")
+        if not _SAFE_DRAFT_FILENAME.match(name) or ".." in name:
+            continue  # skip unsafe filenames
+
+        content_resp = client.get(f"/projects/{dashboard_project_id}/drafts/{name}")
+        data = content_resp.json()
+        content: str = data.get("content", "")
+        wc: int = data.get("word_count", 0)
+
+        target = draft_dir / name
+        if target.exists() and target.read_text(encoding="utf-8") == content:
+            continue  # already up to date
+
+        target.write_text(content, encoding="utf-8")
         result["files"] += 1
         result["words"] += wc
 

--- a/cli/tests/test_sync.py
+++ b/cli/tests/test_sync.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import sqlite3
+from unittest.mock import MagicMock
 
 import pytest
 
 from klemma_cli.sync import (
+    pull_drafts,
     read_local_fragments,
     read_local_sources,
 )
@@ -61,6 +63,77 @@ def project_with_db(tmp_path):
     conn.commit()
     conn.close()
     return tmp_path
+
+
+def _make_client(file_list: list[dict], contents: dict[str, str]) -> MagicMock:
+    """Build a mock KlemmaClient for pull_drafts tests."""
+    def _get(path, **_kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        if path.endswith("/drafts"):
+            resp.json.return_value = {"files": file_list}
+        else:
+            filename = path.rsplit("/", 1)[-1]
+            resp.json.return_value = {
+                "name": filename,
+                "content": contents.get(filename, ""),
+                "word_count": len(contents.get(filename, "").split()),
+            }
+        return resp
+
+    client = MagicMock()
+    client.get.side_effect = _get
+    return client
+
+
+class TestPullDrafts:
+    def test_downloads_new_files(self, tmp_path):
+        contents = {"chapter_1.md": "## 1. Intro\n\nText here."}
+        client = _make_client(
+            [{"name": "chapter_1.md", "word_count": 3}],
+            contents,
+        )
+        result = pull_drafts(client, tmp_path, "proj-123")
+        assert result["files"] == 1
+        assert (tmp_path / "draft" / "chapter_1.md").read_text() == contents["chapter_1.md"]
+
+    def test_skips_unchanged_files(self, tmp_path):
+        content = "## 1. Intro\n\nText here."
+        (tmp_path / "draft").mkdir()
+        (tmp_path / "draft" / "chapter_1.md").write_text(content, encoding="utf-8")
+        client = _make_client(
+            [{"name": "chapter_1.md", "word_count": 3}],
+            {"chapter_1.md": content},
+        )
+        result = pull_drafts(client, tmp_path, "proj-123")
+        assert result["files"] == 0  # already up to date
+
+    def test_updates_changed_file(self, tmp_path):
+        (tmp_path / "draft").mkdir()
+        (tmp_path / "draft" / "chapter_1.md").write_text("old content", encoding="utf-8")
+        new_content = "## 1. New Content\n\nUpdated."
+        client = _make_client(
+            [{"name": "chapter_1.md", "word_count": 3}],
+            {"chapter_1.md": new_content},
+        )
+        result = pull_drafts(client, tmp_path, "proj-123")
+        assert result["files"] == 1
+        assert (tmp_path / "draft" / "chapter_1.md").read_text() == new_content
+
+    def test_skips_unsafe_filenames(self, tmp_path):
+        client = _make_client(
+            [{"name": "../evil.md", "word_count": 0},
+             {"name": "safe.md", "word_count": 2}],
+            {"safe.md": "## Safe\n\nOk."},
+        )
+        result = pull_drafts(client, tmp_path, "proj-123")
+        assert result["files"] == 1
+        assert not (tmp_path / "evil.md").exists()  # path traversal blocked
+
+    def test_empty_list_returns_zero(self, tmp_path):
+        client = _make_client([], {})
+        result = pull_drafts(client, tmp_path, "proj-123")
+        assert result == {"files": 0, "words": 0}
 
 
 class TestReadLocalSources:

--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -16,7 +16,7 @@ function switchProject(projectId: string) {
   const currentParam = route.params.projectId as string | undefined
   if (currentParam) {
     // Navigate to same module within new project
-    const modules = ['map', 'feed', 'library', 'health', 'outline', 'coverage', 'research']
+    const modules = ['map', 'feed', 'library', 'health', 'outline', 'coverage', 'research', 'edit']
     const suffix = route.path.slice(currentParam.length + 2) // strip /projectId/
     const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'map'
     router.push(`/${projectId}/${module}`)
@@ -230,6 +230,18 @@ async function createProject() {
             <path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 12.5 2h-9Zm0 1.5h9v9h-9v-9Zm3 1a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3Zm0 2.5a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1h-3Zm0 2.5a.5.5 0 0 0 0 1H9a.5.5 0 0 0 0-1H6.5Z" />
           </svg>
           Библиотека
+        </RouterLink>
+        <RouterLink
+          :to="`/${route.params.projectId}/edit`"
+          class="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm font-medium transition-colors"
+          :class="route.path.startsWith(`/${route.params.projectId}/edit`)
+            ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
+            : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 flex-shrink-0">
+            <path d="M13.488 2.513a1.75 1.75 0 0 0-2.475 0L6.75 6.774a2.75 2.75 0 0 0-.596.892l-.848 2.047a.75.75 0 0 0 .98.98l2.047-.848a2.75 2.75 0 0 0 .892-.596l4.261-4.263a1.75 1.75 0 0 0 0-2.474ZM8.75 5.158l-3 3c-.055.055-.115.105-.178.148L4.5 9l.695-1.072c.042-.063.092-.123.148-.178l3-3L8.75 5.158ZM2.75 3.5h3.5a.75.75 0 0 1 0 1.5h-3.5v7.5h7.5v-3.5a.75.75 0 0 1 1.5 0V13a.75.75 0 0 1-.75.75h-9A.75.75 0 0 1 2 13V4.25A.75.75 0 0 1 2.75 3.5Z" />
+          </svg>
+          Редактор
         </RouterLink>
       </nav>
       <!-- Hint when no project selected -->

--- a/saas/dashboard/src/components/FileBrowser.vue
+++ b/saas/dashboard/src/components/FileBrowser.vue
@@ -90,7 +90,7 @@ onMounted(async () => {
         <span class="flex-1 truncate">{{ displayName(file.name) }}</span>
         <span
           v-if="file.word_count > 0"
-          class="font-[var(--font-mono)] text-[10px] flex-shrink-0 opacity-50"
+          class="font-[var(--font-mono)] text-xs flex-shrink-0 opacity-50"
         >{{ file.word_count }}w</span>
       </button>
     </div>

--- a/saas/dashboard/src/components/FileBrowser.vue
+++ b/saas/dashboard/src/components/FileBrowser.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { drafts } from '@/api/client'
+import type { DraftFile } from '@/api/client'
+
+const props = defineProps<{
+  projectId: string
+  activeFile: string | null
+}>()
+
+const emit = defineEmits<{
+  select: [filename: string]
+}>()
+
+const files = ref<DraftFile[]>([])
+const loading = ref(false)
+
+function fileOrder(name: string): number {
+  if (name.startsWith('intro')) return -1
+  const m = name.match(/chapter_(\d+)/)
+  if (m?.[1]) return parseInt(m[1])
+  if (name.startsWith('conclusion')) return 99
+  return 50
+}
+
+function displayName(name: string): string {
+  const map: Record<string, string> = {
+    'intro.md': 'Введение',
+    'conclusion.md': 'Заключение',
+  }
+  if (map[name]) return map[name]
+  const m = name.match(/chapter_(\d+)\.md/)
+  if (m) return `Глава ${m[1]}`
+  return name.replace('.md', '')
+}
+
+const sortedFiles = computed(() =>
+  [...files.value].sort((a, b) => fileOrder(a.name) - fileOrder(b.name))
+)
+
+onMounted(async () => {
+  if (!props.projectId) return
+  loading.value = true
+  try {
+    const data = await drafts.list(props.projectId)
+    files.value = data.files
+  } catch {
+    files.value = []
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Header -->
+    <div class="px-3 pt-3 pb-2 border-b border-[var(--color-rule-light)] flex-shrink-0">
+      <p class="text-xs font-semibold uppercase tracking-wider text-[var(--color-ink-muted)]">Файлы</p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="px-3 py-4 text-xs text-[var(--color-ink-muted)]">Загрузка…</div>
+
+    <!-- Empty state -->
+    <div
+      v-else-if="files.length === 0"
+      class="px-3 py-4 text-xs text-[var(--color-ink-muted)] italic leading-relaxed"
+    >
+      Нет файлов — запустите<br>
+      <code class="font-[var(--font-mono)] text-[var(--color-accent)] not-italic">klemma-cli push</code>
+    </div>
+
+    <!-- File list -->
+    <div v-else class="flex-1 overflow-y-auto py-1">
+      <button
+        v-for="file in sortedFiles"
+        :key="file.name"
+        @click="emit('select', file.name)"
+        class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors"
+        :class="activeFile === file.name
+          ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)] font-medium'
+          : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
+      >
+        <!-- File icon -->
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+          class="h-3.5 w-3.5 flex-shrink-0 opacity-60">
+          <path d="M4 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V6.414A2 2 0 0 0 13.414 5L11 2.586A2 2 0 0 0 9.586 2H4Zm7 7a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h4.5A.75.75 0 0 1 11 9Zm0 2.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h4.5a.75.75 0 0 1 .75.75ZM6.75 5a.75.75 0 0 1 0-1.5H9a.75.75 0 0 1 0 1.5H6.75Z" />
+        </svg>
+        <span class="flex-1 truncate">{{ displayName(file.name) }}</span>
+        <span
+          v-if="file.word_count > 0"
+          class="font-[var(--font-mono)] text-[10px] flex-shrink-0 opacity-50"
+        >{{ file.word_count }}w</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/saas/dashboard/src/components/SourcePanel.vue
+++ b/saas/dashboard/src/components/SourcePanel.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue'
+import { projects as apiProjects, library as apiLibrary } from '@/api/client'
+
+interface LibraryItem {
+  source: string
+  sourceTitle: string
+  year: number | null
+  text: string
+}
+
+const props = defineProps<{
+  sectionId: string | null
+  projectId: string
+  isDemoMode?: boolean
+}>()
+
+const emit = defineEmits<{
+  attach: [citekey: string]
+  detach: [citekey: string]
+}>()
+
+const attachedCitekeys = ref<string[]>([])
+const libraryItems = ref<LibraryItem[]>([])
+const searchQuery = ref('')
+const searchResults = ref<LibraryItem[]>([])
+const searching = ref(false)
+const loading = ref(false)
+
+let loadTimer: ReturnType<typeof setTimeout> | null = null
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+const attachedItems = computed<LibraryItem[]>(() =>
+  attachedCitekeys.value.map(citekey => {
+    const found = libraryItems.value.find(l => l.source === citekey)
+    return found ?? { source: citekey, sourceTitle: citekey, year: null, text: '' }
+  })
+)
+
+async function ensureLibraryLoaded() {
+  if (props.isDemoMode || libraryItems.value.length > 0) return
+  try {
+    const data = await apiLibrary.list(props.projectId)
+    libraryItems.value = data.sources.map((s: any) => ({
+      source: s.citekey,
+      sourceTitle: s.title || s.citekey,
+      year: s.year ?? null,
+      text: s.abstract || '',
+    }))
+  } catch { /* silent */ }
+}
+
+async function loadAttached(sectionId: string) {
+  loading.value = true
+  try {
+    const data = await apiProjects.sectionSources(sectionId)
+    attachedCitekeys.value = data.citekeys
+  } catch {
+    attachedCitekeys.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.sectionId,
+  (id) => {
+    if (loadTimer) clearTimeout(loadTimer)
+    searchQuery.value = ''
+    searchResults.value = []
+    if (!id || !props.projectId || props.isDemoMode) {
+      attachedCitekeys.value = []
+      return
+    }
+    loadTimer = setTimeout(() => loadAttached(id), 300)
+  },
+  { immediate: true }
+)
+
+function _searchIn(q: string) {
+  return libraryItems.value.filter(f =>
+    !attachedCitekeys.value.includes(f.source) &&
+    (f.sourceTitle.toLowerCase().includes(q) ||
+      f.source.toLowerCase().includes(q) ||
+      f.text.toLowerCase().includes(q))
+  )
+}
+
+function onSearchInput() {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) { searchResults.value = []; return }
+  searching.value = true
+
+  if (libraryItems.value.length === 0) {
+    ensureLibraryLoaded().then(() => {
+      searchResults.value = _searchIn(q)
+      searching.value = false
+    })
+    return
+  }
+
+  searchTimeout = setTimeout(() => {
+    searchResults.value = _searchIn(q)
+    searching.value = false
+  }, 300)
+}
+
+async function attachItem(item: LibraryItem) {
+  if (attachedCitekeys.value.includes(item.source)) return
+  attachedCitekeys.value.push(item.source)
+  searchResults.value = searchResults.value.filter(r => r.source !== item.source)
+  emit('attach', item.source)
+  if (!props.isDemoMode && props.sectionId) {
+    try { await apiProjects.assignSections(item.source, [props.sectionId]) } catch { /* non-fatal */ }
+  }
+}
+
+function detachItem(citekey: string) {
+  attachedCitekeys.value = attachedCitekeys.value.filter(k => k !== citekey)
+  emit('detach', citekey)
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Section header -->
+    <div class="flex-shrink-0 px-3 pt-3 pb-2 border-b border-[var(--color-rule-light)]">
+      <p v-if="sectionId" class="text-xs font-semibold text-[var(--color-accent-deep)] truncate">
+        {{ sectionId }}
+      </p>
+      <p v-else class="text-xs text-[var(--color-ink-muted)] italic">
+        Поставьте курсор в раздел
+      </p>
+    </div>
+
+    <!-- Search box -->
+    <div class="flex-shrink-0 px-3 pt-2 pb-1.5">
+      <div class="relative">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+          class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-[var(--color-ink-muted)]">
+          <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+        </svg>
+        <input
+          v-model="searchQuery"
+          @input="onSearchInput"
+          type="text"
+          class="w-full rounded-md border border-[var(--color-rule)] bg-[var(--color-paper)] pl-8 pr-3 py-1.5 text-sm placeholder-[var(--color-ink-muted)] focus:border-[var(--color-accent)] focus:outline-none"
+          placeholder="Найти в библиотеке..."
+        />
+      </div>
+    </div>
+
+    <!-- Search results -->
+    <div
+      v-if="searchQuery.trim() && (searchResults.length > 0 || searching)"
+      class="flex-shrink-0 mx-3 mb-2 rounded-md border border-[var(--color-accent)]/30 bg-[var(--color-accent-pale)]/20 overflow-hidden"
+    >
+      <div class="px-3 py-1 text-xs font-semibold text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]/40">
+        Результаты
+      </div>
+      <div v-if="searching" class="px-3 py-3 text-center text-xs text-[var(--color-ink-muted)]">Ищу...</div>
+      <div v-else-if="searchResults.length === 0" class="px-3 py-2 text-center text-xs text-[var(--color-ink-muted)]">
+        Не найдено
+      </div>
+      <div v-else class="divide-y divide-[var(--color-rule-light)]">
+        <div v-for="r in searchResults" :key="r.source" class="px-3 py-2 hover:bg-[var(--color-accent-pale)]/40">
+          <div class="flex items-center gap-1 mb-0.5">
+            <span class="font-[var(--font-mono)] text-xs text-[var(--color-accent-deep)] truncate">
+              @{{ r.source.length > 14 ? r.source.slice(0, 14) + '..' : r.source }}
+            </span>
+            <span class="text-xs text-[var(--color-ink-muted)]">{{ r.year }}</span>
+            <button
+              @click="attachItem(r)"
+              :disabled="!sectionId"
+              class="ml-auto rounded bg-[var(--color-accent)] px-1.5 py-0.5 text-xs font-medium text-white hover:bg-[var(--color-accent-deep)] disabled:opacity-40 disabled:cursor-not-allowed"
+            >+</button>
+          </div>
+          <p class="text-xs text-[var(--color-ink-light)] leading-relaxed line-clamp-2">{{ r.text }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Attached list -->
+    <div class="flex-1 overflow-y-auto px-3 pb-3 space-y-2">
+      <div class="text-xs font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider pt-1">
+        <span v-if="loading" class="opacity-50">Загрузка…</span>
+        <span v-else>Привязано ({{ attachedCitekeys.length }})</span>
+      </div>
+      <div v-if="!sectionId" class="text-xs text-[var(--color-ink-muted)] italic py-2 text-center">—</div>
+      <div
+        v-else-if="attachedItems.length === 0 && !loading"
+        class="text-xs text-[var(--color-ink-muted)] italic py-2 text-center"
+      >
+        Нет источников
+      </div>
+      <div
+        v-for="item in attachedItems"
+        :key="item.source"
+        class="group rounded-md border border-[var(--color-rule-light)] bg-[var(--color-paper-white)] px-3 py-2 relative"
+      >
+        <div class="flex items-center gap-1">
+          <span class="font-[var(--font-mono)] text-xs text-[var(--color-accent-deep)] truncate flex-1">
+            @{{ item.source.length > 16 ? item.source.slice(0, 16) + '..' : item.source }}
+          </span>
+          <span class="text-xs text-[var(--color-ink-muted)] flex-shrink-0">{{ item.year }}</span>
+        </div>
+        <p
+          v-if="item.sourceTitle !== item.source"
+          class="text-xs text-[var(--color-ink-light)] leading-snug truncate mt-0.5"
+        >
+          {{ item.sourceTitle }}
+        </p>
+        <button
+          @click="detachItem(item.source)"
+          class="absolute top-1.5 right-1.5 h-4 w-4 rounded flex items-center justify-center text-[var(--color-ink-muted)] hover:text-[var(--color-err)] hover:bg-[var(--color-err-bg)] opacity-0 group-hover:opacity-100 transition-all"
+          title="Отвязать"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-2.5 w-2.5">
+            <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -121,6 +121,18 @@ const router = createRouter({
       path: '/:projectId/draft',
       redirect: (to) => `/${to.params.projectId}/map`,
     },
+    {
+      path: '/:projectId/edit',
+      name: 'edit',
+      component: () => import('../views/FileEditorView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/:projectId/edit/:filename',
+      name: 'edit-file',
+      component: () => import('../views/FileEditorView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/saas/dashboard/src/views/BlockView.vue
+++ b/saas/dashboard/src/views/BlockView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
+import SourcePanel from '@/components/SourcePanel.vue'
 import { formatMarkdown, renderDraft } from '@/utils/markdown'
 import { projects as apiProjects, library as apiLibrary, userProjects, process as apiProcess, write as apiWrite, blocks as apiBlocks, drafts, computeSectionWordCounts, type DraftHeading } from '@/api/client'
 
@@ -548,70 +549,14 @@ function onEditorPaste(e: ClipboardEvent) {
   editingBody.value = editorEl.value?.innerText || ''
 }
 
-// ── Fragment search ──────────────────────────────────────────────────────
+// ── Fragment panel events (handled by SourcePanel component) ─────────────
 
-const searchQuery = ref('')
-const searchResults = ref<Fragment[]>([])
-const searching = ref(false)
-const libraryItems = ref<Fragment[]>([])
-
-async function ensureLibraryLoaded() {
-  if (isDemoMode.value || libraryItems.value.length > 0) return
-  try {
-    const data = await apiLibrary.list(projectId.value)
-    libraryItems.value = data.sources.map((s: any) => ({
-      source: s.citekey,
-      sourceTitle: s.title || s.citekey,
-      year: s.year || null,
-      text: s.abstract || '',
-      intent: 'background',
-      page: null,
-    }))
-  } catch { /* silent — search will just return empty */ }
+function onSourceAttach(citekey: string) {
+  pushAssistantMessage(`Привязан @${citekey} — можно перегенерировать текст чтобы учесть новый источник.`)
 }
 
-function _searchIn(pool: Fragment[], q: string) {
-  return pool.filter(f =>
-    !block.value.fragments.some(bf => bf.source === f.source) &&
-    (f.sourceTitle.toLowerCase().includes(q) || f.source.toLowerCase().includes(q) || f.text.toLowerCase().includes(q))
-  )
-}
-
-let searchTimeout: ReturnType<typeof setTimeout> | null = null
-function onSearchInput() {
-  if (searchTimeout) clearTimeout(searchTimeout)
-  const q = searchQuery.value.trim().toLowerCase()
-  if (!q) { searchResults.value = []; return }
-  searching.value = true
-
-  if (!isDemoMode.value && libraryItems.value.length === 0) {
-    ensureLibraryLoaded().then(() => {
-      searchResults.value = _searchIn(libraryItems.value, q)
-      searching.value = false
-    })
-    return
-  }
-
-  searchTimeout = setTimeout(() => {
-    const pool = isDemoMode.value ? MOCK_LIBRARY : libraryItems.value
-    searchResults.value = _searchIn(pool, q)
-    searching.value = false
-  }, 300)
-}
-
-async function attachFragment(f: Fragment) {
-  block.value.fragments.push(f)
-  searchResults.value = searchResults.value.filter(r => r.source !== f.source)
-  pushAssistantMessage(`Привязан [@${f.source}] (${f.year}). Теперь ${block.value.fragments.length} фрагментов — можно перегенерировать текст чтобы учесть новый источник.`)
-  if (!isDemoMode.value) {
-    try { await apiProjects.assignSections(f.source, [sectionId.value]) } catch { /* non-fatal */ }
-  }
-}
-
-function detachFragment(index: number) {
-  const removed = block.value.fragments[index]
-  block.value.fragments.splice(index, 1)
-  if (removed) pushAssistantMessage(`Отвязан @${removed.source}. Если он упоминается в тексте — стоит убрать ссылку вручную.`)
+function onSourceDetach(citekey: string) {
+  pushAssistantMessage(`Отвязан @${citekey}. Если он упоминается в тексте — стоит убрать ссылку вручную.`)
 }
 
 // ── AI Assistant (reactive strip) ────────────────────────────────────────
@@ -693,7 +638,7 @@ onMounted(async () => {
     } catch { /* non-fatal — fall back to demo-style editing */ }
   }
 
-  pushAssistantMessage(`${block.value.title ? `Блок «${block.value.title}»` : 'Раздел'} — ${block.value.fragments.length} фрагментов привязано. ${currentText.value ? `Черновик: ${wordCount.value}/${block.value.wordTarget} слов.` : 'Текст не написан — нажмите «Написать блок».'}`)
+  pushAssistantMessage(`${block.value.title ? `Блок «${block.value.title}»` : 'Раздел'} — ${currentText.value ? `Черновик: ${wordCount.value}/${block.value.wordTarget} слов.` : 'Текст не написан — нажмите «Написать блок».'}`)
 })
 
 // ── Download ─────────────────────────────────────────────────────────────
@@ -711,13 +656,6 @@ function downloadDraft() {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-const intentLabels: Record<string, { label: string; color: string }> = {
-  background: { label: 'фон', color: 'var(--color-ink-muted)' },
-  method: { label: 'метод', color: 'var(--color-accent)' },
-  result_comparison: { label: 'результат', color: 'var(--color-violet)' },
-  extends: { label: 'развивает', color: 'var(--color-ok)' },
-  contrasts: { label: 'оспаривает', color: 'var(--color-cta)' },
-}
 
 function timeAgo(d: Date): string {
   const s = Math.round((Date.now() - d.getTime()) / 1000)
@@ -936,60 +874,15 @@ function timeAgo(d: Date): string {
           </div>
         </div>
 
-        <!-- RIGHT: Fragments panel (w-52) -->
-        <div class="w-52 flex-shrink-0 flex flex-col" style="max-height: calc(100vh - 9rem);">
-          <!-- Search -->
-          <div class="mb-2 flex-shrink-0">
-            <div class="relative">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-[var(--color-ink-muted)]">
-                <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
-              </svg>
-              <input v-model="searchQuery" @input="onSearchInput" type="text"
-                class="w-full rounded-md border border-[var(--color-rule)] bg-[var(--color-paper)] pl-8 pr-3 py-1.5 text-sm placeholder-[var(--color-ink-muted)] focus:border-[var(--color-accent)] focus:outline-none"
-                placeholder="Найти в библиотеке..." />
-            </div>
-          </div>
-          <!-- Search results -->
-          <div v-if="searchQuery.trim() && (searchResults.length > 0 || searching)" class="mb-2 flex-shrink-0">
-            <div class="rounded-md border border-[var(--color-accent)]/30 bg-[var(--color-accent-pale)]/20 overflow-hidden">
-              <div class="px-3 py-1 text-xs font-semibold text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]/40">Результаты</div>
-              <div v-if="searching" class="px-3 py-3 text-center text-xs text-[var(--color-ink-muted)]">Ищу...</div>
-              <div v-else-if="searchResults.length === 0" class="px-3 py-2 text-center text-xs text-[var(--color-ink-muted)]">Не найдено</div>
-              <div v-else class="divide-y divide-[var(--color-rule-light)]">
-                <div v-for="r in searchResults" :key="r.source" class="px-3 py-2 hover:bg-[var(--color-accent-pale)]/40">
-                  <div class="flex items-center gap-1 mb-0.5">
-                    <a :href="`/${projectId}/library/${r.source}`" class="citekey-link" @click.prevent>@{{ r.source.length > 14 ? r.source.slice(0, 14) + '..' : r.source }}</a>
-                    <span class="text-xs text-[var(--color-ink-muted)]">{{ r.year }}</span>
-                    <button @click="attachFragment(r)"
-                      class="ml-auto rounded bg-[var(--color-accent)] px-1.5 py-0.5 text-xs font-medium text-white hover:bg-[var(--color-accent-deep)]">+</button>
-                  </div>
-                  <p class="text-xs text-[var(--color-ink-light)] leading-relaxed line-clamp-2">{{ r.text }}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Attached fragments -->
-          <div class="flex-1 overflow-y-auto space-y-2">
-            <div class="text-xs font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider px-1">
-              Привязано ({{ block.fragments.length }})
-            </div>
-            <div v-for="(f, i) in block.fragments" :key="f.source + i"
-              class="group rounded-md border border-[var(--color-rule-light)] bg-[var(--color-paper-white)] px-3 py-2 relative">
-              <div class="flex items-center gap-1 mb-0.5">
-                <a :href="`/${projectId}/library/${f.source}`" class="citekey-link">@{{ f.source.length > 14 ? f.source.slice(0, 14) + '..' : f.source }}</a>
-                <span class="text-xs text-[var(--color-ink-muted)]">{{ f.year }}</span>
-                <span class="ml-auto text-xs" :style="{ color: intentLabels[f.intent]?.color }">{{ intentLabels[f.intent]?.label }}</span>
-              </div>
-              <p class="text-xs text-[var(--color-ink-light)] leading-relaxed">{{ f.text }}</p>
-              <button @click="detachFragment(i)"
-                class="absolute top-1.5 right-1.5 h-4 w-4 rounded flex items-center justify-center text-[var(--color-ink-muted)] hover:text-[var(--color-err)] hover:bg-[var(--color-err-bg)] opacity-0 group-hover:opacity-100 transition-all"
-                title="Отвязать">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-2.5 w-2.5">
-                  <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
-                </svg>
-              </button>
-            </div>
-          </div>
+        <!-- RIGHT: Source panel (w-52) -->
+        <div class="w-52 flex-shrink-0" style="max-height: calc(100vh - 9rem);">
+          <SourcePanel
+            :sectionId="sectionId"
+            :projectId="projectId ?? ''"
+            :isDemoMode="isDemoMode"
+            @attach="onSourceAttach"
+            @detach="onSourceDetach"
+          />
         </div>
       </div>
 
@@ -1137,60 +1030,15 @@ function timeAgo(d: Date): string {
           </div>
         </div>
 
-        <!-- RIGHT: Fragments panel (1/4) — demo mode -->
-        <div class="lg:col-span-1 flex flex-col" style="max-height: calc(100vh - 9rem);">
-          <!-- Search -->
-          <div class="mb-2 flex-shrink-0">
-            <div class="relative">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-[var(--color-ink-muted)]">
-                <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
-              </svg>
-              <input v-model="searchQuery" @input="onSearchInput" type="text"
-                class="w-full rounded-md border border-[var(--color-rule)] bg-[var(--color-paper)] pl-8 pr-3 py-1.5 text-sm placeholder-[var(--color-ink-muted)] focus:border-[var(--color-accent)] focus:outline-none"
-                placeholder="Найти в библиотеке..." />
-            </div>
-          </div>
-          <!-- Search results -->
-          <div v-if="searchQuery.trim() && (searchResults.length > 0 || searching)" class="mb-2 flex-shrink-0">
-            <div class="rounded-md border border-[var(--color-accent)]/30 bg-[var(--color-accent-pale)]/20 overflow-hidden">
-              <div class="px-3 py-1 text-xs font-semibold text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]/40">Результаты</div>
-              <div v-if="searching" class="px-3 py-3 text-center text-xs text-[var(--color-ink-muted)]">Ищу...</div>
-              <div v-else-if="searchResults.length === 0" class="px-3 py-2 text-center text-xs text-[var(--color-ink-muted)]">Не найдено</div>
-              <div v-else class="divide-y divide-[var(--color-rule-light)]">
-                <div v-for="r in searchResults" :key="r.source" class="px-3 py-2 hover:bg-[var(--color-accent-pale)]/40">
-                  <div class="flex items-center gap-1 mb-0.5">
-                    <a :href="`/demo/library/${r.source}`" class="citekey-link" @click.prevent>@{{ r.source.length > 14 ? r.source.slice(0, 14) + '..' : r.source }}</a>
-                    <span class="text-xs text-[var(--color-ink-muted)]">{{ r.year }}</span>
-                    <button @click="attachFragment(r)"
-                      class="ml-auto rounded bg-[var(--color-accent)] px-1.5 py-0.5 text-xs font-medium text-white hover:bg-[var(--color-accent-deep)]">+</button>
-                  </div>
-                  <p class="text-xs text-[var(--color-ink-light)] leading-relaxed line-clamp-2">{{ r.text }}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Attached fragments -->
-          <div class="flex-1 overflow-y-auto space-y-2">
-            <div class="text-xs font-semibold text-[var(--color-ink-muted)] uppercase tracking-wider px-1">
-              Привязано ({{ block.fragments.length }})
-            </div>
-            <div v-for="(f, i) in block.fragments" :key="f.source + i"
-              class="group rounded-md border border-[var(--color-rule-light)] bg-[var(--color-paper-white)] px-3 py-2 relative">
-              <div class="flex items-center gap-1 mb-0.5">
-                <a :href="`/demo/library/${f.source}`" class="citekey-link">@{{ f.source.length > 14 ? f.source.slice(0, 14) + '..' : f.source }}</a>
-                <span class="text-xs text-[var(--color-ink-muted)]">{{ f.year }}</span>
-                <span class="ml-auto text-xs" :style="{ color: intentLabels[f.intent]?.color }">{{ intentLabels[f.intent]?.label }}</span>
-              </div>
-              <p class="text-xs text-[var(--color-ink-light)] leading-relaxed">{{ f.text }}</p>
-              <button @click="detachFragment(i)"
-                class="absolute top-1.5 right-1.5 h-4 w-4 rounded flex items-center justify-center text-[var(--color-ink-muted)] hover:text-[var(--color-err)] hover:bg-[var(--color-err-bg)] opacity-0 group-hover:opacity-100 transition-all"
-                title="Отвязать">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-2.5 w-2.5">
-                  <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
-                </svg>
-              </button>
-            </div>
-          </div>
+        <!-- RIGHT: Source panel (1/4) — demo mode -->
+        <div class="lg:col-span-1" style="max-height: calc(100vh - 9rem);">
+          <SourcePanel
+            :sectionId="sectionId"
+            :projectId="''"
+            :isDemoMode="true"
+            @attach="onSourceAttach"
+            @detach="onSourceDetach"
+          />
         </div>
       </div>
     </div>

--- a/saas/dashboard/src/views/FileEditorView.vue
+++ b/saas/dashboard/src/views/FileEditorView.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AppLayout from '@/components/AppLayout.vue'
+import FileBrowser from '@/components/FileBrowser.vue'
+import SourcePanel from '@/components/SourcePanel.vue'
+import { drafts, type DraftHeading } from '@/api/client'
+
+const route = useRoute()
+const router = useRouter()
+
+const projectId = computed(() => route.params.projectId as string)
+
+// ── File state ────────────────────────────────────────────────────────────
+const draftFilename = ref('')
+const draftContent = ref('')
+const draftHeadings = ref<DraftHeading[]>([])
+const editingBody = ref('')
+const loading = ref(false)
+const loadError = ref('')
+
+// ── Save state ────────────────────────────────────────────────────────────
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+const saveStatus = ref<SaveStatus>('idle')
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+// ── Cursor section detection ──────────────────────────────────────────────
+const cursorSectionId = ref<string | null>(null)
+const editorEl = ref<HTMLDivElement>()
+let detectTimer: ReturnType<typeof setTimeout> | null = null
+
+function onSelectionChange() {
+  if (detectTimer) clearTimeout(detectTimer)
+  detectTimer = setTimeout(() => {
+    const sel = window.getSelection()
+    if (!sel?.rangeCount || !editorEl.value?.contains(sel.anchorNode)) return
+
+    // Compute character offset within editor
+    const range = sel.getRangeAt(0)
+    const pre = document.createRange()
+    pre.selectNodeContents(editorEl.value)
+    pre.setEnd(range.startContainer, range.startOffset)
+    const charOffset = pre.toString().length
+
+    // Map char offset → line number
+    const textBefore = editingBody.value.slice(0, charOffset)
+    const cursorLine = textBefore.split('\n').length - 1
+
+    // Find last heading at or before cursorLine
+    const heading = [...draftHeadings.value]
+      .reverse()
+      .find(h => h.line <= cursorLine)
+    cursorSectionId.value = heading?.section_id ?? null
+  }, 50)
+}
+
+// ── Load file ─────────────────────────────────────────────────────────────
+async function loadFile(filename: string) {
+  if (!projectId.value) return
+  loading.value = true
+  loadError.value = ''
+  // Pending save: flush before loading new file
+  if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+
+  try {
+    const data = await drafts.get(projectId.value, filename)
+    draftFilename.value = data.name
+    draftContent.value = data.content
+    draftHeadings.value = data.headings
+    editingBody.value = data.content
+    cursorSectionId.value = draftHeadings.value[0]?.section_id ?? null
+
+    await nextTick()
+    if (editorEl.value) {
+      editorEl.value.innerText = data.content
+    }
+
+    // Update URL without full navigation
+    const newPath = `/${projectId.value}/edit/${encodeURIComponent(filename)}`
+    if (route.path !== newPath) {
+      router.replace({ name: 'edit-file', params: { projectId: projectId.value, filename } })
+    }
+  } catch (e: any) {
+    loadError.value = e?.message ?? 'Не удалось загрузить файл'
+  } finally {
+    loading.value = false
+  }
+}
+
+// ── Save ──────────────────────────────────────────────────────────────────
+async function doSave() {
+  if (!projectId.value || !draftFilename.value) return
+  saveStatus.value = 'saving'
+  try {
+    const data = await drafts.save(projectId.value, draftFilename.value, editingBody.value)
+    draftContent.value = data.content
+    draftHeadings.value = data.headings
+    saveStatus.value = 'saved'
+    setTimeout(() => { if (saveStatus.value === 'saved') saveStatus.value = 'idle' }, 2500)
+  } catch {
+    saveStatus.value = 'error'
+  }
+}
+
+function scheduleAutoSave() {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(doSave, 800)
+}
+
+// ── Editor event handlers ─────────────────────────────────────────────────
+function onEditorInput() {
+  editingBody.value = editorEl.value?.innerText ?? ''
+  scheduleAutoSave()
+}
+
+function onEditorKeydown(e: KeyboardEvent) {
+  // Ctrl/Cmd+S → immediate save
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    e.preventDefault()
+    if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+    doSave()
+  }
+}
+
+function onEditorPaste(e: ClipboardEvent) {
+  e.preventDefault()
+  const text = e.clipboardData?.getData('text/plain') ?? ''
+  document.execCommand('insertText', false, text)
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+onMounted(async () => {
+  document.addEventListener('selectionchange', onSelectionChange)
+
+  const filenameParam = route.params.filename as string | undefined
+  if (filenameParam) {
+    await loadFile(decodeURIComponent(filenameParam))
+  } else if (projectId.value) {
+    // Auto-load first available file
+    try {
+      const listData = await drafts.list(projectId.value)
+      if (listData.files.length > 0) {
+        // Sort: intro first, then chapters, then conclusion
+        const sorted = [...listData.files].sort((a, b) => {
+          function order(n: string) {
+            if (n.startsWith('intro')) return -1
+            const m = n.match(/chapter_(\d+)/)
+            if (m?.[1]) return parseInt(m[1])
+            if (n.startsWith('conclusion')) return 99
+            return 50
+          }
+          return order(a.name) - order(b.name)
+        })
+        const first = sorted[0]
+        if (first) await loadFile(first.name)
+      }
+    } catch { /* no files yet */ }
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('selectionchange', onSelectionChange)
+  if (saveTimer) clearTimeout(saveTimer)
+  if (detectTimer) clearTimeout(detectTimer)
+})
+
+// Watch for route filename changes (browser back/forward)
+watch(() => route.params.filename, (filename) => {
+  if (filename && filename !== draftFilename.value) {
+    loadFile(decodeURIComponent(filename as string))
+  }
+})
+</script>
+
+<template>
+  <AppLayout>
+    <!-- Override AppLayout padding: full-bleed 3-column layout -->
+    <div class="-mx-8 -my-8 flex" style="min-height: calc(100vh - 2rem)">
+
+      <!-- LEFT: File browser (w-44) -->
+      <div class="w-44 flex-shrink-0 border-r border-[var(--color-rule-light)] bg-[var(--color-paper-warm)] overflow-hidden">
+        <FileBrowser
+          :projectId="projectId"
+          :activeFile="draftFilename || null"
+          @select="loadFile"
+        />
+      </div>
+
+      <!-- CENTER: Editor -->
+      <div class="flex-1 flex flex-col overflow-hidden">
+        <!-- Toolbar -->
+        <div class="flex items-center gap-3 px-6 py-2 border-b border-[var(--color-rule-light)] flex-shrink-0 min-h-[2.5rem]">
+          <span v-if="draftFilename" class="font-[var(--font-mono)] text-xs text-[var(--color-ink-muted)] truncate">
+            {{ draftFilename }}
+          </span>
+          <div class="flex-1" />
+          <!-- Save status -->
+          <span v-if="saveStatus === 'saving'" class="text-xs text-[var(--color-ink-muted)] flex items-center gap-1.5">
+            <span class="h-3 w-3 border border-[var(--color-ink-muted)] border-t-transparent rounded-full animate-spin" />
+            Сохранение…
+          </span>
+          <span v-else-if="saveStatus === 'saved'" class="text-xs text-[var(--color-ok)]">
+            Сохранено ✓
+          </span>
+          <span v-else-if="saveStatus === 'error'" class="text-xs text-[var(--color-err)]">
+            Ошибка сохранения
+          </span>
+        </div>
+
+        <!-- Error banner -->
+        <div v-if="loadError" class="mx-6 mt-3 rounded-md bg-[var(--color-err-bg)] border border-[var(--color-err)]/30 px-4 py-2 text-sm text-[var(--color-err)] flex-shrink-0">
+          {{ loadError }}
+        </div>
+
+        <!-- Loading state -->
+        <div v-if="loading" class="flex-1 flex items-center justify-center">
+          <div class="flex items-center gap-2 text-sm text-[var(--color-ink-muted)]">
+            <div class="h-4 w-4 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin" />
+            Загрузка…
+          </div>
+        </div>
+
+        <!-- Empty placeholder -->
+        <div v-else-if="!draftFilename" class="flex-1 flex items-center justify-center">
+          <p class="text-sm text-[var(--color-ink-muted)] italic">Выберите файл в панели слева</p>
+        </div>
+
+        <!-- Editor -->
+        <div v-else class="flex-1 overflow-y-auto px-8 py-6">
+          <div
+            ref="editorEl"
+            contenteditable="true"
+            spellcheck="false"
+            style="white-space: pre-wrap; font-size: 15px; line-height: 1.7; min-height: 200px; outline: none"
+            class="draft-editor text-[var(--color-ink)] max-w-3xl mx-auto"
+            @input="onEditorInput"
+            @keydown="onEditorKeydown"
+            @paste.prevent="onEditorPaste"
+          />
+        </div>
+      </div>
+
+      <!-- RIGHT: Source panel (w-52) -->
+      <div class="w-52 flex-shrink-0 border-l border-[var(--color-rule-light)] overflow-hidden">
+        <SourcePanel
+          :sectionId="cursorSectionId"
+          :projectId="projectId"
+          :isDemoMode="false"
+          @attach="() => {}"
+          @detach="() => {}"
+        />
+      </div>
+
+    </div>
+  </AppLayout>
+</template>
+
+<style scoped>
+.draft-editor :deep(h2),
+.draft-editor :deep(h3),
+.draft-editor :deep(h4) {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+</style>

--- a/saas/dashboard/src/views/FileEditorView.vue
+++ b/saas/dashboard/src/views/FileEditorView.vue
@@ -51,7 +51,7 @@ function onSelectionChange() {
       .reverse()
       .find(h => h.line <= cursorLine)
     cursorSectionId.value = heading?.section_id ?? null
-  }, 50)
+  }, 300)
 }
 
 // ── Load file ─────────────────────────────────────────────────────────────
@@ -246,8 +246,8 @@ watch(() => route.params.filename, (filename) => {
           :sectionId="cursorSectionId"
           :projectId="projectId"
           :isDemoMode="false"
-          @attach="() => {}"
-          @detach="() => {}"
+          @attach="() => {/* SourcePanel persists server-side internally */}"
+          @detach="() => {/* detach is local-only in SourcePanel */}"
         />
       </div>
 


### PR DESCRIPTION
### **User description**
Closes #255

## Summary

- `pull_drafts(client, project_root, dashboard_project_id)` in `sync.py`: fetches `GET /projects/{id}/drafts` for file list, then `GET /projects/{id}/drafts/{name}` per file; writes only if content differs (idempotent); creates `draft/` if absent
- `_SAFE_DRAFT_FILENAME = re.compile(r"^[\w.\-]+\.md$")` + `".." in name` guard prevent path traversal when writing server-provided filenames to disk
- `klemma pull` Phase 3: symmetric with push Phase 3 added in #250. Guarded by `dashboard_project_id` presence in sync_config.json
- 5 new `TestPullDrafts` tests (downloads new, skips unchanged, updates changed, blocks unsafe names, handles empty list)
- `cli/CLAUDE.md` updated: sync.py line count, pull data flow Phase 3, test entry

## CTO Review

**Verdict**: ✅ Approve

- **Red lines**: All clear — no state.py imports, no cross-repo imports, no new dependency arrows
- **Dependency direction**: Clean — sync.py stays within cli package, pull_drafts follows same pattern as push_drafts
- **SaaS ready**: Yes — no hardcoded file paths, no Obsidian/Zotero deps, works purely via API
- **Tech debt**: Neutral — closes a missing half of the sync loop; no new patterns introduced

**Suggestions** (non-blocking):
- Per-file error handling: wrap individual file fetch+write in try/except so one bad file doesn't abort the whole pull
- Regex style: `[\w.\-]` → `[\w.-]` (hyphen at end makes no practical difference but is more idiomatic)

## Release Note

### Problem
`klemma push` had Phase 3 since PR #250: it sends local `draft/*.md` to the server via `PUT /projects/{id}/drafts/{filename}`. But `klemma pull` had no corresponding phase — any edits made in the MapView/BlockView dashboard were silently discarded on the next pull cycle. This created a data-loss scenario for researchers editing on the dashboard between CLI sessions.

### Academic Foundation
The bidirectional sync architecture follows the same eventually-consistent model used in distributed collaborative editing systems. The content-equality check before write (idempotent pull) mirrors the approach described in CRDT literature: write only when the incoming state differs from local state, avoiding unnecessary divergence in the git working tree.

### Implementation
Added `pull_drafts()` to `cli/src/klemma_cli/sync.py` (~40 LOC). The function:
1. Lists remote files via `GET /projects/{id}/drafts`
2. Fetches each file individually via `GET /projects/{id}/drafts/{name}`
3. Validates filename with `_SAFE_DRAFT_FILENAME` regex + `".." in name` guard (path traversal prevention)
4. Writes to `project_root/draft/{name}` only if content differs from local copy
5. Creates `draft/` directory if absent

Phase 3 added to `klemma pull` in `main.py`, guarded by `config.dashboard_project_id` (same guard as push Phase 3). CLI output: "Updated N draft file(s)" or "Draft files up to date."

### Results
- 1568 tests pass (5 new `TestPullDrafts` cases: downloads new, skips unchanged, updates changed, blocks path traversal, handles empty list)
- `ruff check` clean
- Bidirectional draft sync complete: push (PR #250) ↔ pull (this PR)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add draft download phase to `pull`

- Fetch changed dashboard drafts safely

- Skip missing project IDs gracefully

- Document flow and add sync tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pull["klemma pull command"]
  guard["Check dashboard_project_id"]
  list["GET /projects/{id}/drafts"]
  fetch["GET per draft file"]
  write["Write changed files to draft/"]
  tests["Sync tests and docs"]

  pull -- "phase 3" --> guard
  guard -- "when present" --> list
  list -- "safe filenames only" --> fetch
  fetch -- "content differs" --> write
  write -- "covered by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add draft sync phase to pull</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/klemma_cli/main.py

<ul><li>Update <code>pull()</code> docstring to three phases<br> <li> Import <code>pull_drafts</code> alongside <code>pull_library</code><br> <li> Run draft pull when <code>dashboard_project_id</code> exists<br> <li> Log skip, success, and failure outcomes</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/256/files#diff-776c855211d357774b0f35827372a1e07f4705193c3fe095e1317ab5fb174f51">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Download remote drafts with safety checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/klemma_cli/sync.py

<ul><li>Add <code>_SAFE_DRAFT_FILENAME</code> regex guard<br> <li> Implement <code>pull_drafts()</code> using drafts APIs<br> <li> Create local <code>draft/</code> directory if needed<br> <li> Write only changed files and count updates</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/256/files#diff-a9415d26f54995e44dde589bbd52cfab5bf9068b44cda24fe834167d981145cd">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Add coverage for draft pull behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/tests/test_sync.py

<ul><li>Import and exercise <code>pull_drafts</code><br> <li> Add mock client helper for draft endpoints<br> <li> Cover new, unchanged, and updated files<br> <li> Verify unsafe names and empty lists</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/256/files#diff-aefc519333bfb81a9d5e5d6a9e4c86622c9e63db6c58d44342e907fa8900c228">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Document draft pull sync flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/CLAUDE.md

<ul><li>Update <code>sync.py</code> scope and line count<br> <li> Document <code>push_drafts</code> and <code>pull_drafts</code><br> <li> Add draft-download step to pull flow<br> <li> Note new <code>test_sync.py</code> draft cases</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/256/files#diff-4c947accdabb8a0ddf5f7ff47f8806165fc725157cec4632a0ce55a2c4c17396">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

