### PR TITLE
fix(cli): filter status output to klemma-synced paths only

### DIFF
--- a/cli/src/klemma_cli/gitops.py
+++ b/cli/src/klemma_cli/gitops.py
@@ -132,10 +132,17 @@ def log(path: Path, count: int = 10, format_str: str = "%h %s") -> list[str]:
     return [line for line in result.stdout.strip().split("\n") if line]
 
 
+_SYNCED_PREFIXES = ("KLEMMA.md", "draft/", "notes/research/", ".gitignore")
+
+
 def status(path: Path) -> str:
-    """Return git status output."""
+    """Return git status filtered to klemma-synced paths only."""
     result = _run(["status", "--short"], cwd=path, check=False)
-    return result.stdout.strip()
+    lines = [
+        line for line in result.stdout.splitlines()
+        if len(line) > 3 and any(line[3:].startswith(p) for p in _SYNCED_PREFIXES)
+    ]
+    return "\n".join(lines)
 
 
 def remote_log(path: Path, remote: str = "klemma", branch: str | None = None) -> list[str]:

--- a/cli/tests/test_gitops.py
+++ b/cli/tests/test_gitops.py
@@ -71,12 +71,23 @@ class TestCommit:
 class TestStatus:
     def test_clean_status(self, git_repo):
         s = status(git_repo)
-        assert s == ""  # or empty — clean repo
+        assert s == ""
 
-    def test_dirty_status(self, git_repo):
-        (git_repo / "new.md").write_text("new file")
+    def test_non_synced_file_hidden(self, git_repo):
+        """Files outside synced paths are not shown."""
+        (git_repo / "random_file.md").write_text("not synced")
         s = status(git_repo)
-        assert "new.md" in s
+        assert s == ""
+
+    def test_synced_file_shown(self, git_repo):
+        """Files under synced paths (KLEMMA.md, draft/, notes/research/) are shown."""
+        (git_repo / "KLEMMA.md").write_text("project metadata")
+        (git_repo / "draft").mkdir()
+        (git_repo / "draft" / "chapter_1.md").write_text("chapter text")
+        s = status(git_repo)
+        assert "KLEMMA.md" in s
+        assert "draft/" in s
+        assert "random_file.md" not in s
 
 
 class TestHasChanges:


### PR DESCRIPTION
### **User description**
## Summary

`klemma-cli status` was showing all untracked files in the dissertation root — papers/, notebooks, Russian thesis chapters, Jupyter experiments. Since `klemma-cli push` only stages `KLEMMA.md`, `draft/`, `notes/research/`, and `.gitignore`, the status output should be filtered to those same paths.

## Change

Added `_SYNCED_PREFIXES` constant to `gitops.py` and filter `git status --short` output to lines matching those prefixes. Non-synced files are silently ignored.

**Before:**
```
=== Local changes ===
M .klemma/config.yaml
?? papers/titds-2025/
?? papers/gm-iiee/
... (30+ unrelated lines)
```

**After:**
```
=== Local changes ===
(clean)   ← or only draft/ / KLEMMA.md changes
```

## Test plan
- [ ] `pytest cli/tests/test_gitops.py` — 20 tests pass
- [ ] `klemma-cli status` in dissertation — shows only klemma-managed files


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Filter status to synced paths only

- Add synced-path prefix allowlist

- Hide unrelated repository file changes

- Expand tests for visible paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gs["Git short status output"]
  fp["Filter by synced prefixes"]
  so["CLI status shows managed files only"]
  tv["Tests verify shown and hidden paths"]
  gs -- "processed by" --> fp
  fp -- "produces" --> so
  fp -- "validated by" --> tv
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitops.py</strong><dd><code>Filter status output to synced paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/klemma_cli/gitops.py

<ul><li>Add <code>_SYNCED_PREFIXES</code> for managed paths<br> <li> Filter <code>status()</code> output by synced prefixes<br> <li> Update docstring to reflect filtered status</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/270/files#diff-dd10fac6d5e6968887e943a09ec3958e225028fe9e718f0aaaa9a95c426e86c6">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gitops.py</strong><dd><code>Add status filtering behavior tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/tests/test_gitops.py

<ul><li>Keep clean repo status expectation empty<br> <li> Add test hiding non-synced file changes<br> <li> Add test showing <code>KLEMMA.md</code> and <code>draft/</code> changes<br> <li> Assert unrelated files stay excluded</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/270/files#diff-2cef3b6ad8e5550e17efb0ec2744a1378d5a4d40f087b9fc36a2c2a2470c979a">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

