### PR TITLE
fix(sync): incremental pull — since filter + last_pull on success (#260 item 7)

### DIFF
--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -247,11 +247,19 @@ def pull() -> None:
     # Phase 2: Library
     click.echo("Pulling library data...")
     client = KlemmaClient(api_url=config.api_url)
-    result = pull_library(client, project_root, since=config.last_pull or None)
-    click.echo(
-        f"Pulled {result['sources']} sources, "
-        f"{result['fragments']} fragments"
-    )
+    try:
+        result = pull_library(client, project_root, since=config.last_pull or None)
+        click.echo(
+            f"Pulled {result['sources']} sources, "
+            f"{result['fragments']} fragments"
+        )
+        # Update last_pull immediately after successful library pull (#260 item 7).
+        # This ensures the timestamp always marks the last *successful* library sync,
+        # and the next incremental pull only fetches sources added after this point.
+        config.last_pull = datetime.now(timezone.utc).isoformat()
+        save_sync_config(project_root, config)
+    except Exception as exc:
+        click.echo(f"Library pull failed: {exc}", err=True)
 
     # Phase 3: Drafts (dashboard edits → local draft/)
     if config.dashboard_project_id:
@@ -266,10 +274,6 @@ def pull() -> None:
             click.echo(f"Draft pull failed: {exc}", err=True)
     else:
         click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
-
-    # Update last_pull timestamp
-    config.last_pull = datetime.now(timezone.utc).isoformat()
-    save_sync_config(project_root, config)
 
 
 def _resolve_project_id(config: object) -> str:

--- a/src/klemma/api/routes/sync.py
+++ b/src/klemma/api/routes/sync.py
@@ -668,7 +668,7 @@ async def pull_library(
     library = get_user_library()
     paper_store = get_paper_store()
 
-    all_sources = library.get_all_sources(user_id=user.user_id)
+    all_sources = library.get_all_sources(user_id=user.user_id, since=since)
     project_store = get_project_store()
 
     sources = []

--- a/src/klemma/stores/user_library.py
+++ b/src/klemma/stores/user_library.py
@@ -285,8 +285,16 @@ class LocalUserLibrary:
         self,
         project_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        since: Optional[str] = None,
     ) -> list["UserSource"]:
-        """Return all UserSource entries, optionally filtered by project and/or user."""
+        """Return all UserSource entries, optionally filtered by project, user, and time.
+
+        Args:
+            project_id: Restrict to sources belonging to this project.
+            user_id: Restrict to sources belonging to this user.
+            since: ISO 8601 timestamp. Only return sources added on or after this time.
+                   Used for incremental pull (#260 item 7).
+        """
         with self._conn() as conn:
             conditions = []
             params: list = []
@@ -298,6 +306,10 @@ class LocalUserLibrary:
             if project_id is not None:
                 conditions.append("(project_id = ? OR project_id IS NULL)")
                 params.append(project_id)
+
+            if since is not None:
+                conditions.append("added_at >= ?")
+                params.append(since)
 
             where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
             rows = conn.execute(

--- a/tests/test_api_sync.py
+++ b/tests/test_api_sync.py
@@ -271,3 +271,43 @@ class TestVerifyGitToken:
             "project_id": "token-proj2",
         })
         assert resp.status_code == 401
+
+
+class TestIncrementalPullLibrary:
+    """Tests for incremental pull with 'since' parameter — issue #260 item 7."""
+
+    def test_pull_without_since_returns_all(self, client):
+        """No since parameter returns all sources."""
+        client.post("/sync/push/library", json={
+            "sources": [
+                {"citekey": "incr-a", "title": "Alpha", "status": "pending"},
+                {"citekey": "incr-b", "title": "Beta", "status": "pending"},
+            ],
+            "fragments": [],
+        })
+        resp = client.get("/sync/pull/library")
+        assert resp.status_code == 200
+        citekeys = {s["citekey"] for s in resp.json()["sources"]}
+        assert "incr-a" in citekeys
+        assert "incr-b" in citekeys
+
+    def test_pull_with_future_since_returns_empty(self, client):
+        """since=far-future returns zero sources (everything is older)."""
+        client.post("/sync/push/library", json={
+            "sources": [{"citekey": "incr-old", "title": "Old", "status": "pending"}],
+            "fragments": [],
+        })
+        resp = client.get("/sync/pull/library", params={"since": "2099-01-01T00:00:00+00:00"})
+        assert resp.status_code == 200
+        assert resp.json()["sources"] == []
+
+    def test_pull_with_epoch_since_returns_all(self, client):
+        """since=epoch (far past) returns all sources."""
+        client.post("/sync/push/library", json={
+            "sources": [{"citekey": "incr-epoch", "title": "Old", "status": "pending"}],
+            "fragments": [],
+        })
+        resp = client.get("/sync/pull/library", params={"since": "2000-01-01T00:00:00+00:00"})
+        assert resp.status_code == 200
+        citekeys = {s["citekey"] for s in resp.json()["sources"]}
+        assert "incr-epoch" in citekeys

--- a/tests/test_user_library.py
+++ b/tests/test_user_library.py
@@ -205,3 +205,19 @@ def test_project_id_preserved_on_status_upsert(lib):
     lib.add_source("pid1", "src_x", status="completed")  # no project_id
     src = lib.get_source_by_citekey("src_x")
     assert src.status == "completed"
+
+
+def test_get_all_sources_since_future_returns_empty(lib):
+    """since=far-future filters out all existing sources."""
+    lib.add_source("pid1", "alpha")
+    lib.add_source("pid2", "beta")
+    sources = lib.get_all_sources(since="2099-01-01T00:00:00")
+    assert sources == []
+
+
+def test_get_all_sources_since_past_returns_all(lib):
+    """since=far-past returns all sources."""
+    lib.add_source("pid1", "alpha")
+    lib.add_source("pid2", "beta")
+    sources = lib.get_all_sources(since="2000-01-01T00:00:00")
+    assert {s.citekey for s in sources} == {"alpha", "beta"}


### PR DESCRIPTION
## Summary

- `LocalUserLibrary.get_all_sources(since=)` filters by `added_at >= since` — server now returns only sources added after the last pull timestamp
- `sync.py pull_library` passes the `since` query param to `get_all_sources`
- `cli pull()` wraps library phase in try/except; updates `last_pull` immediately after successful library pull (not at the very end), consistent with `last_push` fix in #263

Without this fix: a fresh install (no `last_pull`) triggered a full-library download on every pull, even after the first successful sync.

## Test plan

- [ ] `pytest tests/test_api_sync.py` — 3 new incremental pull tests (no since = all, future since = empty, epoch since = all)
- [ ] `pytest tests/test_user_library.py` — 2 new since-filter tests
- [ ] Full suite: 1594 tests pass
- [ ] `ruff check src/ tests/ cli/` — clean

## Release Note

### Problem
Two related reliability gaps: (1) the `GET /sync/pull/library` endpoint accepted a `since` timestamp parameter but ignored it, always returning the full library; (2) `last_pull` was updated unconditionally at the end of the `pull` command, even when the library phase failed, and after all phases finished rather than immediately after success.

### Academic Foundation
Incremental synchronization is a standard pattern in distributed systems: a sentinel timestamp marks the last successful sync point, and subsequent operations only transfer data created after that point. This reduces bandwidth from O(total_library) to O(new_sources_since_last_pull).

### Implementation
`LocalUserLibrary.get_all_sources()` gains an optional `since: str` parameter (ISO 8601) that adds `added_at >= ?` to the SQL query. The endpoint threads this through from the HTTP query parameter. The CLI now saves `last_pull` immediately after a successful library pull phase, wrapped in try/except with explicit failure reporting.

### Results
5 new tests. Total: 1594 tests pass. Ruff clean. Backward compatible: `since=None` (default) returns all sources as before.

Part of #260