### PR TITLE
fix(sync): remove server-side git, pure REST API sync

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,17 +1,17 @@
 # klemma-cli
 
-Lightweight git-native sync client for Klemma SaaS. Separate package (`pip install klemma-cli`).
+Lightweight API-native sync client for Klemma SaaS. Separate package (`pip install klemma-cli`).
 
 ## Architecture
 
-- Files sync via **git** (push/pull to bare repos on server)
-- Library data syncs via **REST API** (batch JSON for sources/fragments/embeddings)
-- No AI, no heavy deps — just click, requests, pydantic, pyyaml + git subprocess
+- All sync via **REST API only** (no server-side git)
+- Local git stays intact — power users use `git` directly; `k status` shows local uncommitted changes
+- No AI, no heavy deps — just click, requests, pydantic, pyyaml + git subprocess (local only)
 
 ## Modules
 
-### main.py (~280 lines)
-Click CLI entry point. 6 commands: `link`, `push`, `pull`, `status`, `rollback`, `login`.
+### main.py (~260 lines)
+Click CLI entry point. 5 commands: `link`, `push`, `pull`, `status`, `login`.
 
 ### auth.py (~80 lines)
 Login to Klemma API, token storage at `~/.klemma-cli/auth.json`.
@@ -22,11 +22,11 @@ Login to Klemma API, token storage at `~/.klemma-cli/auth.json`.
 `KlemmaClient` — HTTP client with auto-refresh on 401.
 - `get(path)`, `post(path, json)` — wrappers with auth headers
 
-### gitops.py (~180 lines)
-Git subprocess wrappers.
-- `init`, `add_remote`, `add_files`, `commit`, `push`, `pull`, `fetch`
-- `log`, `status`, `remote_log`, `revert_last_n`, `force_push`
-- `write_gitignore` — auto-generate .gitignore for klemma projects
+### gitops.py (~110 lines)
+Local git subprocess wrappers (no server transport functions).
+- `is_git_repo`, `init`, `add_files`, `has_changes`, `commit`, `log`
+- `status` — filtered to klemma-synced paths (`KLEMMA.md`, `draft/`, `notes/research/`, `.gitignore`)
+- `get_head_hash`, `write_gitignore`
 
 ### sync.py (~265 lines)
 Library and draft sync — read local SQLite DB and push/pull via API.
@@ -41,8 +41,9 @@ Library and draft sync — read local SQLite DB and push/pull via API.
 ### project.py (~50 lines)
 Project discovery — find `.klemma/` directory, parse KLEMMA.md.
 
-### models.py (~60 lines)
+### models.py (~55 lines)
 Pydantic schemas: `SourcePayload`, `FragmentPayload`, `EmbeddingPayload`, `DecisionPayload`, `SyncConfig`.
+`SyncConfig` fields: `api_url`, `dashboard_project_id`, `last_push`, `last_pull` (no `git_url`, no `access_token`).
 
 ### state.py (~30 lines)
 Sync state persistence — `.klemma/sync_config.json` CRUD.
@@ -51,30 +52,43 @@ Sync state persistence — `.klemma/sync_config.json` CRUD.
 
 ```
 klemma-cli push
-  1. git add KLEMMA.md notes/drafts/ notes/research/ .gitignore
-  2. git commit "sync: push from CLI — {date}"
-  3. git push klemma main
-  4. Read local library.db → POST /sync/push/library (sources + fragments)
-  5. Read local embeddings → POST /sync/push/embeddings (base64 chunks)
-  6. Update .klemma/sync_config.json last_push timestamp
+  1. Read local library.db → POST /sync/push/library (sources + fragments)
+  2. Read local embeddings → POST /sync/push/embeddings (base64 chunks)
+  3. PUT draft/*.md → POST /projects/{id}/drafts/{name} (each file)
+  4. Update .klemma/sync_config.json last_push timestamp
 ```
 
 ## Data flow: pull
 
 ```
 klemma-cli pull
-  1. git pull klemma main (conflicts → print instructions)
-  2. GET /sync/pull/library → write sources/fragments to local library.db
-  3. GET /projects/{id}/drafts → list; GET /projects/{id}/drafts/{name} per file
+  1. GET /sync/pull/library → write sources/fragments to local library.db
+  2. GET /projects/{id}/drafts → list; GET /projects/{id}/drafts/{name} per file
      → write to draft/{name} only if content differs (ADR-016)
-  4. Update .klemma/sync_config.json last_pull timestamp
+  3. Update .klemma/sync_config.json last_pull timestamp
 ```
+
+## Data flow: link
+
+```
+klemma-cli link
+  1. Login → GET /projects (find by name) or POST /projects (create)
+  2. write_gitignore(project_root)
+  3. Save SyncConfig {api_url, dashboard_project_id} to .klemma/sync_config.json
+```
+
+## Local git story
+
+- `k status` shows local uncommitted changes via `git status --short` (filtered to synced paths)
+- Power users: use `git add / commit / log` directly in the dissertation directory
+- `k link` writes `.gitignore` with klemma-specific exclusions
+- Server has no bare repos — all file sync via `/projects/{id}/drafts` REST API
 
 ## Tests
 
-- `cli/tests/test_gitops.py` — git subprocess wrapper tests
+- `cli/tests/test_gitops.py` — git subprocess wrapper tests (local ops only)
 - `cli/tests/test_project.py` — project discovery tests
 - `cli/tests/test_sync.py` — library DB read tests + pull_drafts tests (5 cases)
-- `tests/test_api_sync.py` — backend sync API endpoint tests (15 tests)
+- `tests/test_api_sync.py` — backend sync API endpoint tests (library sync only)
 
 See: [API Routes](../src/klemma/api/routes/CLAUDE.md) | [Root](../CLAUDE.md)

--- a/cli/src/klemma_cli/client.py
+++ b/cli/src/klemma_cli/client.py
@@ -49,12 +49,12 @@ class KlemmaClient:
         resp.raise_for_status()
         return resp
 
-    def post(self, path: str, json: Any = None, **kwargs: Any) -> requests.Response:
+    def post(self, path: str, json: Any = None, timeout: int = 120, **kwargs: Any) -> requests.Response:
         """POST request with auto-refresh on 401."""
         url = f"{self.api_url}{path}"
-        resp = requests.post(url, headers=self._headers(), json=json, timeout=30, **kwargs)
+        resp = requests.post(url, headers=self._headers(), json=json, timeout=timeout, **kwargs)
         if self._maybe_refresh(resp):
-            resp = requests.post(url, headers=self._headers(), json=json, timeout=30, **kwargs)
+            resp = requests.post(url, headers=self._headers(), json=json, timeout=timeout, **kwargs)
         resp.raise_for_status()
         return resp
 

--- a/cli/src/klemma_cli/gitops.py
+++ b/cli/src/klemma_cli/gitops.py
@@ -1,8 +1,11 @@
-"""Git subprocess wrappers for klemma-cli sync operations."""
+"""Git subprocess wrappers for local klemma-cli operations.
+
+Only local git operations — no server transport (push/pull to remote).
+Server sync is handled exclusively via the REST API (sync.py).
+"""
 
 from __future__ import annotations
 
-import base64
 import subprocess
 from pathlib import Path
 
@@ -47,16 +50,6 @@ def init(path: Path) -> None:
     _run(["init"], cwd=path)
 
 
-def add_remote(path: Path, name: str, url: str) -> None:
-    """Add a git remote. Removes existing remote with same name first."""
-    # Check if remote exists
-    result = _run(["remote", "get-url", name], cwd=path, check=False)
-    if result.returncode == 0:
-        _run(["remote", "set-url", name, url], cwd=path)
-    else:
-        _run(["remote", "add", name, url], cwd=path)
-
-
 def add_files(path: Path, patterns: list[str]) -> None:
     """Stage files matching patterns."""
     for pattern in patterns:
@@ -85,41 +78,6 @@ def commit(path: Path, message: str) -> str | None:
     return hash_result.stdout.strip()
 
 
-def current_branch(path: Path) -> str:
-    """Return the current branch name, or 'main' as fallback."""
-    result = _run(["rev-parse", "--abbrev-ref", "HEAD"], cwd=path, check=False)
-    if result.returncode == 0 and result.stdout.strip():
-        return result.stdout.strip()
-    return "main"
-
-
-def push(path: Path, remote: str = "klemma", branch: str | None = None) -> bool:
-    """Push to remote. Returns True on success, False if rejected."""
-    branch = branch or current_branch(path)
-    result = _run(["push", remote, branch], cwd=path, check=False)
-    if result.returncode != 0:
-        if "rejected" in result.stderr or "non-fast-forward" in result.stderr:
-            return False
-        raise GitError("push", result.stderr.strip())
-    return True
-
-
-def pull(path: Path, remote: str = "klemma", branch: str | None = None) -> str:
-    """Pull from remote. Returns output text."""
-    branch = branch or current_branch(path)
-    result = _run(["pull", remote, branch, "--no-rebase"], cwd=path, check=False)
-    if result.returncode != 0:
-        if "CONFLICT" in result.stdout + result.stderr:
-            return f"CONFLICT: {result.stdout}\n{result.stderr}"
-        raise GitError("pull", result.stderr.strip())
-    return result.stdout.strip()
-
-
-def fetch(path: Path, remote: str = "klemma") -> None:
-    """Fetch from remote."""
-    _run(["fetch", remote], cwd=path, check=False)
-
-
 def log(path: Path, count: int = 10, format_str: str = "%h %s") -> list[str]:
     """Return recent commit log entries."""
     result = _run(
@@ -145,59 +103,12 @@ def status(path: Path) -> str:
     return "\n".join(lines)
 
 
-def remote_log(path: Path, remote: str = "klemma", branch: str | None = None) -> list[str]:
-    """Return commits on remote that are not in local HEAD."""
-    branch = branch or current_branch(path)
-    fetch(path, remote)
-    result = _run(
-        ["log", f"HEAD..{remote}/{branch}", "--oneline"],
-        cwd=path,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    return [line for line in result.stdout.strip().split("\n") if line]
-
-
-def revert_last_n(path: Path, n: int) -> None:
-    """Revert the last N commits (creates revert commits)."""
-    if n <= 0:
-        return
-    _run(["revert", "--no-edit", f"HEAD~{n}..HEAD"], cwd=path)
-
-
-def force_push(path: Path, remote: str = "klemma", branch: str | None = None) -> None:
-    """Force push with lease (safe force push)."""
-    branch = branch or current_branch(path)
-    _run(["push", "--force-with-lease", remote, branch], cwd=path)
-
-
 def get_head_hash(path: Path) -> str | None:
     """Return HEAD commit hash or None if no commits."""
     result = _run(["rev-parse", "HEAD"], cwd=path, check=False)
     if result.returncode != 0:
         return None
     return result.stdout.strip()
-
-
-def set_http_auth_header(path: Path, server_url: str, token: str) -> None:
-    """Configure git to use an Authorization header for requests to server_url.
-
-    Stores auth in the local repo git config (.git/config), not embedded in
-    the remote URL — so tokens are never visible in 'git remote -v' or pushed
-    to the server.
-
-    Args:
-        path: Path to the local git repository.
-        server_url: URL prefix to match, e.g. 'https://litresearch.ru'.
-        token: Raw access token (encoded as 'Basic token:<token>').
-    """
-    encoded = base64.b64encode(f"token:{token}".encode()).decode()
-    _run(
-        ["config", "--local", f"http.{server_url}/.extraHeader",
-         f"Authorization: Basic {encoded}"],
-        cwd=path,
-    )
 
 
 def write_gitignore(path: Path) -> None:

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -162,11 +162,15 @@ def push() -> None:
         click.echo("Pushing draft files...")
         try:
             draft_result = push_drafts(client, project_root, config.dashboard_project_id)
-            if draft_result["files"]:
-                click.echo(
-                    f"Pushed {draft_result['files']} draft file(s), "
-                    f"{draft_result['words']} words"
-                )
+            pushed = draft_result["files"]
+            skipped = draft_result.get("skipped", 0)
+            if pushed:
+                msg = f"Pushed {pushed} draft file(s), {draft_result['words']} words"
+                if skipped:
+                    msg += f" ({skipped} skipped — server copy is newer)"
+                click.echo(msg)
+            elif skipped:
+                click.echo(f"Draft files up to date ({skipped} file(s) skipped — server copy is newer).")
             else:
                 click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
@@ -217,8 +221,15 @@ def pull() -> None:
         click.echo("Pulling draft files...")
         try:
             draft_result = pull_drafts(client, project_root, config.dashboard_project_id)
-            if draft_result["files"]:
-                click.echo(f"Updated {draft_result['files']} draft file(s)")
+            updated = draft_result["files"]
+            skipped = draft_result.get("skipped", 0)
+            if updated:
+                msg = f"Updated {updated} draft file(s)"
+                if skipped:
+                    msg += f" ({skipped} skipped — local copy is newer)"
+                click.echo(msg)
+            elif skipped:
+                click.echo(f"Draft files up to date ({skipped} file(s) skipped — local copy is newer).")
             else:
                 click.echo("Draft files up to date.")
         except Exception as exc:

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -1,6 +1,9 @@
-"""klemma-cli — git-native sync client for Klemma SaaS.
+"""klemma-cli — API-native sync client for Klemma SaaS.
 
-Commands: link, push, pull, status, rollback
+Commands: link, push, pull, status, login
+
+Sync is via REST API only. Local git operations (commit, log) are available
+directly through git or via gitops helpers for those who prefer the CLI.
 """
 
 from __future__ import annotations
@@ -19,31 +22,21 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option("--api-url", default="https://litresearch.ru/api", help="API base URL (include /api for production)")
+@click.option("--api-url", default="https://litresearch.ru/api", help="API base URL")
 @click.option("--email", default=None, help="Account email")
 @click.option("--password", default=None, help="Account password")
 def link(api_url: str, email: str | None, password: str | None) -> None:
     """Connect this project to Klemma SaaS.
 
-    Discovers .klemma/ project root, logs in, creates a server-side git repo,
-    initializes local git, and sets up the 'klemma' remote.
+    Discovers .klemma/ project root, logs in, finds or creates a dashboard project,
+    and saves the sync configuration.
     """
-    from urllib.parse import urlparse
-
     from .auth import login
     from .client import KlemmaClient
-    from .gitops import (
-        add_files,
-        add_remote,
-        commit,
-        init,
-        is_git_repo,
-        set_http_auth_header,
-        write_gitignore,
-    )
+    from .gitops import write_gitignore
     from .models import SyncConfig
     from .project import ensure_project_root, get_project_name
-    from .state import load_sync_config, save_sync_config
+    from .state import save_sync_config
 
     # 0. Show server URL and project BEFORE asking for credentials
     click.echo(f"Server: {api_url}")
@@ -52,7 +45,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
     click.echo(f"Project: {project_name} ({project_root})")
     click.echo()
 
-    # 1. Prompt for credentials (after user sees where they're going)
+    # 1. Prompt for credentials
     if not email:
         email = click.prompt("Email")
     if not password:
@@ -65,75 +58,40 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
     except Exception as e:
         click.echo(f"Login failed: {e}", err=True)
         raise SystemExit(1)
-    username = auth_data.get("username", "")
-    click.echo(f"Logged in as {auth_data['email']} ({username})")
+    click.echo(f"Logged in as {auth_data['email']}")
 
-    # 3. Create server-side repo (username/project-name format, like GitHub)
+    # 3. Find or create dashboard project
     client = KlemmaClient(api_url=api_url, access_token=auth_data["access_token"])
-    project_slug = project_name.lower().replace(" ", "-").replace("_", "-")
-
+    dashboard_project_id = ""
     try:
-        resp = client.post("/sync/init-repo", json={"project_id": project_slug})
-        repo_data = resp.json()
-    except Exception as e:
-        error_msg = str(e)
-        if "409" in error_msg:
-            click.echo("Server repo already exists — reconnecting.")
-            base = api_url.rstrip("/").removesuffix("/api")
-            namespaced = f"{username}/{project_slug}" if username else project_slug
-            repo_data = {"git_url": f"{base}/git/{namespaced}.git", "access_token": ""}
-            # Recover git token from existing sync_config so auth header is re-applied.
-            existing_config = load_sync_config(project_root)
-            if existing_config and existing_config.access_token:
-                repo_data["access_token"] = existing_config.access_token
-            # Look up dashboard_project_id for this git project (#260 item 5)
-            try:
-                lookup = client.get("/sync/dashboard-project", params={"project_id": namespaced})
-                lookup.raise_for_status()
-                repo_data["dashboard_project_id"] = lookup.json().get("dashboard_project_id", "")
-            except Exception as lookup_err:
-                click.echo(
-                    f"Warning: could not resolve dashboard project ID ({lookup_err}).\n"
-                    "Draft sync will be skipped until this is resolved.\n"
-                    "Open https://litresearch.ru, create a project, then re-run 'klemma-cli link'.",
-                    err=True,
-                )
+        resp = client.get("/projects")
+        projects = resp.json().get("projects", [])
+        # Find existing project by name (case-insensitive)
+        match = next(
+            (p for p in projects if p["name"].lower() == project_name.lower()),
+            None,
+        )
+        if match:
+            dashboard_project_id = match["project_id"]
+            click.echo(f"Found existing project: {project_name} ({dashboard_project_id[:8]})")
         else:
-            click.echo(f"Failed to create server repo: {e}", err=True)
-            raise SystemExit(1)
+            create_resp = client.post("/projects", json={"name": project_name})
+            dashboard_project_id = create_resp.json()["project_id"]
+            click.echo(f"Created project: {project_name} ({dashboard_project_id[:8]})")
+    except Exception as e:
+        click.echo(
+            f"Warning: could not find/create dashboard project ({e}).\n"
+            "Draft sync will be skipped. Re-run 'klemma-cli link' to retry.",
+            err=True,
+        )
 
-    git_url = repo_data["git_url"]
-    access_token = repo_data.get("access_token", "")
-
-    # 4. Init local git
-    if not is_git_repo(project_root):
-        click.echo("Initializing git repository...")
-        init(project_root)
-
-    # 5. Add remote (clean URL — token stored in git local config, not in URL)
-    add_remote(project_root, "klemma", git_url)
-    click.echo(f"Remote 'klemma' set to {git_url}")
-    if access_token:
-        parsed = urlparse(git_url)
-        server_url = f"{parsed.scheme}://{parsed.netloc}"
-        set_http_auth_header(project_root, server_url, access_token)
-
-    # 6. Auto-generate .gitignore
+    # 4. Write .gitignore (local git stays, just no server transport)
     write_gitignore(project_root)
 
-    # 7. Initial commit + push
-    add_files(project_root, ["KLEMMA.md", "draft/", "notes/", ".gitignore"])
-    commit_hash = commit(project_root, f"sync: initial link — {datetime.now(timezone.utc).strftime('%Y-%m-%d')}")
-    if commit_hash:
-        click.echo(f"Initial commit: {commit_hash[:8]}")
-
-    # 8. Save sync config
+    # 5. Save sync config
     config = SyncConfig(
-        project_id=repo_data.get("project_id", project_slug),
         api_url=api_url,
-        git_url=git_url,
-        access_token=access_token,
-        dashboard_project_id=repo_data.get("dashboard_project_id", ""),
+        dashboard_project_id=dashboard_project_id,
     )
     save_sync_config(project_root, config)
     click.echo("Linked! Run 'klemma-cli push' to sync.")
@@ -144,7 +102,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
 @click.option("--email", default=None, help="Account email")
 @click.option("--password", default=None, help="Account password")
 def login(api_url: str | None, email: str | None, password: str | None) -> None:
-    """Refresh auth tokens without changing git remotes or sync config.
+    """Refresh auth tokens without changing sync config.
 
     Use when 'klemma-cli pull' or 'push' returns 401 Unauthorized.
     """
@@ -170,13 +128,8 @@ def login(api_url: str | None, email: str | None, password: str | None) -> None:
 
 @cli.command()
 def push() -> None:
-    """Push local changes to Klemma SaaS.
-
-    Two phases: git push (files) + API push (library data).
-    """
+    """Push local changes to Klemma SaaS (library + drafts via API)."""
     from .client import KlemmaClient
-    from .gitops import add_files, commit
-    from .gitops import push as git_push
     from .project import ensure_project_root
     from .state import load_sync_config, save_sync_config
     from .sync import push_drafts, push_library
@@ -187,33 +140,10 @@ def push() -> None:
         click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
         raise SystemExit(1)
 
-    # Phase 1: Git (may fail if git-http-backend not configured on server)
-    click.echo("Pushing files...")
-    add_files(project_root, [
-        "KLEMMA.md",
-        "draft/",
-        "notes/research/",
-        ".gitignore",
-    ])
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
-    commit_hash = commit(project_root, f"sync: push from CLI — {now}")
-    if commit_hash:
-        click.echo(f"Committed: {commit_hash[:8]}")
-    else:
-        click.echo("No file changes to commit.")
-
-    try:
-        success = git_push(project_root)
-        if not success:
-            click.echo("Push rejected — run 'klemma-cli pull' first.", err=True)
-        else:
-            click.echo("Files pushed.")
-    except Exception as exc:
-        click.echo(f"Git push failed: {exc}", err=True)
-
-    # Phase 2: Library
-    click.echo("Pushing library data...")
     client = KlemmaClient(api_url=config.api_url)
+
+    # Phase 1: Library
+    click.echo("Pushing library data...")
     library_ok = False
     try:
         result = push_library(client, project_root)
@@ -226,7 +156,7 @@ def push() -> None:
     except Exception as exc:
         click.echo(f"Library push failed: {exc}", err=True)
 
-    # Phase 3: Drafts
+    # Phase 2: Drafts
     drafts_ok = False
     if config.dashboard_project_id:
         click.echo("Pushing draft files...")
@@ -238,7 +168,7 @@ def push() -> None:
                     f"{draft_result['words']} words"
                 )
             else:
-                click.echo("No draft files found (draft/ is empty or missing — run migrate_drafts.py).")
+                click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
         except Exception as exc:
             click.echo(f"Draft push failed: {exc}", err=True)
@@ -246,7 +176,6 @@ def push() -> None:
         click.echo("Draft push skipped (no dashboard_project_id — re-run 'klemma-cli link').")
         drafts_ok = True  # N/A, not a failure
 
-    # Only update last_push when library + drafts both succeeded (#260 item 3)
     if library_ok and drafts_ok:
         config.last_push = datetime.now(timezone.utc).isoformat()
     else:
@@ -256,12 +185,8 @@ def push() -> None:
 
 @cli.command()
 def pull() -> None:
-    """Pull changes from Klemma SaaS.
-
-    Three phases: git pull (files) + API pull (library data) + draft files.
-    """
+    """Pull changes from Klemma SaaS (library + drafts via API)."""
     from .client import KlemmaClient
-    from .gitops import pull as git_pull
     from .project import ensure_project_root
     from .state import load_sync_config, save_sync_config
     from .sync import pull_drafts, pull_library
@@ -272,36 +197,22 @@ def pull() -> None:
         click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
         raise SystemExit(1)
 
-    # Phase 1: Git (may fail if git-http-backend not configured on server)
-    click.echo("Pulling files...")
-    try:
-        output = git_pull(project_root)
-        if output.startswith("CONFLICT"):
-            click.echo("Merge conflicts detected. Resolve manually, then run 'klemma-cli pull' again.")
-            click.echo(output)
-            raise SystemExit(1)
-        click.echo(output or "Already up to date.")
-    except Exception:
-        click.echo("Git pull skipped (server git transport not configured).")
-
-    # Phase 2: Library
-    click.echo("Pulling library data...")
     client = KlemmaClient(api_url=config.api_url)
+
+    # Phase 1: Library
+    click.echo("Pulling library data...")
     try:
         result = pull_library(client, project_root, since=config.last_pull or None)
         click.echo(
             f"Pulled {result['sources']} sources, "
             f"{result['fragments']} fragments"
         )
-        # Update last_pull immediately after successful library pull (#260 item 7).
-        # This ensures the timestamp always marks the last *successful* library sync,
-        # and the next incremental pull only fetches sources added after this point.
         config.last_pull = datetime.now(timezone.utc).isoformat()
         save_sync_config(project_root, config)
     except Exception as exc:
         click.echo(f"Library pull failed: {exc}", err=True)
 
-    # Phase 3: Drafts (dashboard edits → local draft/)
+    # Phase 2: Drafts
     if config.dashboard_project_id:
         click.echo("Pulling draft files...")
         try:
@@ -316,28 +227,11 @@ def pull() -> None:
         click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
 
 
-def _resolve_project_id(config: object) -> str:
-    """Get the namespaced project_id (username/project) from config.
-
-    Falls back to extracting from git_url if project_id lacks a slash.
-    """
-    pid = config.project_id  # type: ignore[attr-defined]
-    if "/" in pid:
-        return pid
-    # Extract from git_url: https://litresearch.ru/git/username/project.git
-    git_url = config.git_url  # type: ignore[attr-defined]
-    if "/git/" in git_url:
-        path = git_url.split("/git/", 1)[1].removesuffix(".git")
-        if "/" in path:
-            return path
-    return pid
-
-
 @cli.command("status")
 def sync_status() -> None:
-    """Show sync status — local changes + remote diff + library counts."""
-    from .client import KlemmaClient  # noqa: I001
-    from .gitops import remote_log, status as git_status
+    """Show sync status — local changes + server library counts."""
+    from .client import KlemmaClient
+    from .gitops import status as git_status
     from .project import ensure_project_root
     from .state import load_sync_config
 
@@ -352,65 +246,16 @@ def sync_status() -> None:
     click.echo("=== Local changes ===")
     click.echo(local or "(clean)")
 
-    # Remote changes
-    remote = remote_log(project_root)
-    click.echo("\n=== Remote changes (not pulled) ===")
-    if remote:
-        for line in remote:
-            click.echo(f"  {line}")
-    else:
-        click.echo("  (up to date)")
-
     # Library status from server
     click.echo("\n=== Library ===")
     try:
         client = KlemmaClient(api_url=config.api_url)
-        project_id = _resolve_project_id(config)
-        resp = client.get(f"/sync/status/{project_id}")
+        resp = client.get(f"/sync/status/{config.dashboard_project_id}")
         data = resp.json()
         click.echo(f"  Sources: {data['source_count']}")
         click.echo(f"  Fragments: {data['fragment_count']}")
-        if data.get("last_commit"):
-            click.echo(f"  Last commit: {data['last_commit']} ({data.get('last_commit_date', '')})")
     except Exception as e:
         click.echo(f"  (could not reach server: {e})")
-
-
-@cli.command()
-@click.argument("n", type=int, default=1)
-def rollback(n: int) -> None:
-    """Rollback the last N commits (files only, not library data).
-
-    Creates revert commits and force-pushes to the server.
-    """
-    from .gitops import force_push, log, revert_last_n
-    from .project import ensure_project_root
-    from .state import load_sync_config
-
-    project_root = ensure_project_root()
-    config = load_sync_config(project_root)
-    if not config:
-        click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
-        raise SystemExit(1)
-
-    # Show recent history
-    history = log(project_root, count=10)
-    click.echo("Recent history:")
-    for entry in history:
-        click.echo(f"  {entry}")
-
-    if n < 1:
-        click.echo("Nothing to rollback.")
-        return
-
-    click.echo(f"\nRolling back {n} commit(s)...")
-    try:
-        revert_last_n(project_root, n)
-        force_push(project_root)
-        click.echo(f"Rolled back {n} commit(s) and pushed to server.")
-    except Exception as e:
-        click.echo(f"Rollback failed: {e}", err=True)
-        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -154,7 +154,11 @@ def push() -> None:
         )
         library_ok = True
     except Exception as exc:
-        click.echo(f"Library push failed: {exc}", err=True)
+        msg = str(exc)
+        if "401" in msg or "Unauthorized" in msg:
+            click.echo("Library push failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+        else:
+            click.echo(f"Library push failed: {exc}", err=True)
 
     # Phase 2: Drafts
     drafts_ok = False
@@ -175,7 +179,11 @@ def push() -> None:
                 click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
         except Exception as exc:
-            click.echo(f"Draft push failed: {exc}", err=True)
+            msg = str(exc)
+            if "401" in msg or "Unauthorized" in msg:
+                click.echo("Draft push failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+            else:
+                click.echo(f"Draft push failed: {exc}", err=True)
     else:
         click.echo("Draft push skipped (no dashboard_project_id — re-run 'klemma-cli link').")
         drafts_ok = True  # N/A, not a failure
@@ -214,7 +222,11 @@ def pull() -> None:
         config.last_pull = datetime.now(timezone.utc).isoformat()
         save_sync_config(project_root, config)
     except Exception as exc:
-        click.echo(f"Library pull failed: {exc}", err=True)
+        msg = str(exc)
+        if "401" in msg or "Unauthorized" in msg:
+            click.echo("Library pull failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+        else:
+            click.echo(f"Library pull failed: {exc}", err=True)
 
     # Phase 2: Drafts
     if config.dashboard_project_id:
@@ -233,7 +245,11 @@ def pull() -> None:
             else:
                 click.echo("Draft files up to date.")
         except Exception as exc:
-            click.echo(f"Draft pull failed: {exc}", err=True)
+            msg = str(exc)
+            if "401" in msg or "Unauthorized" in msg:
+                click.echo("Draft pull failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+            else:
+                click.echo(f"Draft pull failed: {exc}", err=True)
     else:
         click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
 

--- a/cli/src/klemma_cli/models.py
+++ b/cli/src/klemma_cli/models.py
@@ -49,10 +49,7 @@ class DecisionPayload(BaseModel):
 class SyncConfig(BaseModel):
     """Persisted in .klemma/sync_config.json."""
 
-    project_id: str
     api_url: str
-    git_url: str
-    access_token: str
-    dashboard_project_id: str = ""  # UUID for /projects/{id}/drafts API
+    dashboard_project_id: str  # UUID for /projects/{id}/drafts API
     last_push: str = ""
     last_pull: str = ""

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import re
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -159,14 +160,37 @@ def push_library(client: KlemmaClient, project_root: Path) -> dict:
 
     result = {"sources": 0, "fragments": 0, "embeddings": 0}
 
-    if sources or fragments:
+    # Push in chunks to avoid timeout on large libraries
+    src_chunk = 200
+    frag_chunk = 1000
+    src_list = [s.model_dump() for s in sources]
+    frag_list = [f.model_dump() for f in fragments]
+
+    # First chunk carries all sources + first batch of fragments
+    for src_start in range(0, max(len(src_list), 1), src_chunk):
+        src_batch = src_list[src_start:src_start + src_chunk]
+        frag_start = (src_start // src_chunk) * frag_chunk
+        frag_batch = frag_list[frag_start:frag_start + frag_chunk]
+        if not src_batch and not frag_batch:
+            break
         resp = client.post("/sync/push/library", json={
-            "sources": [s.model_dump() for s in sources],
-            "fragments": [f.model_dump() for f in fragments],
+            "sources": src_batch,
+            "fragments": frag_batch,
         })
         data = resp.json()
-        result["sources"] = data.get("sources_saved", 0)
-        result["fragments"] = data.get("fragments_saved", 0)
+        result["sources"] += data.get("sources_saved", 0)
+        result["fragments"] += data.get("fragments_saved", 0)
+
+    # Push any remaining fragments not covered by source chunks
+    src_batches_count = max(1, (len(src_list) + src_chunk - 1) // src_chunk)
+    frag_offset = src_batches_count * frag_chunk
+    for i in range(frag_offset, len(frag_list), frag_chunk):
+        resp = client.post("/sync/push/library", json={
+            "sources": [],
+            "fragments": frag_list[i:i + frag_chunk],
+        })
+        data = resp.json()
+        result["fragments"] += data.get("fragments_saved", 0)
 
     # Push embeddings in chunks
     paper_embs, fragment_embs = read_local_embeddings(project_root)
@@ -197,19 +221,40 @@ def push_library(client: KlemmaClient, project_root: Path) -> dict:
 def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: str) -> dict:
     """Push local draft .md files to server's /projects/{id}/drafts API.
 
-    Reads all .md files from draft/ (ADR-016 canonical location) and uploads each
-    via PUT /projects/{id}/drafts/{filename}.
-    Returns summary dict with 'files' and 'words' counts.
+    Only pushes a file if the local copy is strictly newer than the server copy.
+    This prevents older local files from overwriting dashboard edits.
+    Returns summary dict with 'files' (pushed count), 'skipped', and 'words'.
     """
     drafts_dir = project_root / "draft"
-    result: dict = {"files": 0, "words": 0}
+    result: dict = {"files": 0, "skipped": 0, "words": 0}
 
     if not drafts_dir.exists():
         return result
 
+    # Fetch server file timestamps once
+    server_times: dict[str, datetime] = {}
+    try:
+        resp = client.get(f"/projects/{dashboard_project_id}/drafts")
+        for f in resp.json().get("files", []):
+            ts = f.get("updated_at", "")
+            if ts:
+                try:
+                    server_times[f["name"]] = datetime.fromisoformat(ts)
+                except ValueError:
+                    pass
+    except Exception:
+        pass  # if list fails, push everything
+
     for md_file in sorted(drafts_dir.glob("*.md")):
-        content = md_file.read_text(encoding="utf-8")
         filename = md_file.name
+        local_mtime = datetime.fromtimestamp(md_file.stat().st_mtime, tz=timezone.utc)
+        server_mtime = server_times.get(filename)
+
+        if server_mtime and server_mtime >= local_mtime:
+            result["skipped"] += 1
+            continue
+
+        content = md_file.read_text(encoding="utf-8")
         resp = client.put(
             f"/projects/{dashboard_project_id}/drafts/{filename}",
             json={"content": content},
@@ -241,19 +286,34 @@ def pull_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: 
     draft_dir = project_root / "draft"
     draft_dir.mkdir(exist_ok=True)
 
+    result["skipped"] = 0
+
     for file_info in file_list:
         name = file_info.get("name", "")
         if not _SAFE_DRAFT_FILENAME.match(name) or ".." in name:
             continue  # skip unsafe filenames
+
+        target = draft_dir / name
+
+        # Skip if local copy is strictly newer than server copy
+        server_ts = file_info.get("updated_at", "")
+        if server_ts and target.exists():
+            try:
+                server_mtime = datetime.fromisoformat(server_ts)
+                local_mtime = datetime.fromtimestamp(target.stat().st_mtime, tz=timezone.utc)
+                if local_mtime > server_mtime:
+                    result["skipped"] += 1
+                    continue
+            except ValueError:
+                pass
 
         content_resp = client.get(f"/projects/{dashboard_project_id}/drafts/{name}")
         data = content_resp.json()
         content: str = data.get("content", "")
         wc: int = data.get("word_count", 0)
 
-        target = draft_dir / name
         if target.exists() and target.read_text(encoding="utf-8") == content:
-            continue  # already up to date
+            continue  # already up to date (same content)
 
         target.write_text(content, encoding="utf-8")
         result["files"] += 1

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -242,8 +242,11 @@ def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: 
                     server_times[f["name"]] = datetime.fromisoformat(ts)
                 except ValueError:
                     pass
-    except Exception:
-        pass  # if list fails, push everything
+    except Exception as e:
+        # Re-raise auth errors so caller can show helpful message
+        if "401" in str(e) or "Unauthorized" in str(e):
+            raise
+        # Other errors (network, 404) — proceed without timestamps, push everything
 
     for md_file in sorted(drafts_dir.glob("*.md")):
         filename = md_file.name

--- a/cli/tests/test_gitops.py
+++ b/cli/tests/test_gitops.py
@@ -14,7 +14,6 @@ from klemma_cli.gitops import (
     init,
     is_git_repo,
     log,
-    set_http_auth_header,
     status,
     write_gitignore,
 )
@@ -126,37 +125,6 @@ class TestGetHeadHash:
         h = get_head_hash(git_repo)
         assert h is not None
         assert len(h) == 40
-
-
-class TestSetHttpAuthHeader:
-    def test_stores_authorization_header_in_local_config(self, git_repo):
-        set_http_auth_header(git_repo, "https://litresearch.ru", "mytoken123")
-        result = subprocess.run(
-            ["git", "config", "--local", "http.https://litresearch.ru/.extraHeader"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        assert result.returncode == 0
-        assert "Authorization: Basic" in result.stdout
-
-    def test_token_not_stored_in_plaintext(self, git_repo):
-        set_http_auth_header(git_repo, "https://litresearch.ru", "supersecrettoken")
-        result = subprocess.run(
-            ["git", "config", "--local", "--list"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        assert "supersecrettoken" not in result.stdout
-
-    def test_overwrites_existing_header_on_relink(self, git_repo):
-        import base64
-
-        set_http_auth_header(git_repo, "https://litresearch.ru", "old_token")
-        set_http_auth_header(git_repo, "https://litresearch.ru", "new_token")
-        result = subprocess.run(
-            ["git", "config", "--local", "http.https://litresearch.ru/.extraHeader"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        expected = base64.b64encode(b"token:new_token").decode()
-        assert expected in result.stdout
 
 
 class TestWriteGitignore:

--- a/saas/deploy/Caddyfile
+++ b/saas/deploy/Caddyfile
@@ -3,15 +3,6 @@
 }
 
 litresearch.ru {
-	# Git HTTP backend — full path preserved so FastAPI route /git/{path} matches
-	handle /git/* {
-		reverse_proxy api:8000 {
-			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-For {remote_host}
-			header_up X-Forwarded-Proto {scheme}
-		}
-	}
-
 	# API proxy — strip /api prefix
 	handle_path /api/* {
 		reverse_proxy api:8000 {

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -72,17 +72,9 @@ Write endpoints — mounted with `prefix="/write"`. All require Bearer auth.
 - Jobs polled via shared `GET /process/jobs/{job_id}`
 - Task stubs in `api/tasks.py` (AI pipeline not yet wired for headless SaaS)
 
-### sync.py (~550 lines)
-Git-native sync endpoints — mounted with `prefix="/sync"`. All require Bearer auth (except verify-git-token).
-Server-side for `klemma-cli` sync client. Git repos are bare repos at `KLEMMA_DATA_DIR/repos/{project_id}/`.
-
-**Git repo management:**
-- `POST /sync/init-repo` → `InitRepoResponse` (201) — create bare repo + access token
-- `GET /sync/file/{project_id}/{file_path}` → `FileContentResponse` — `git show HEAD:{path}`
-- `GET /sync/history/{project_id}` → `[HistoryEntry]` — `git log`
-- `POST /sync/commit/{project_id}` → `CommitResponse` — commit file from browser edit (bare repo plumbing)
-- `POST /sync/rollback/{project_id}` → rollback N commits via `git update-ref`
-- `GET /sync/status/{project_id}` → `SyncStatusResponse` — file hashes, library counts, last commit
+### sync.py (~340 lines)
+API-only sync endpoints — mounted with `prefix="/sync"`. All require Bearer auth.
+Server-side for `klemma-cli` sync client. No server-side git — all file sync via `/projects/{id}/drafts`.
 
 **Library bulk sync:**
 - `POST /sync/push/library` — batch upsert sources + fragments (JSON)
@@ -91,8 +83,8 @@ Server-side for `klemma-cli` sync client. Git repos are bare repos at `KLEMMA_DA
 - `GET /sync/pull/library?since=` — incremental: sources + fragments
 - `GET /sync/pull/decisions?since=` — decisions (stub)
 
-**Token verification:**
-- `GET /sync/verify-git-token?token=&project_id=` — for reverse proxy auth (no Bearer required)
+**Status:**
+- `GET /sync/status/{project_id}` → `SyncStatusResponse` — library counts (`source_count`, `fragment_count`)
 
 ## Adding a new router
 

--- a/src/klemma/api/routes/drafts.py
+++ b/src/klemma/api/routes/drafts.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -264,6 +265,7 @@ class FileInfo(BaseModel):
     name: str
     headings: list[HeadingInfo]
     word_count: int
+    updated_at: str = ""  # ISO 8601 UTC, e.g. "2026-03-28T12:00:00+00:00"
 
 
 class FileListResponse(BaseModel):
@@ -315,7 +317,10 @@ def list_draft_files(
             content = md.read_text(encoding="utf-8")
             headings = [HeadingInfo(**h) for h in parse_headings(content)]
             wc = len(content.split())
-            files.append(FileInfo(name=md.name, headings=headings, word_count=wc))
+            mtime = md.stat().st_mtime
+            updated_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+            files.append(FileInfo(name=md.name, headings=headings, word_count=wc,
+                                  updated_at=updated_at))
     return FileListResponse(files=files)
 
 

--- a/src/klemma/api/routes/sync.py
+++ b/src/klemma/api/routes/sync.py
@@ -1,143 +1,28 @@
-"""Sync endpoints: git-native file sync + library bulk transfer.
+"""Sync endpoints: library bulk transfer between klemma-cli and server.
 
-Provides the server-side API for klemma-cli to synchronize markdown files
-(via git) and structured data (library, embeddings, decisions) via REST.
-
-Git repos are bare repos stored at KLEMMA_DATA_DIR/repos/{project_id}/.
-Files are served via git show; commits are created via git subprocess.
+All file sync (draft/*.md) goes through the /projects/{id}/drafts API.
+No server-side git — local git is the user's own business.
 """
 
 from __future__ import annotations
 
 import base64
 import logging
-import os
-import secrets
 import struct
-import subprocess
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from klemma.models import UserRecord
 
-from ..auth.deps import get_current_user, get_user_store
+from ..auth.deps import get_current_user
 from ..deps import get_paper_store, get_project_store, get_user_library
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _data_dir() -> Path:
-    return Path(os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma")))
-
-
-def _repos_dir() -> Path:
-    d = _data_dir() / "repos"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def _repo_path(project_id: str) -> Path:
-    """Return path to the bare git repo for a project. Validates project_id.
-
-    project_id format: "username/project-name" (like GitHub).
-    Maps to: KLEMMA_DATA_DIR/repos/username/project-name/
-    """
-    # Reject traversal and dangerous chars, but allow single /
-    if ".." in project_id or "\\" in project_id or project_id.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid project_id")
-    parts = project_id.split("/")
-    if len(parts) > 2 or any(not p or p.startswith("-") for p in parts):
-        raise HTTPException(status_code=400, detail="Invalid project_id format")
-    return _repos_dir() / project_id
-
-
-def _run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
-    """Run a git command in the given directory."""
-    result = subprocess.run(
-        ["git"] + args,
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if check and result.returncode != 0:
-        logger.warning("git %s failed: %s", " ".join(args), result.stderr.strip())
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Git operation failed: {result.stderr.strip()[:200]}",
-        )
-    return result
-
-
-def _ensure_repo_access(project_id: str, user: UserRecord) -> Path:
-    """Return repo path, verifying it exists and the user owns the project."""
-    repo = _repo_path(project_id)
-    if not repo.exists():
-        raise HTTPException(status_code=404, detail="Repository not found")
-    # Check ownership — reject repos without owner file (corrupted state)
-    token_file = repo / "klemma_owner"
-    if not token_file.exists():
-        raise HTTPException(status_code=403, detail="Repository has no owner")
-    owner_id = token_file.read_text().strip()
-    if owner_id != user.user_id:
-        raise HTTPException(status_code=403, detail="Not your repository")
-    return repo
-
-
-# ---------------------------------------------------------------------------
-# Schemas — Git repo management
-# ---------------------------------------------------------------------------
-
-
-class InitRepoRequest(BaseModel):
-    project_id: str
-    project_type: str = "dissertation"  # passed to dashboard project creation
-
-
-class InitRepoResponse(BaseModel):
-    git_url: str
-    access_token: str
-    project_id: str
-    dashboard_project_id: str = ""  # UUID for /projects/{id}/drafts API
-
-
-class FileContentResponse(BaseModel):
-    path: str
-    content: str
-    encoding: str = "utf-8"
-
-
-class CommitRequest(BaseModel):
-    file_path: str = Field(..., max_length=500)
-    content: str = Field(..., max_length=1_000_000)  # 1MB max per file
-    message: str = Field(default="edit from SaaS dashboard", max_length=500)
-
-
-class CommitResponse(BaseModel):
-    commit_hash: str
-    message: str
-
-
-class HistoryEntry(BaseModel):
-    hash: str
-    message: str
-    author: str
-    date: str
-
-
-class RollbackRequest(BaseModel):
-    steps: int = Field(default=1, ge=1, le=20)
 
 
 # ---------------------------------------------------------------------------
@@ -229,301 +114,6 @@ class SyncStatusResponse(BaseModel):
     project_id: str
     source_count: int
     fragment_count: int
-    last_commit: str = ""
-    last_commit_date: str = ""
-    head_hash: str = ""
-
-
-# ---------------------------------------------------------------------------
-# Git repo management endpoints
-# ---------------------------------------------------------------------------
-
-
-def _find_or_create_dashboard_project(user_id: str, project_name: str,
-                                       project_type: str) -> str:
-    """Find existing dashboard project by name or create one. Returns project_id (UUID)."""
-    store = get_user_store()
-    projects = store.get_projects(user_id)
-    for p in projects:
-        if p.get("name") == project_name:
-            return p["project_id"]
-    project = store.create_project(user_id, project_name, project_type)
-    return project["project_id"]
-
-
-@router.post("/init-repo", response_model=InitRepoResponse, status_code=201)
-async def init_repo(
-    body: InitRepoRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> InitRepoResponse:
-    """Create a bare git repo for a project. Returns git URL + access token.
-
-    project_id is namespaced with user_id prefix to prevent collision
-    between users who choose the same project name (e.g. "dissertation").
-    Also finds/creates a dashboard project and returns its UUID.
-    """
-    # Namespace: username/project_id → like GitHub (e.g. "ilya-bolkhovsky/dissertation")
-    if not user.username:
-        raise HTTPException(status_code=400, detail="User has no username — re-login to generate one")
-    namespaced_id = f"{user.username}/{body.project_id}"
-    repo = _repo_path(namespaced_id)
-    if repo.exists():
-        raise HTTPException(status_code=409, detail="Repository already exists")
-
-    repo.mkdir(parents=True)
-    _run_git(["init", "--bare"], cwd=repo)
-    # Enable git push via HTTP (disabled by default in git-http-backend)
-    _run_git(["config", "http.receivepack", "true"], cwd=repo)
-
-    # Store owner
-    (repo / "klemma_owner").write_text(user.user_id)
-
-    # Generate access token for git HTTP auth
-    token = secrets.token_urlsafe(32)
-    (repo / "klemma_token").write_text(token)
-
-    # Find or create dashboard project (for /projects/{id}/drafts API)
-    # Store the git_project_id association so reconnect (409 path) can look up by it.
-    # Non-fatal: if user store lacks the record (e.g. during tests), return empty string
-    try:
-        user_store = get_user_store()
-        dashboard_project_id = _find_or_create_dashboard_project(
-            user.user_id, body.project_id, body.project_type
-        )
-        user_store.set_git_project_id(dashboard_project_id, namespaced_id)
-    except Exception as exc:
-        logger.warning("dashboard project lookup/create failed for %s: %s", body.project_id, exc)
-        dashboard_project_id = ""
-
-    # Construct git URL (token embedded for MVP — Option A from plan)
-    api_base = os.environ.get("KLEMMA_API_URL", "https://litresearch.ru")
-    git_url = f"{api_base}/git/{namespaced_id}.git"
-
-    return InitRepoResponse(
-        git_url=git_url,
-        access_token=token,
-        project_id=namespaced_id,
-        dashboard_project_id=dashboard_project_id,
-    )
-
-
-@router.get("/dashboard-project")
-async def get_dashboard_project(
-    project_id: str = Query(..., description="Namespaced git project_id (username/project)"),
-    user: UserRecord = Depends(get_current_user),
-) -> dict:
-    """Look up the dashboard project UUID for a git project. Used during reconnect (409).
-
-    Returns {dashboard_project_id, project_name} for the matching dashboard project.
-    Matches by looking for a project with name == the short project name (without username prefix).
-    """
-    store = get_user_store()
-
-    # Primary lookup: by git_project_id (set during init-repo, survives name changes)
-    p = store.get_project_by_git_id(project_id)
-    if p and p["user_id"] == user.user_id:
-        return {"dashboard_project_id": p["project_id"], "project_name": p["name"]}
-
-    # Fallback: match by short name (e.g. "ilya-bolkhovsky/dissertation" → "dissertation")
-    short_name = project_id.split("/", 1)[-1] if "/" in project_id else project_id
-    projects = store.get_projects(user.user_id)
-    for p in projects:
-        if p.get("name") == short_name:
-            # Backfill the association for faster future lookups
-            store.set_git_project_id(p["project_id"], project_id)
-            return {"dashboard_project_id": p["project_id"], "project_name": p["name"]}
-
-    raise HTTPException(status_code=404, detail="No dashboard project found for this git project")
-
-
-@router.get("/file/{project_id:path}", response_model=FileContentResponse)
-async def get_file(
-    project_id: str,
-    file_path: str = Query(..., description="Path to file in repo"),
-    user: UserRecord = Depends(get_current_user),
-) -> FileContentResponse:
-    """Read a file from the project's git repo (HEAD revision).
-
-    file_path is a query param (not path) because project_id itself contains slashes.
-    Example: GET /sync/file/ilya-bolkhovsky/dissertation?file_path=KLEMMA.md
-    """
-    repo = _ensure_repo_access(project_id, user)
-
-    # Validate path — prevent flag injection and path traversal
-    if ".." in file_path or file_path.startswith("/") or file_path.startswith("-"):
-        raise HTTPException(status_code=400, detail="Invalid file path")
-
-    result = _run_git(["show", f"HEAD:{file_path}"], cwd=repo, check=False)
-    if result.returncode != 0:
-        raise HTTPException(status_code=404, detail=f"File not found: {file_path}")
-
-    return FileContentResponse(path=file_path, content=result.stdout)
-
-
-@router.get("/history/{project_id:path}")
-async def get_history(
-    project_id: str,
-    user: UserRecord = Depends(get_current_user),
-    limit: int = Query(default=20, ge=1, le=100),
-) -> list[HistoryEntry]:
-    """Return commit history for a project's git repo."""
-    repo = _ensure_repo_access(project_id, user)
-
-    result = _run_git(
-        ["log", f"-{limit}", "--format=%H|%s|%an|%aI"],
-        cwd=repo,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []  # Empty repo, no commits yet
-
-    entries = []
-    for line in result.stdout.strip().split("\n"):
-        if not line:
-            continue
-        parts = line.split("|", 3)
-        if len(parts) >= 4:
-            entries.append(HistoryEntry(
-                hash=parts[0], message=parts[1],
-                author=parts[2], date=parts[3],
-            ))
-    return entries
-
-
-@router.post("/commit/{project_id:path}", response_model=CommitResponse)
-async def commit_file(
-    project_id: str,
-    body: CommitRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> CommitResponse:
-    """Commit a file change to the project repo (for browser edits).
-
-    Works on a bare repo by using a temporary index.
-    """
-    repo = _ensure_repo_access(project_id, user)
-
-    # Validate file_path — prevent traversal and flag injection
-    if ".." in body.file_path or body.file_path.startswith("/") or body.file_path.startswith("-"):
-        raise HTTPException(status_code=400, detail="Invalid file path")
-
-    # Write content to a blob and update the tree
-    blob_result = subprocess.run(
-        ["git", "hash-object", "-w", "--stdin"],
-        input=body.content,
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if blob_result.returncode != 0:
-        raise HTTPException(status_code=500, detail="Failed to write blob")
-
-    blob_hash = blob_result.stdout.strip()
-
-    # Read current tree (if any)
-    tree_result = _run_git(["rev-parse", "HEAD^{tree}"], cwd=repo, check=False)
-    # Minimal env — avoid leaking server secrets (JWT_SECRET, API keys) into subprocess
-    env = {
-        "HOME": os.environ.get("HOME", "/tmp"),
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        "GIT_AUTHOR_NAME": user.name or user.email,
-        "GIT_AUTHOR_EMAIL": user.email,
-        "GIT_COMMITTER_NAME": user.name or user.email,
-        "GIT_COMMITTER_EMAIL": user.email,
-    }
-
-    if tree_result.returncode == 0:
-        # Update existing tree
-        parent_tree = tree_result.stdout.strip()
-        # Read tree into index, update the file, write tree
-        tmp_index = repo / "tmp_index"
-        env["GIT_INDEX_FILE"] = str(tmp_index)
-        _run_git(["read-tree", parent_tree], cwd=repo)
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob_hash},{body.file_path}"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree_result = subprocess.run(
-            ["git", "write-tree"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree = new_tree_result.stdout.strip()
-        tmp_index.unlink(missing_ok=True)
-
-        # Create commit with parent
-        head = _run_git(["rev-parse", "HEAD"], cwd=repo).stdout.strip()
-        commit_result = subprocess.run(
-            ["git", "commit-tree", new_tree, "-p", head, "-m", body.message],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-    else:
-        # First commit — create tree from scratch
-        env["GIT_INDEX_FILE"] = str(repo / "tmp_index")
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob_hash},{body.file_path}"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree_result = subprocess.run(
-            ["git", "write-tree"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree = new_tree_result.stdout.strip()
-        (repo / "tmp_index").unlink(missing_ok=True)
-
-        commit_result = subprocess.run(
-            ["git", "commit-tree", new_tree, "-m", body.message],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-
-    if commit_result.returncode != 0:
-        raise HTTPException(status_code=500, detail="Failed to create commit")
-
-    commit_hash = commit_result.stdout.strip()
-    # Update HEAD
-    _run_git(["update-ref", "HEAD", commit_hash], cwd=repo)
-
-    return CommitResponse(commit_hash=commit_hash, message=body.message)
-
-
-@router.post("/rollback/{project_id:path}")
-async def rollback(
-    project_id: str,
-    body: RollbackRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> dict:
-    """Revert the last N commits in the project repo."""
-    repo = _ensure_repo_access(project_id, user)
-
-    # Check we have enough commits
-    result = _run_git(
-        ["rev-list", "--count", "HEAD"],
-        cwd=repo,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise HTTPException(status_code=400, detail="No commits to rollback")
-
-    count = int(result.stdout.strip())
-    if body.steps >= count:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Cannot rollback {body.steps} commits — only {count} exist",
-        )
-
-    # Get the target commit
-    target = _run_git(
-        ["rev-parse", f"HEAD~{body.steps}"],
-        cwd=repo,
-    ).stdout.strip()
-
-    # Reset HEAD to target (safe for bare repos)
-    _run_git(["update-ref", "HEAD", target], cwd=repo)
-
-    return {
-        "rolled_back_to": target,
-        "steps": body.steps,
-        "message": f"Rolled back {body.steps} commit(s)",
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -597,7 +187,6 @@ async def push_library(
 
     for frag in body.fragments:
         from klemma.models import FragmentRecord
-        # Resolve client paper_id to server paper_id
         resolved_paper_id = paper_id_map.get(frag.paper_id, frag.paper_id)
         record = FragmentRecord(
             fragment_id=frag.fragment_id,
@@ -651,9 +240,7 @@ async def push_decisions(
     body: DecisionsPushRequest,
     user: UserRecord = Depends(get_current_user),
 ) -> dict:
-    """Batch upsert decisions from CLI."""
-    # Decisions are stored in the project's state.db — for now, store as
-    # JSON in a simple key-value table. Full integration deferred to Phase 3.
+    """Batch upsert decisions from CLI (storage deferred to Phase 3)."""
     count = len(body.decisions)
     logger.info("Received %d decisions from user %s (storage deferred)", count, user.user_id)
     return {"decisions_received": count, "status": "acknowledged"}
@@ -694,7 +281,6 @@ async def pull_library(
             updated_at=datetime.now(timezone.utc).isoformat(),
         ))
 
-        # Include fragments for each source
         if paper:
             for frag in paper_store.get_fragments(src.paper_id):
                 fragments.append(FragmentPull(
@@ -718,72 +304,26 @@ async def pull_decisions(
     return {"decisions": []}
 
 
-@router.get("/status/{project_id:path}", response_model=SyncStatusResponse)
+@router.get("/status/{project_id}", response_model=SyncStatusResponse)
 async def sync_status(
     project_id: str,
     user: UserRecord = Depends(get_current_user),
 ) -> SyncStatusResponse:
-    """Summary: file hashes, library counts, last sync time."""
-    repo = _ensure_repo_access(project_id, user)
-
+    """Library counts for the authenticated user."""
     library = get_user_library()
     paper_store = get_paper_store()
 
     source_count = library.count(user_id=user.user_id)
-
-    # Count fragments across all user's sources
     all_sources = library.get_all_sources(user_id=user.user_id)
     fragment_count = sum(
         len(paper_store.get_fragments(s.paper_id)) for s in all_sources
     )
 
-    # Get last commit info
-    result = _run_git(
-        ["log", "-1", "--format=%H|%s|%aI"],
-        cwd=repo,
-        check=False,
-    )
-    head_hash = ""
-    last_commit = ""
-    last_commit_date = ""
-    if result.returncode == 0 and result.stdout.strip():
-        parts = result.stdout.strip().split("|", 2)
-        if len(parts) >= 3:
-            head_hash = parts[0]
-            last_commit = parts[1]
-            last_commit_date = parts[2]
-
     return SyncStatusResponse(
         project_id=project_id,
         source_count=source_count,
         fragment_count=fragment_count,
-        last_commit=last_commit,
-        last_commit_date=last_commit_date,
-        head_hash=head_hash,
     )
-
-
-# ---------------------------------------------------------------------------
-# Token verification endpoint (for Caddy/nginx auth_request)
-# ---------------------------------------------------------------------------
-
-
-@router.get("/verify-git-token")
-async def verify_git_token(
-    token: str = Query(...),
-    project_id: str = Query(...),
-) -> dict:
-    """Verify a git access token for a project. Used by reverse proxy auth."""
-    repo = _repo_path(project_id)
-    token_file = repo / "klemma_token"
-    if not token_file.exists():
-        raise HTTPException(status_code=401, detail="Invalid token")
-
-    stored_token = token_file.read_text().strip()
-    if not secrets.compare_digest(token, stored_token):
-        raise HTTPException(status_code=401, detail="Invalid token")
-
-    return {"status": "ok"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_sync.py
+++ b/tests/test_api_sync.py
@@ -2,22 +2,8 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-
 import pytest
 from fastapi.testclient import TestClient
-
-
-@pytest.fixture
-def data_dir(tmp_path):
-    """Create a temporary data directory for repos."""
-    d = tmp_path / "klemma_data"
-    d.mkdir()
-    os.environ["KLEMMA_DATA_DIR"] = str(d)
-    yield d
-    os.environ.pop("KLEMMA_DATA_DIR", None)
 
 
 @pytest.fixture
@@ -35,7 +21,7 @@ def mock_user():
 
 
 @pytest.fixture
-def client(data_dir, mock_user):
+def client(mock_user):
     """Create a test client with mocked auth and initialized stores."""
     from klemma.api.app import create_app
     from klemma.api.auth.deps import get_current_user
@@ -46,151 +32,6 @@ def client(data_dir, mock_user):
     # Use lifespan context to initialize stores
     with TestClient(app) as c:
         yield c
-
-
-class TestInitRepo:
-    def test_init_creates_bare_repo(self, client, data_dir):
-        resp = client.post(
-            "/sync/init-repo",
-            json={"project_id": "my-project"},
-        )
-        assert resp.status_code == 201
-        data = resp.json()
-        # project_id is namespaced as username/project-name
-        assert data["project_id"] == "test-user/my-project"
-        assert "git_url" in data
-        assert "access_token" in data
-        assert "dashboard_project_id" in data  # field present (may be "" when user not in store)
-
-        # Verify bare repo was created (namespaced path)
-        repo_path = data_dir / "repos" / "test-user" / "my-project"
-        assert repo_path.exists()
-        assert (repo_path / "HEAD").exists()  # bare repo indicator
-        assert (repo_path / "klemma_owner").read_text() == "test-user-123"
-
-    def test_init_rejects_duplicate(self, client, data_dir):
-        client.post("/sync/init-repo", json={"project_id": "dup-project"})
-        resp = client.post("/sync/init-repo", json={"project_id": "dup-project"})
-        assert resp.status_code == 409
-
-    def test_init_rejects_path_traversal(self, client):
-        resp = client.post("/sync/init-repo", json={"project_id": "../escape"})
-        assert resp.status_code == 400
-
-
-class TestDashboardProject:
-    def test_dashboard_project_not_found(self, client):
-        resp = client.get("/sync/dashboard-project", params={"project_id": "nonexistent/project"})
-        assert resp.status_code == 404
-
-
-class TestFileEndpoints:
-    def _create_repo_with_file(self, data_dir, project_id, file_path, content):
-        """Helper: create a bare repo with a file committed."""
-        repo = data_dir / "repos" / project_id
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-        (repo / "klemma_token").write_text("test-token")
-
-        # Create a temporary working copy to commit a file
-        work = data_dir / "tmp_work"
-        work.mkdir()
-        subprocess.run(["git", "clone", str(repo), str(work)], capture_output=True)
-        (work / file_path).parent.mkdir(parents=True, exist_ok=True)
-        (work / file_path).write_text(content)
-        subprocess.run(["git", "add", "."], cwd=str(work), capture_output=True)
-        env = os.environ.copy()
-        env["GIT_AUTHOR_NAME"] = "Test"
-        env["GIT_AUTHOR_EMAIL"] = "test@test.com"
-        env["GIT_COMMITTER_NAME"] = "Test"
-        env["GIT_COMMITTER_EMAIL"] = "test@test.com"
-        subprocess.run(
-            ["git", "commit", "-m", "init"],
-            cwd=str(work), capture_output=True, env=env,
-        )
-        subprocess.run(
-            ["git", "push", "origin", "master"],
-            cwd=str(work), capture_output=True,
-        )
-        shutil.rmtree(work)
-
-    def test_get_file(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "test-proj", "KLEMMA.md", "# Test Project")
-        resp = client.get("/sync/file/test-proj", params={"file_path": "KLEMMA.md"})
-        assert resp.status_code == 200
-        assert "# Test Project" in resp.json()["content"]
-
-    def test_get_file_not_found(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "test-proj2", "KLEMMA.md", "test")
-        resp = client.get("/sync/file/test-proj2", params={"file_path": "nonexistent.md"})
-        assert resp.status_code == 404
-
-    def test_get_file_wrong_user(self, client, data_dir):
-        repo = data_dir / "repos" / "other-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("other-user-456")
-        resp = client.get("/sync/file/other-proj", params={"file_path": "KLEMMA.md"})
-        assert resp.status_code == 403
-
-    def test_get_history(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "hist-proj", "test.md", "content")
-        resp = client.get("/sync/history/hist-proj")
-        assert resp.status_code == 200
-        entries = resp.json()
-        assert len(entries) >= 1
-        assert entries[0]["message"] == "init"
-
-    def test_history_empty_repo(self, client, data_dir):
-        namespaced = "test-use-empty-proj"
-        repo = data_dir / "repos" / namespaced
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-        resp = client.get(f"/sync/history/{namespaced}")
-        assert resp.status_code == 200
-        assert resp.json() == []
-
-
-class TestCommit:
-    def test_commit_new_file(self, client, data_dir):
-        # Create empty bare repo
-        repo = data_dir / "repos" / "commit-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-
-        resp = client.post("/sync/commit/commit-proj", json={
-            "file_path": "notes/test.md",
-            "content": "# Hello World",
-            "message": "test commit",
-        })
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "commit_hash" in data
-        assert data["message"] == "test commit"
-
-        # Verify file is readable
-        read_resp = client.get("/sync/file/commit-proj", params={"file_path": "notes/test.md"})
-        assert read_resp.status_code == 200
-        assert "Hello World" in read_resp.json()["content"]
-
-
-class TestRollback:
-    def test_rollback_rejects_too_many(self, client, data_dir):
-        repo = data_dir / "repos" / "rb-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-
-        # Commit one file
-        client.post("/sync/commit/rb-proj", json={
-            "file_path": "test.md", "content": "v1",
-        })
-
-        resp = client.post("/sync/rollback/rb-proj", json={"steps": 5})
-        assert resp.status_code == 400
 
 
 class TestLibrarySync:
@@ -247,30 +88,6 @@ class TestLibrarySync:
         })
         assert resp.status_code == 200
         assert resp.json()["paper_embeddings_saved"] == 1
-
-
-class TestVerifyGitToken:
-    def test_valid_token(self, client, data_dir):
-        repo = data_dir / "repos" / "token-proj"
-        repo.mkdir(parents=True)
-        (repo / "klemma_token").write_text("secret-token-123")
-
-        resp = client.get("/sync/verify-git-token", params={
-            "token": "secret-token-123",
-            "project_id": "token-proj",
-        })
-        assert resp.status_code == 200
-
-    def test_invalid_token(self, client, data_dir):
-        repo = data_dir / "repos" / "token-proj2"
-        repo.mkdir(parents=True)
-        (repo / "klemma_token").write_text("correct-token")
-
-        resp = client.get("/sync/verify-git-token", params={
-            "token": "wrong-token",
-            "project_id": "token-proj2",
-        })
-        assert resp.status_code == 401
 
 
 class TestIncrementalPullLibrary:


### PR DESCRIPTION
### **User description**
Closes #267

## Summary

- Remove all server-side git infrastructure from `klemma-cli` and the API backend
- `k push/pull` is now pure REST API — no bare repos on server, no git transport
- Local git stays intact: `k status` shows local uncommitted changes, power users use `git` directly

## Changes

**Backend (`src/klemma/api/routes/sync.py`)**
- Remove `_run_git`, `_repos_dir`, `_repo_path`, `_ensure_repo_access` helpers
- Remove endpoints: `POST /sync/init-repo`, `GET /sync/file/{id}`, `GET /sync/history/{id}`, `POST /sync/commit/{id}`, `POST /sync/rollback/{id}`, `GET /sync/verify-git-token`, `GET /sync/dashboard-project`
- Remove git schemas: `InitRepoRequest/Response`, `FileContentResponse`, `CommitRequest/Response`, `HistoryEntry`, `RollbackRequest`
- Simplify `SyncStatusResponse` to `{project_id, source_count, fragment_count}` (no git fields)
- Net: −220 lines

**CLI (`cli/src/klemma_cli/`)**
- `gitops.py`: remove server-transport functions (`add_remote`, `push`, `pull`, `fetch`, `remote_log`, `revert_last_n`, `force_push`, `set_http_auth_header`)
- `models.py`: `SyncConfig` drops `git_url`, `access_token` fields
- `main.py`: `k link` uses `GET /projects` + `POST /projects` (find-or-create by name); remove git init/commit/push phases from push/pull; remove `rollback` command

**Infrastructure**
- `saas/deploy/Caddyfile`: remove `/git/*` reverse proxy block

**Tests**
- Remove `TestInitRepo`, `TestDashboardProject`, `TestFileEndpoints`, `TestCommit`, `TestRollback`, `TestVerifyGitToken`, `TestSetHttpAuthHeader`

## Test plan
- [x] `ruff check src/ tests/ cli/` — clean
- [x] `python -m pytest tests/ -q` — 1577 passed
- [ ] `k link` — no git remote setup, saves SyncConfig with api_url + dashboard_project_id
- [x] `k push` — pushes library + drafts via API only, no git commit message
- [ ] `k pull` — pulls library + drafts, no git pull step

## Release Note

### Problem
`klemma-cli` previously used a dual-transport architecture: git bare repos on the server for file sync, plus REST API for library/embedding data. The git transport was redundant — the database was already the authoritative source, the dashboard wrote directly to the DB, and the git pull was immediately overwritten by the API pull. This created operational complexity (bare repo management on VPS), potential conflicts (git merge on bare repos), and two separate auth mechanisms (JWT + git HTTP token).

### Academic Foundation
No specific academic citations — this is an operational simplification. The decision aligns with the principle of avoiding unnecessary infrastructure complexity in research tooling (KISS principle applied to system design).

### Implementation
Removed ~220 lines from `sync.py` (all git endpoint handlers and helpers), 7 server-transport functions from `gitops.py`, 2 fields from `SyncConfig`, and the `rollback` CLI command. The `k link` command now uses the existing `/projects` REST API to find-or-create the dashboard project by name — replacing `POST /sync/init-repo`. Local git is preserved: `k status` still shows uncommitted changes via `git status --short` filtered to klemma-synced paths; power users can use `git log draft/chapter_1.md` directly.

### Results
- Net −925 lines removed (1035 deleted, 110 added for updated docs/tests)
- 1577 tests pass (removed 17 git-specific tests that tested now-deleted endpoints)
- Ruff clean
- Eliminates bare repo management from VPS operations
- Closes issue #258 (dashboard-project name mismatch bug — endpoint removed entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Remove backend git repo endpoints

- Make CLI sync REST-only

- Simplify sync config and status

- Update tests, docs, proxy configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI link push pull status"]
  B["REST sync endpoints"]
  C["Projects and drafts APIs"]
  D["Local git helpers only"]
  E["Server-side git removed"]
  A -- "uses" --> B
  B -- "syncs files through" --> C
  A -- "keeps" --> D
  E -- "simplifies" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>gitops.py</strong><dd><code>Remove remote transport git helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-dd10fac6d5e6968887e943a09ec3958e225028fe9e718f0aaaa9a95c426e86c6">+5/-94</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Switch CLI commands to REST-only sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-776c855211d357774b0f35827372a1e07f4705193c3fe095e1317ab5fb174f51">+52/-207</a></td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Simplify sync config to API fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-5b67d7858ece9a33bc40f7081aec20a315d16d373f809eef7c94fa73c83bbb88">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sync.py</strong><dd><code>Drop git endpoints from sync router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-67ef5b0ba7ed82e1b28ce9879cfa34766d2cba15da95a7b780b2a63ad73f4db3">+8/-468</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_gitops.py</strong><dd><code>Remove git auth header transport tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-2cef3b6ad8e5550e17efb0ec2744a1378d5a4d40f087b9fc36a2c2a2470c979a">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_api_sync.py</strong><dd><code>Remove backend git endpoint test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-73b11874bb21391d7e3394f19a60d9b844fca9b45ea88d30e489ee878d8e3bd3">+1/-184</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Document API-native CLI sync architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-4c947accdabb8a0ddf5f7ff47f8806165fc725157cec4632a0ce55a2c4c17396">+38/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Update route docs for API-only sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-98c2beb2cb3c7cec72f46202827a22a43eab4744853dca1ce9884ca2ee2f8f28">+5/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Caddyfile</strong><dd><code>Remove Caddy git proxy routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/271/files#diff-6a600fa19113289c9c7ffe7ba1442eaffbdaf5314a64530219951d927fd5eb56">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

