### PR TITLE
feat(saas): SectionEditorView Phase 5A+5B — section-card write paradigm + source drawer

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,17 +1,17 @@
 # klemma-cli
 
-Lightweight git-native sync client for Klemma SaaS. Separate package (`pip install klemma-cli`).
+Lightweight API-native sync client for Klemma SaaS. Separate package (`pip install klemma-cli`).
 
 ## Architecture
 
-- Files sync via **git** (push/pull to bare repos on server)
-- Library data syncs via **REST API** (batch JSON for sources/fragments/embeddings)
-- No AI, no heavy deps — just click, requests, pydantic, pyyaml + git subprocess
+- All sync via **REST API only** (no server-side git)
+- Local git stays intact — power users use `git` directly; `k status` shows local uncommitted changes
+- No AI, no heavy deps — just click, requests, pydantic, pyyaml + git subprocess (local only)
 
 ## Modules
 
-### main.py (~280 lines)
-Click CLI entry point. 6 commands: `link`, `push`, `pull`, `status`, `rollback`, `login`.
+### main.py (~260 lines)
+Click CLI entry point. 5 commands: `link`, `push`, `pull`, `status`, `login`.
 
 ### auth.py (~80 lines)
 Login to Klemma API, token storage at `~/.klemma-cli/auth.json`.
@@ -22,11 +22,11 @@ Login to Klemma API, token storage at `~/.klemma-cli/auth.json`.
 `KlemmaClient` — HTTP client with auto-refresh on 401.
 - `get(path)`, `post(path, json)` — wrappers with auth headers
 
-### gitops.py (~180 lines)
-Git subprocess wrappers.
-- `init`, `add_remote`, `add_files`, `commit`, `push`, `pull`, `fetch`
-- `log`, `status`, `remote_log`, `revert_last_n`, `force_push`
-- `write_gitignore` — auto-generate .gitignore for klemma projects
+### gitops.py (~110 lines)
+Local git subprocess wrappers (no server transport functions).
+- `is_git_repo`, `init`, `add_files`, `has_changes`, `commit`, `log`
+- `status` — filtered to klemma-synced paths (`KLEMMA.md`, `draft/`, `notes/research/`, `.gitignore`)
+- `get_head_hash`, `write_gitignore`
 
 ### sync.py (~265 lines)
 Library and draft sync — read local SQLite DB and push/pull via API.
@@ -41,8 +41,9 @@ Library and draft sync — read local SQLite DB and push/pull via API.
 ### project.py (~50 lines)
 Project discovery — find `.klemma/` directory, parse KLEMMA.md.
 
-### models.py (~60 lines)
+### models.py (~55 lines)
 Pydantic schemas: `SourcePayload`, `FragmentPayload`, `EmbeddingPayload`, `DecisionPayload`, `SyncConfig`.
+`SyncConfig` fields: `api_url`, `dashboard_project_id`, `last_push`, `last_pull` (no `git_url`, no `access_token`).
 
 ### state.py (~30 lines)
 Sync state persistence — `.klemma/sync_config.json` CRUD.
@@ -51,30 +52,43 @@ Sync state persistence — `.klemma/sync_config.json` CRUD.
 
 ```
 klemma-cli push
-  1. git add KLEMMA.md notes/drafts/ notes/research/ .gitignore
-  2. git commit "sync: push from CLI — {date}"
-  3. git push klemma main
-  4. Read local library.db → POST /sync/push/library (sources + fragments)
-  5. Read local embeddings → POST /sync/push/embeddings (base64 chunks)
-  6. Update .klemma/sync_config.json last_push timestamp
+  1. Read local library.db → POST /sync/push/library (sources + fragments)
+  2. Read local embeddings → POST /sync/push/embeddings (base64 chunks)
+  3. PUT draft/*.md → POST /projects/{id}/drafts/{name} (each file)
+  4. Update .klemma/sync_config.json last_push timestamp
 ```
 
 ## Data flow: pull
 
 ```
 klemma-cli pull
-  1. git pull klemma main (conflicts → print instructions)
-  2. GET /sync/pull/library → write sources/fragments to local library.db
-  3. GET /projects/{id}/drafts → list; GET /projects/{id}/drafts/{name} per file
+  1. GET /sync/pull/library → write sources/fragments to local library.db
+  2. GET /projects/{id}/drafts → list; GET /projects/{id}/drafts/{name} per file
      → write to draft/{name} only if content differs (ADR-016)
-  4. Update .klemma/sync_config.json last_pull timestamp
+  3. Update .klemma/sync_config.json last_pull timestamp
 ```
+
+## Data flow: link
+
+```
+klemma-cli link
+  1. Login → GET /projects (find by name) or POST /projects (create)
+  2. write_gitignore(project_root)
+  3. Save SyncConfig {api_url, dashboard_project_id} to .klemma/sync_config.json
+```
+
+## Local git story
+
+- `k status` shows local uncommitted changes via `git status --short` (filtered to synced paths)
+- Power users: use `git add / commit / log` directly in the dissertation directory
+- `k link` writes `.gitignore` with klemma-specific exclusions
+- Server has no bare repos — all file sync via `/projects/{id}/drafts` REST API
 
 ## Tests
 
-- `cli/tests/test_gitops.py` — git subprocess wrapper tests
+- `cli/tests/test_gitops.py` — git subprocess wrapper tests (local ops only)
 - `cli/tests/test_project.py` — project discovery tests
 - `cli/tests/test_sync.py` — library DB read tests + pull_drafts tests (5 cases)
-- `tests/test_api_sync.py` — backend sync API endpoint tests (15 tests)
+- `tests/test_api_sync.py` — backend sync API endpoint tests (library sync only)
 
 See: [API Routes](../src/klemma/api/routes/CLAUDE.md) | [Root](../CLAUDE.md)

--- a/cli/src/klemma_cli/client.py
+++ b/cli/src/klemma_cli/client.py
@@ -49,12 +49,12 @@ class KlemmaClient:
         resp.raise_for_status()
         return resp
 
-    def post(self, path: str, json: Any = None, **kwargs: Any) -> requests.Response:
+    def post(self, path: str, json: Any = None, timeout: int = 120, **kwargs: Any) -> requests.Response:
         """POST request with auto-refresh on 401."""
         url = f"{self.api_url}{path}"
-        resp = requests.post(url, headers=self._headers(), json=json, timeout=30, **kwargs)
+        resp = requests.post(url, headers=self._headers(), json=json, timeout=timeout, **kwargs)
         if self._maybe_refresh(resp):
-            resp = requests.post(url, headers=self._headers(), json=json, timeout=30, **kwargs)
+            resp = requests.post(url, headers=self._headers(), json=json, timeout=timeout, **kwargs)
         resp.raise_for_status()
         return resp
 

--- a/cli/src/klemma_cli/gitops.py
+++ b/cli/src/klemma_cli/gitops.py
@@ -1,8 +1,11 @@
-"""Git subprocess wrappers for klemma-cli sync operations."""
+"""Git subprocess wrappers for local klemma-cli operations.
+
+Only local git operations — no server transport (push/pull to remote).
+Server sync is handled exclusively via the REST API (sync.py).
+"""
 
 from __future__ import annotations
 
-import base64
 import subprocess
 from pathlib import Path
 
@@ -47,16 +50,6 @@ def init(path: Path) -> None:
     _run(["init"], cwd=path)
 
 
-def add_remote(path: Path, name: str, url: str) -> None:
-    """Add a git remote. Removes existing remote with same name first."""
-    # Check if remote exists
-    result = _run(["remote", "get-url", name], cwd=path, check=False)
-    if result.returncode == 0:
-        _run(["remote", "set-url", name, url], cwd=path)
-    else:
-        _run(["remote", "add", name, url], cwd=path)
-
-
 def add_files(path: Path, patterns: list[str]) -> None:
     """Stage files matching patterns."""
     for pattern in patterns:
@@ -85,41 +78,6 @@ def commit(path: Path, message: str) -> str | None:
     return hash_result.stdout.strip()
 
 
-def current_branch(path: Path) -> str:
-    """Return the current branch name, or 'main' as fallback."""
-    result = _run(["rev-parse", "--abbrev-ref", "HEAD"], cwd=path, check=False)
-    if result.returncode == 0 and result.stdout.strip():
-        return result.stdout.strip()
-    return "main"
-
-
-def push(path: Path, remote: str = "klemma", branch: str | None = None) -> bool:
-    """Push to remote. Returns True on success, False if rejected."""
-    branch = branch or current_branch(path)
-    result = _run(["push", remote, branch], cwd=path, check=False)
-    if result.returncode != 0:
-        if "rejected" in result.stderr or "non-fast-forward" in result.stderr:
-            return False
-        raise GitError("push", result.stderr.strip())
-    return True
-
-
-def pull(path: Path, remote: str = "klemma", branch: str | None = None) -> str:
-    """Pull from remote. Returns output text."""
-    branch = branch or current_branch(path)
-    result = _run(["pull", remote, branch, "--no-rebase"], cwd=path, check=False)
-    if result.returncode != 0:
-        if "CONFLICT" in result.stdout + result.stderr:
-            return f"CONFLICT: {result.stdout}\n{result.stderr}"
-        raise GitError("pull", result.stderr.strip())
-    return result.stdout.strip()
-
-
-def fetch(path: Path, remote: str = "klemma") -> None:
-    """Fetch from remote."""
-    _run(["fetch", remote], cwd=path, check=False)
-
-
 def log(path: Path, count: int = 10, format_str: str = "%h %s") -> list[str]:
     """Return recent commit log entries."""
     result = _run(
@@ -145,59 +103,12 @@ def status(path: Path) -> str:
     return "\n".join(lines)
 
 
-def remote_log(path: Path, remote: str = "klemma", branch: str | None = None) -> list[str]:
-    """Return commits on remote that are not in local HEAD."""
-    branch = branch or current_branch(path)
-    fetch(path, remote)
-    result = _run(
-        ["log", f"HEAD..{remote}/{branch}", "--oneline"],
-        cwd=path,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    return [line for line in result.stdout.strip().split("\n") if line]
-
-
-def revert_last_n(path: Path, n: int) -> None:
-    """Revert the last N commits (creates revert commits)."""
-    if n <= 0:
-        return
-    _run(["revert", "--no-edit", f"HEAD~{n}..HEAD"], cwd=path)
-
-
-def force_push(path: Path, remote: str = "klemma", branch: str | None = None) -> None:
-    """Force push with lease (safe force push)."""
-    branch = branch or current_branch(path)
-    _run(["push", "--force-with-lease", remote, branch], cwd=path)
-
-
 def get_head_hash(path: Path) -> str | None:
     """Return HEAD commit hash or None if no commits."""
     result = _run(["rev-parse", "HEAD"], cwd=path, check=False)
     if result.returncode != 0:
         return None
     return result.stdout.strip()
-
-
-def set_http_auth_header(path: Path, server_url: str, token: str) -> None:
-    """Configure git to use an Authorization header for requests to server_url.
-
-    Stores auth in the local repo git config (.git/config), not embedded in
-    the remote URL — so tokens are never visible in 'git remote -v' or pushed
-    to the server.
-
-    Args:
-        path: Path to the local git repository.
-        server_url: URL prefix to match, e.g. 'https://litresearch.ru'.
-        token: Raw access token (encoded as 'Basic token:<token>').
-    """
-    encoded = base64.b64encode(f"token:{token}".encode()).decode()
-    _run(
-        ["config", "--local", f"http.{server_url}/.extraHeader",
-         f"Authorization: Basic {encoded}"],
-        cwd=path,
-    )
 
 
 def write_gitignore(path: Path) -> None:

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -162,11 +162,15 @@ def push() -> None:
         click.echo("Pushing draft files...")
         try:
             draft_result = push_drafts(client, project_root, config.dashboard_project_id)
-            if draft_result["files"]:
-                click.echo(
-                    f"Pushed {draft_result['files']} draft file(s), "
-                    f"{draft_result['words']} words"
-                )
+            pushed = draft_result["files"]
+            skipped = draft_result.get("skipped", 0)
+            if pushed:
+                msg = f"Pushed {pushed} draft file(s), {draft_result['words']} words"
+                if skipped:
+                    msg += f" ({skipped} skipped — server copy is newer)"
+                click.echo(msg)
+            elif skipped:
+                click.echo(f"Draft files up to date ({skipped} file(s) skipped — server copy is newer).")
             else:
                 click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
@@ -217,8 +221,15 @@ def pull() -> None:
         click.echo("Pulling draft files...")
         try:
             draft_result = pull_drafts(client, project_root, config.dashboard_project_id)
-            if draft_result["files"]:
-                click.echo(f"Updated {draft_result['files']} draft file(s)")
+            updated = draft_result["files"]
+            skipped = draft_result.get("skipped", 0)
+            if updated:
+                msg = f"Updated {updated} draft file(s)"
+                if skipped:
+                    msg += f" ({skipped} skipped — local copy is newer)"
+                click.echo(msg)
+            elif skipped:
+                click.echo(f"Draft files up to date ({skipped} file(s) skipped — local copy is newer).")
             else:
                 click.echo("Draft files up to date.")
         except Exception as exc:

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -1,6 +1,9 @@
-"""klemma-cli — git-native sync client for Klemma SaaS.
+"""klemma-cli — API-native sync client for Klemma SaaS.
 
-Commands: link, push, pull, status, rollback
+Commands: link, push, pull, status, login
+
+Sync is via REST API only. Local git operations (commit, log) are available
+directly through git or via gitops helpers for those who prefer the CLI.
 """
 
 from __future__ import annotations
@@ -19,31 +22,21 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option("--api-url", default="https://litresearch.ru/api", help="API base URL (include /api for production)")
+@click.option("--api-url", default="https://litresearch.ru/api", help="API base URL")
 @click.option("--email", default=None, help="Account email")
 @click.option("--password", default=None, help="Account password")
 def link(api_url: str, email: str | None, password: str | None) -> None:
     """Connect this project to Klemma SaaS.
 
-    Discovers .klemma/ project root, logs in, creates a server-side git repo,
-    initializes local git, and sets up the 'klemma' remote.
+    Discovers .klemma/ project root, logs in, finds or creates a dashboard project,
+    and saves the sync configuration.
     """
-    from urllib.parse import urlparse
-
     from .auth import login
     from .client import KlemmaClient
-    from .gitops import (
-        add_files,
-        add_remote,
-        commit,
-        init,
-        is_git_repo,
-        set_http_auth_header,
-        write_gitignore,
-    )
+    from .gitops import write_gitignore
     from .models import SyncConfig
     from .project import ensure_project_root, get_project_name
-    from .state import load_sync_config, save_sync_config
+    from .state import save_sync_config
 
     # 0. Show server URL and project BEFORE asking for credentials
     click.echo(f"Server: {api_url}")
@@ -52,7 +45,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
     click.echo(f"Project: {project_name} ({project_root})")
     click.echo()
 
-    # 1. Prompt for credentials (after user sees where they're going)
+    # 1. Prompt for credentials
     if not email:
         email = click.prompt("Email")
     if not password:
@@ -65,75 +58,40 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
     except Exception as e:
         click.echo(f"Login failed: {e}", err=True)
         raise SystemExit(1)
-    username = auth_data.get("username", "")
-    click.echo(f"Logged in as {auth_data['email']} ({username})")
+    click.echo(f"Logged in as {auth_data['email']}")
 
-    # 3. Create server-side repo (username/project-name format, like GitHub)
+    # 3. Find or create dashboard project
     client = KlemmaClient(api_url=api_url, access_token=auth_data["access_token"])
-    project_slug = project_name.lower().replace(" ", "-").replace("_", "-")
-
+    dashboard_project_id = ""
     try:
-        resp = client.post("/sync/init-repo", json={"project_id": project_slug})
-        repo_data = resp.json()
-    except Exception as e:
-        error_msg = str(e)
-        if "409" in error_msg:
-            click.echo("Server repo already exists — reconnecting.")
-            base = api_url.rstrip("/").removesuffix("/api")
-            namespaced = f"{username}/{project_slug}" if username else project_slug
-            repo_data = {"git_url": f"{base}/git/{namespaced}.git", "access_token": ""}
-            # Recover git token from existing sync_config so auth header is re-applied.
-            existing_config = load_sync_config(project_root)
-            if existing_config and existing_config.access_token:
-                repo_data["access_token"] = existing_config.access_token
-            # Look up dashboard_project_id for this git project (#260 item 5)
-            try:
-                lookup = client.get("/sync/dashboard-project", params={"project_id": namespaced})
-                lookup.raise_for_status()
-                repo_data["dashboard_project_id"] = lookup.json().get("dashboard_project_id", "")
-            except Exception as lookup_err:
-                click.echo(
-                    f"Warning: could not resolve dashboard project ID ({lookup_err}).\n"
-                    "Draft sync will be skipped until this is resolved.\n"
-                    "Open https://litresearch.ru, create a project, then re-run 'klemma-cli link'.",
-                    err=True,
-                )
+        resp = client.get("/projects")
+        projects = resp.json().get("projects", [])
+        # Find existing project by name (case-insensitive)
+        match = next(
+            (p for p in projects if p["name"].lower() == project_name.lower()),
+            None,
+        )
+        if match:
+            dashboard_project_id = match["project_id"]
+            click.echo(f"Found existing project: {project_name} ({dashboard_project_id[:8]})")
         else:
-            click.echo(f"Failed to create server repo: {e}", err=True)
-            raise SystemExit(1)
+            create_resp = client.post("/projects", json={"name": project_name})
+            dashboard_project_id = create_resp.json()["project_id"]
+            click.echo(f"Created project: {project_name} ({dashboard_project_id[:8]})")
+    except Exception as e:
+        click.echo(
+            f"Warning: could not find/create dashboard project ({e}).\n"
+            "Draft sync will be skipped. Re-run 'klemma-cli link' to retry.",
+            err=True,
+        )
 
-    git_url = repo_data["git_url"]
-    access_token = repo_data.get("access_token", "")
-
-    # 4. Init local git
-    if not is_git_repo(project_root):
-        click.echo("Initializing git repository...")
-        init(project_root)
-
-    # 5. Add remote (clean URL — token stored in git local config, not in URL)
-    add_remote(project_root, "klemma", git_url)
-    click.echo(f"Remote 'klemma' set to {git_url}")
-    if access_token:
-        parsed = urlparse(git_url)
-        server_url = f"{parsed.scheme}://{parsed.netloc}"
-        set_http_auth_header(project_root, server_url, access_token)
-
-    # 6. Auto-generate .gitignore
+    # 4. Write .gitignore (local git stays, just no server transport)
     write_gitignore(project_root)
 
-    # 7. Initial commit + push
-    add_files(project_root, ["KLEMMA.md", "draft/", "notes/", ".gitignore"])
-    commit_hash = commit(project_root, f"sync: initial link — {datetime.now(timezone.utc).strftime('%Y-%m-%d')}")
-    if commit_hash:
-        click.echo(f"Initial commit: {commit_hash[:8]}")
-
-    # 8. Save sync config
+    # 5. Save sync config
     config = SyncConfig(
-        project_id=repo_data.get("project_id", project_slug),
         api_url=api_url,
-        git_url=git_url,
-        access_token=access_token,
-        dashboard_project_id=repo_data.get("dashboard_project_id", ""),
+        dashboard_project_id=dashboard_project_id,
     )
     save_sync_config(project_root, config)
     click.echo("Linked! Run 'klemma-cli push' to sync.")
@@ -144,7 +102,7 @@ def link(api_url: str, email: str | None, password: str | None) -> None:
 @click.option("--email", default=None, help="Account email")
 @click.option("--password", default=None, help="Account password")
 def login(api_url: str | None, email: str | None, password: str | None) -> None:
-    """Refresh auth tokens without changing git remotes or sync config.
+    """Refresh auth tokens without changing sync config.
 
     Use when 'klemma-cli pull' or 'push' returns 401 Unauthorized.
     """
@@ -170,13 +128,8 @@ def login(api_url: str | None, email: str | None, password: str | None) -> None:
 
 @cli.command()
 def push() -> None:
-    """Push local changes to Klemma SaaS.
-
-    Two phases: git push (files) + API push (library data).
-    """
+    """Push local changes to Klemma SaaS (library + drafts via API)."""
     from .client import KlemmaClient
-    from .gitops import add_files, commit
-    from .gitops import push as git_push
     from .project import ensure_project_root
     from .state import load_sync_config, save_sync_config
     from .sync import push_drafts, push_library
@@ -187,33 +140,10 @@ def push() -> None:
         click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
         raise SystemExit(1)
 
-    # Phase 1: Git (may fail if git-http-backend not configured on server)
-    click.echo("Pushing files...")
-    add_files(project_root, [
-        "KLEMMA.md",
-        "draft/",
-        "notes/research/",
-        ".gitignore",
-    ])
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
-    commit_hash = commit(project_root, f"sync: push from CLI — {now}")
-    if commit_hash:
-        click.echo(f"Committed: {commit_hash[:8]}")
-    else:
-        click.echo("No file changes to commit.")
-
-    try:
-        success = git_push(project_root)
-        if not success:
-            click.echo("Push rejected — run 'klemma-cli pull' first.", err=True)
-        else:
-            click.echo("Files pushed.")
-    except Exception as exc:
-        click.echo(f"Git push failed: {exc}", err=True)
-
-    # Phase 2: Library
-    click.echo("Pushing library data...")
     client = KlemmaClient(api_url=config.api_url)
+
+    # Phase 1: Library
+    click.echo("Pushing library data...")
     library_ok = False
     try:
         result = push_library(client, project_root)
@@ -226,7 +156,7 @@ def push() -> None:
     except Exception as exc:
         click.echo(f"Library push failed: {exc}", err=True)
 
-    # Phase 3: Drafts
+    # Phase 2: Drafts
     drafts_ok = False
     if config.dashboard_project_id:
         click.echo("Pushing draft files...")
@@ -238,7 +168,7 @@ def push() -> None:
                     f"{draft_result['words']} words"
                 )
             else:
-                click.echo("No draft files found (draft/ is empty or missing — run migrate_drafts.py).")
+                click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
         except Exception as exc:
             click.echo(f"Draft push failed: {exc}", err=True)
@@ -246,7 +176,6 @@ def push() -> None:
         click.echo("Draft push skipped (no dashboard_project_id — re-run 'klemma-cli link').")
         drafts_ok = True  # N/A, not a failure
 
-    # Only update last_push when library + drafts both succeeded (#260 item 3)
     if library_ok and drafts_ok:
         config.last_push = datetime.now(timezone.utc).isoformat()
     else:
@@ -256,12 +185,8 @@ def push() -> None:
 
 @cli.command()
 def pull() -> None:
-    """Pull changes from Klemma SaaS.
-
-    Three phases: git pull (files) + API pull (library data) + draft files.
-    """
+    """Pull changes from Klemma SaaS (library + drafts via API)."""
     from .client import KlemmaClient
-    from .gitops import pull as git_pull
     from .project import ensure_project_root
     from .state import load_sync_config, save_sync_config
     from .sync import pull_drafts, pull_library
@@ -272,36 +197,22 @@ def pull() -> None:
         click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
         raise SystemExit(1)
 
-    # Phase 1: Git (may fail if git-http-backend not configured on server)
-    click.echo("Pulling files...")
-    try:
-        output = git_pull(project_root)
-        if output.startswith("CONFLICT"):
-            click.echo("Merge conflicts detected. Resolve manually, then run 'klemma-cli pull' again.")
-            click.echo(output)
-            raise SystemExit(1)
-        click.echo(output or "Already up to date.")
-    except Exception:
-        click.echo("Git pull skipped (server git transport not configured).")
-
-    # Phase 2: Library
-    click.echo("Pulling library data...")
     client = KlemmaClient(api_url=config.api_url)
+
+    # Phase 1: Library
+    click.echo("Pulling library data...")
     try:
         result = pull_library(client, project_root, since=config.last_pull or None)
         click.echo(
             f"Pulled {result['sources']} sources, "
             f"{result['fragments']} fragments"
         )
-        # Update last_pull immediately after successful library pull (#260 item 7).
-        # This ensures the timestamp always marks the last *successful* library sync,
-        # and the next incremental pull only fetches sources added after this point.
         config.last_pull = datetime.now(timezone.utc).isoformat()
         save_sync_config(project_root, config)
     except Exception as exc:
         click.echo(f"Library pull failed: {exc}", err=True)
 
-    # Phase 3: Drafts (dashboard edits → local draft/)
+    # Phase 2: Drafts
     if config.dashboard_project_id:
         click.echo("Pulling draft files...")
         try:
@@ -316,28 +227,11 @@ def pull() -> None:
         click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
 
 
-def _resolve_project_id(config: object) -> str:
-    """Get the namespaced project_id (username/project) from config.
-
-    Falls back to extracting from git_url if project_id lacks a slash.
-    """
-    pid = config.project_id  # type: ignore[attr-defined]
-    if "/" in pid:
-        return pid
-    # Extract from git_url: https://litresearch.ru/git/username/project.git
-    git_url = config.git_url  # type: ignore[attr-defined]
-    if "/git/" in git_url:
-        path = git_url.split("/git/", 1)[1].removesuffix(".git")
-        if "/" in path:
-            return path
-    return pid
-
-
 @cli.command("status")
 def sync_status() -> None:
-    """Show sync status — local changes + remote diff + library counts."""
-    from .client import KlemmaClient  # noqa: I001
-    from .gitops import remote_log, status as git_status
+    """Show sync status — local changes + server library counts."""
+    from .client import KlemmaClient
+    from .gitops import status as git_status
     from .project import ensure_project_root
     from .state import load_sync_config
 
@@ -352,65 +246,16 @@ def sync_status() -> None:
     click.echo("=== Local changes ===")
     click.echo(local or "(clean)")
 
-    # Remote changes
-    remote = remote_log(project_root)
-    click.echo("\n=== Remote changes (not pulled) ===")
-    if remote:
-        for line in remote:
-            click.echo(f"  {line}")
-    else:
-        click.echo("  (up to date)")
-
     # Library status from server
     click.echo("\n=== Library ===")
     try:
         client = KlemmaClient(api_url=config.api_url)
-        project_id = _resolve_project_id(config)
-        resp = client.get(f"/sync/status/{project_id}")
+        resp = client.get(f"/sync/status/{config.dashboard_project_id}")
         data = resp.json()
         click.echo(f"  Sources: {data['source_count']}")
         click.echo(f"  Fragments: {data['fragment_count']}")
-        if data.get("last_commit"):
-            click.echo(f"  Last commit: {data['last_commit']} ({data.get('last_commit_date', '')})")
     except Exception as e:
         click.echo(f"  (could not reach server: {e})")
-
-
-@cli.command()
-@click.argument("n", type=int, default=1)
-def rollback(n: int) -> None:
-    """Rollback the last N commits (files only, not library data).
-
-    Creates revert commits and force-pushes to the server.
-    """
-    from .gitops import force_push, log, revert_last_n
-    from .project import ensure_project_root
-    from .state import load_sync_config
-
-    project_root = ensure_project_root()
-    config = load_sync_config(project_root)
-    if not config:
-        click.echo("Not linked. Run 'klemma-cli link' first.", err=True)
-        raise SystemExit(1)
-
-    # Show recent history
-    history = log(project_root, count=10)
-    click.echo("Recent history:")
-    for entry in history:
-        click.echo(f"  {entry}")
-
-    if n < 1:
-        click.echo("Nothing to rollback.")
-        return
-
-    click.echo(f"\nRolling back {n} commit(s)...")
-    try:
-        revert_last_n(project_root, n)
-        force_push(project_root)
-        click.echo(f"Rolled back {n} commit(s) and pushed to server.")
-    except Exception as e:
-        click.echo(f"Rollback failed: {e}", err=True)
-        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/cli/src/klemma_cli/main.py
+++ b/cli/src/klemma_cli/main.py
@@ -154,7 +154,11 @@ def push() -> None:
         )
         library_ok = True
     except Exception as exc:
-        click.echo(f"Library push failed: {exc}", err=True)
+        msg = str(exc)
+        if "401" in msg or "Unauthorized" in msg:
+            click.echo("Library push failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+        else:
+            click.echo(f"Library push failed: {exc}", err=True)
 
     # Phase 2: Drafts
     drafts_ok = False
@@ -175,7 +179,11 @@ def push() -> None:
                 click.echo("No draft files found (draft/ is empty or missing).")
             drafts_ok = True
         except Exception as exc:
-            click.echo(f"Draft push failed: {exc}", err=True)
+            msg = str(exc)
+            if "401" in msg or "Unauthorized" in msg:
+                click.echo("Draft push failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+            else:
+                click.echo(f"Draft push failed: {exc}", err=True)
     else:
         click.echo("Draft push skipped (no dashboard_project_id — re-run 'klemma-cli link').")
         drafts_ok = True  # N/A, not a failure
@@ -214,7 +222,11 @@ def pull() -> None:
         config.last_pull = datetime.now(timezone.utc).isoformat()
         save_sync_config(project_root, config)
     except Exception as exc:
-        click.echo(f"Library pull failed: {exc}", err=True)
+        msg = str(exc)
+        if "401" in msg or "Unauthorized" in msg:
+            click.echo("Library pull failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+        else:
+            click.echo(f"Library pull failed: {exc}", err=True)
 
     # Phase 2: Drafts
     if config.dashboard_project_id:
@@ -233,7 +245,11 @@ def pull() -> None:
             else:
                 click.echo("Draft files up to date.")
         except Exception as exc:
-            click.echo(f"Draft pull failed: {exc}", err=True)
+            msg = str(exc)
+            if "401" in msg or "Unauthorized" in msg:
+                click.echo("Draft pull failed: session expired. Run 'klemma-cli login' to refresh.", err=True)
+            else:
+                click.echo(f"Draft pull failed: {exc}", err=True)
     else:
         click.echo("Draft pull skipped (no dashboard_project_id — re-run 'klemma-cli link').")
 

--- a/cli/src/klemma_cli/models.py
+++ b/cli/src/klemma_cli/models.py
@@ -49,10 +49,7 @@ class DecisionPayload(BaseModel):
 class SyncConfig(BaseModel):
     """Persisted in .klemma/sync_config.json."""
 
-    project_id: str
     api_url: str
-    git_url: str
-    access_token: str
-    dashboard_project_id: str = ""  # UUID for /projects/{id}/drafts API
+    dashboard_project_id: str  # UUID for /projects/{id}/drafts API
     last_push: str = ""
     last_pull: str = ""

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import re
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -159,14 +160,37 @@ def push_library(client: KlemmaClient, project_root: Path) -> dict:
 
     result = {"sources": 0, "fragments": 0, "embeddings": 0}
 
-    if sources or fragments:
+    # Push in chunks to avoid timeout on large libraries
+    src_chunk = 200
+    frag_chunk = 1000
+    src_list = [s.model_dump() for s in sources]
+    frag_list = [f.model_dump() for f in fragments]
+
+    # First chunk carries all sources + first batch of fragments
+    for src_start in range(0, max(len(src_list), 1), src_chunk):
+        src_batch = src_list[src_start:src_start + src_chunk]
+        frag_start = (src_start // src_chunk) * frag_chunk
+        frag_batch = frag_list[frag_start:frag_start + frag_chunk]
+        if not src_batch and not frag_batch:
+            break
         resp = client.post("/sync/push/library", json={
-            "sources": [s.model_dump() for s in sources],
-            "fragments": [f.model_dump() for f in fragments],
+            "sources": src_batch,
+            "fragments": frag_batch,
         })
         data = resp.json()
-        result["sources"] = data.get("sources_saved", 0)
-        result["fragments"] = data.get("fragments_saved", 0)
+        result["sources"] += data.get("sources_saved", 0)
+        result["fragments"] += data.get("fragments_saved", 0)
+
+    # Push any remaining fragments not covered by source chunks
+    src_batches_count = max(1, (len(src_list) + src_chunk - 1) // src_chunk)
+    frag_offset = src_batches_count * frag_chunk
+    for i in range(frag_offset, len(frag_list), frag_chunk):
+        resp = client.post("/sync/push/library", json={
+            "sources": [],
+            "fragments": frag_list[i:i + frag_chunk],
+        })
+        data = resp.json()
+        result["fragments"] += data.get("fragments_saved", 0)
 
     # Push embeddings in chunks
     paper_embs, fragment_embs = read_local_embeddings(project_root)
@@ -197,19 +221,40 @@ def push_library(client: KlemmaClient, project_root: Path) -> dict:
 def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: str) -> dict:
     """Push local draft .md files to server's /projects/{id}/drafts API.
 
-    Reads all .md files from draft/ (ADR-016 canonical location) and uploads each
-    via PUT /projects/{id}/drafts/{filename}.
-    Returns summary dict with 'files' and 'words' counts.
+    Only pushes a file if the local copy is strictly newer than the server copy.
+    This prevents older local files from overwriting dashboard edits.
+    Returns summary dict with 'files' (pushed count), 'skipped', and 'words'.
     """
     drafts_dir = project_root / "draft"
-    result: dict = {"files": 0, "words": 0}
+    result: dict = {"files": 0, "skipped": 0, "words": 0}
 
     if not drafts_dir.exists():
         return result
 
+    # Fetch server file timestamps once
+    server_times: dict[str, datetime] = {}
+    try:
+        resp = client.get(f"/projects/{dashboard_project_id}/drafts")
+        for f in resp.json().get("files", []):
+            ts = f.get("updated_at", "")
+            if ts:
+                try:
+                    server_times[f["name"]] = datetime.fromisoformat(ts)
+                except ValueError:
+                    pass
+    except Exception:
+        pass  # if list fails, push everything
+
     for md_file in sorted(drafts_dir.glob("*.md")):
-        content = md_file.read_text(encoding="utf-8")
         filename = md_file.name
+        local_mtime = datetime.fromtimestamp(md_file.stat().st_mtime, tz=timezone.utc)
+        server_mtime = server_times.get(filename)
+
+        if server_mtime and server_mtime >= local_mtime:
+            result["skipped"] += 1
+            continue
+
+        content = md_file.read_text(encoding="utf-8")
         resp = client.put(
             f"/projects/{dashboard_project_id}/drafts/{filename}",
             json={"content": content},
@@ -241,19 +286,34 @@ def pull_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: 
     draft_dir = project_root / "draft"
     draft_dir.mkdir(exist_ok=True)
 
+    result["skipped"] = 0
+
     for file_info in file_list:
         name = file_info.get("name", "")
         if not _SAFE_DRAFT_FILENAME.match(name) or ".." in name:
             continue  # skip unsafe filenames
+
+        target = draft_dir / name
+
+        # Skip if local copy is strictly newer than server copy
+        server_ts = file_info.get("updated_at", "")
+        if server_ts and target.exists():
+            try:
+                server_mtime = datetime.fromisoformat(server_ts)
+                local_mtime = datetime.fromtimestamp(target.stat().st_mtime, tz=timezone.utc)
+                if local_mtime > server_mtime:
+                    result["skipped"] += 1
+                    continue
+            except ValueError:
+                pass
 
         content_resp = client.get(f"/projects/{dashboard_project_id}/drafts/{name}")
         data = content_resp.json()
         content: str = data.get("content", "")
         wc: int = data.get("word_count", 0)
 
-        target = draft_dir / name
         if target.exists() and target.read_text(encoding="utf-8") == content:
-            continue  # already up to date
+            continue  # already up to date (same content)
 
         target.write_text(content, encoding="utf-8")
         result["files"] += 1

--- a/cli/src/klemma_cli/sync.py
+++ b/cli/src/klemma_cli/sync.py
@@ -242,8 +242,11 @@ def push_drafts(client: KlemmaClient, project_root: Path, dashboard_project_id: 
                     server_times[f["name"]] = datetime.fromisoformat(ts)
                 except ValueError:
                     pass
-    except Exception:
-        pass  # if list fails, push everything
+    except Exception as e:
+        # Re-raise auth errors so caller can show helpful message
+        if "401" in str(e) or "Unauthorized" in str(e):
+            raise
+        # Other errors (network, 404) — proceed without timestamps, push everything
 
     for md_file in sorted(drafts_dir.glob("*.md")):
         filename = md_file.name

--- a/cli/tests/test_gitops.py
+++ b/cli/tests/test_gitops.py
@@ -14,7 +14,6 @@ from klemma_cli.gitops import (
     init,
     is_git_repo,
     log,
-    set_http_auth_header,
     status,
     write_gitignore,
 )
@@ -126,37 +125,6 @@ class TestGetHeadHash:
         h = get_head_hash(git_repo)
         assert h is not None
         assert len(h) == 40
-
-
-class TestSetHttpAuthHeader:
-    def test_stores_authorization_header_in_local_config(self, git_repo):
-        set_http_auth_header(git_repo, "https://litresearch.ru", "mytoken123")
-        result = subprocess.run(
-            ["git", "config", "--local", "http.https://litresearch.ru/.extraHeader"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        assert result.returncode == 0
-        assert "Authorization: Basic" in result.stdout
-
-    def test_token_not_stored_in_plaintext(self, git_repo):
-        set_http_auth_header(git_repo, "https://litresearch.ru", "supersecrettoken")
-        result = subprocess.run(
-            ["git", "config", "--local", "--list"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        assert "supersecrettoken" not in result.stdout
-
-    def test_overwrites_existing_header_on_relink(self, git_repo):
-        import base64
-
-        set_http_auth_header(git_repo, "https://litresearch.ru", "old_token")
-        set_http_auth_header(git_repo, "https://litresearch.ru", "new_token")
-        result = subprocess.run(
-            ["git", "config", "--local", "http.https://litresearch.ru/.extraHeader"],
-            cwd=str(git_repo), capture_output=True, text=True,
-        )
-        expected = base64.b64encode(b"token:new_token").decode()
-        assert expected in result.stdout
 
 
 class TestWriteGitignore:

--- a/saas/dashboard/CLAUDE.md
+++ b/saas/dashboard/CLAUDE.md
@@ -14,7 +14,7 @@ saas/dashboard/
 │   ├── api/client.ts      — typed API client, JWT management, token refresh
 │   ├── router/index.ts    — routes + auth guard
 │   ├── components/        — shared components
-│   │   └── AppLayout      — sidebar nav (Здоровье / Библиотека / Исследование) + project switcher + token meter
+│   │   └── AppLayout      — sidebar nav (Карта / Лента / Библиотека / Редактор→/write) + project switcher + token meter
 │   ├── views/             — page components
 │   │   ├── LandingView    — public landing page (Russian)
 │   │   ├── LoginView      — email/password login
@@ -26,7 +26,11 @@ saas/dashboard/
 │   │   ├── ReportView     — structured research report: argument blocks, citations
 │   │   ├── OutlineView    — structure editor (accessible via settings icon, not in primary nav)
 │   │   ├── CoverageView   — coverage heatmap (accessible via direct URL, not in primary nav)
-│   │   ├── DashboardView  — legacy, redirects to HealthView
+│   │   ├── SectionEditorView — /:projectId/write — section-card write paradigm (Phase 5A, #273)
+│   │   │     standalone layout (no AppLayout), topbar, doc-structure sidebar, section cards
+│   │   │     3-state draft machine (0/1-4/5+ sources), prompt+presets, polling draft gen, diff review
+│   │   ├── FileEditorView — /:projectId/edit/:filename — raw markdown editor (fallback)
+│   │   ├── DashboardView  — legacy, redirects to MapView
 │   │   └── GlobalLibraryView — all sources across projects
 │   └── assets/main.css    — Tailwind entry point
 ├── vite.config.ts         — Tailwind plugin + /api proxy

--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -104,12 +104,32 @@ export const auth = {
 
 // Library
 export const library = {
-  list: (projectId?: string) => {
-    const qs = projectId ? `?project_id=${encodeURIComponent(projectId)}` : ''
+  list: (projectId?: string, q?: string) => {
+    const params = new URLSearchParams()
+    if (projectId) params.set('project_id', projectId)
+    if (q) params.set('q', q)
+    const qs = params.size ? `?${params}` : ''
     return request<{ sources: any[]; total: number }>(`/library/sources${qs}`)
   },
 
   get: (citekey: string) => request<any>(`/library/sources/${citekey}`),
+
+  fragmentSearch: (q: string, limit = 10) => {
+    const params = new URLSearchParams({ q, limit: String(limit) })
+    return request<{
+      results: {
+        fragment_id: string
+        citekey: string
+        title: string
+        authors: string
+        year: number | null
+        text: string
+        fragment_type: string
+      }[]
+      total: number
+      query: string
+    }>(`/library/fragments/search?${params}`)
+  },
 
   add: (data: { citekey: string; title: string; authors?: string; year?: number; doi?: string }) =>
     request<any>('/library/sources', { method: 'POST', body: JSON.stringify(data) }),
@@ -216,6 +236,11 @@ export const projects = {
 
   sourceSections: (citekey: string) =>
     request<{ citekey: string; sections: string[] }>(`/projects/sources/${citekey}/sections`),
+
+  detachSection: (citekey: string, section: string) =>
+    request<void>(`/projects/sections/${encodeURIComponent(section)}/sources/${encodeURIComponent(citekey)}`, {
+      method: 'DELETE',
+    }),
 }
 
 // Process

--- a/saas/dashboard/src/components/AppLayout.vue
+++ b/saas/dashboard/src/components/AppLayout.vue
@@ -16,7 +16,7 @@ function switchProject(projectId: string) {
   const currentParam = route.params.projectId as string | undefined
   if (currentParam) {
     // Navigate to same module within new project
-    const modules = ['map', 'feed', 'library', 'health', 'outline', 'coverage', 'research', 'edit']
+    const modules = ['map', 'feed', 'library', 'health', 'outline', 'coverage', 'research', 'write', 'edit']
     const suffix = route.path.slice(currentParam.length + 2) // strip /projectId/
     const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'map'
     router.push(`/${projectId}/${module}`)
@@ -232,9 +232,9 @@ async function createProject() {
           Библиотека
         </RouterLink>
         <RouterLink
-          :to="`/${route.params.projectId}/edit`"
+          :to="`/${route.params.projectId}/write`"
           class="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm font-medium transition-colors"
-          :class="route.path.startsWith(`/${route.params.projectId}/edit`)
+          :class="route.path.startsWith(`/${route.params.projectId}/write`)
             ? 'text-[var(--color-accent-deep)] bg-[var(--color-accent-pale)]'
             : 'text-[var(--color-ink-muted)] hover:text-[var(--color-ink)] hover:bg-[var(--color-rule-light)]'"
         >

--- a/saas/dashboard/src/components/SourceDrawer.vue
+++ b/saas/dashboard/src/components/SourceDrawer.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { library, projects as apiProjects } from '@/api/client'
+
+const props = defineProps<{
+  citekey: string
+  projectId: string
+  activeSectionId?: string | null
+}>()
+const emit = defineEmits<{ close: [] }>()
+
+interface Fragment { fragment_id: string; text: string; fragment_type: string; section?: string }
+interface SourceDetail {
+  citekey: string; title: string; authors?: string; year?: number
+  abstract?: string; journal?: string; fragments?: Fragment[]
+}
+
+const loading = ref(true)
+const error = ref('')
+const source = ref<SourceDetail | null>(null)
+const assignedSections = ref<string[]>([])
+const attaching = ref(false)
+
+onMounted(async () => {
+  try {
+    const [src, sect] = await Promise.all([
+      library.get(props.citekey),
+      apiProjects.sourceSections(props.citekey).catch(() => ({ sections: [] as string[] })),
+    ])
+    source.value = src
+    assignedSections.value = sect.sections
+  } catch (e: any) {
+    error.value = e.message ?? 'Ошибка загрузки'
+  } finally {
+    loading.value = false
+  }
+})
+
+async function toggleSection(sectionId: string) {
+  if (!source.value) return
+  const isAssigned = assignedSections.value.includes(sectionId)
+  attaching.value = true
+  try {
+    const newSections = isAssigned
+      ? assignedSections.value.filter(s => s !== sectionId)
+      : [...assignedSections.value, sectionId]
+    await apiProjects.assignSections(props.citekey, newSections)
+    assignedSections.value = newSections
+  } catch { /* ignore */ } finally {
+    attaching.value = false
+  }
+}
+
+const isCurrentSectionAssigned = () =>
+  props.activeSectionId ? assignedSections.value.includes(props.activeSectionId) : false
+</script>
+
+<template>
+  <!-- Overlay backdrop -->
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 bg-black/10" @click="emit('close')" />
+    <div class="fixed right-0 top-0 h-full w-80 bg-white border-l border-[var(--color-rule)] shadow-2xl z-50 flex flex-col">
+
+      <!-- Header -->
+      <div class="flex items-center gap-2.5 px-4 py-3 border-b border-[var(--color-rule)] flex-shrink-0">
+        <span class="text-[12px] font-mono font-semibold text-[var(--color-accent)] bg-[var(--color-accent-pale)] rounded px-1.5 py-0.5 flex-1 truncate">
+          @{{ citekey }}
+        </span>
+        <button
+          @click="emit('close')"
+          class="w-7 h-7 flex items-center justify-center rounded text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="flex items-center justify-center flex-1 text-[var(--color-ink-muted)]">
+        <svg class="animate-spin w-5 h-5" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" stroke-dasharray="31.4" stroke-dashoffset="10"/>
+        </svg>
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="p-4 text-[var(--color-err)] text-sm">
+        {{ error }}
+      </div>
+
+      <!-- Content -->
+      <div v-else-if="source" class="flex-1 overflow-y-auto">
+
+        <!-- Bibliographic info -->
+        <div class="px-4 pt-4 pb-3 border-b border-[var(--color-rule-light)]">
+          <h3 class="text-[14px] font-semibold text-[var(--color-ink)] leading-snug mb-1.5">{{ source.title }}</h3>
+          <p v-if="source.authors" class="text-[12px] text-[var(--color-ink-muted)] mb-0.5">{{ source.authors }}</p>
+          <p v-if="source.year || source.journal" class="text-[11px] font-mono text-[var(--color-ink-muted)]">
+            <span v-if="source.year">{{ source.year }}</span>
+            <span v-if="source.journal && source.year"> · </span>
+            <span v-if="source.journal">{{ source.journal }}</span>
+          </p>
+          <p v-if="source.abstract" class="text-[12px] text-[var(--color-ink-muted)] mt-2 leading-relaxed line-clamp-4">
+            {{ source.abstract }}
+          </p>
+        </div>
+
+        <!-- Assign to active section -->
+        <div v-if="activeSectionId" class="px-4 py-3 border-b border-[var(--color-rule-light)]">
+          <button
+            @click="toggleSection(activeSectionId)"
+            :disabled="attaching"
+            :class="[
+              'w-full inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors',
+              isCurrentSectionAssigned()
+                ? 'border border-[var(--color-ok)] text-[var(--color-ok)] bg-[var(--color-ok-bg)] hover:bg-green-100'
+                : 'bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-deep)]',
+              attaching ? 'opacity-60 cursor-wait' : ''
+            ]"
+          >
+            <svg v-if="isCurrentSectionAssigned()" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+            <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            {{ isCurrentSectionAssigned() ? `Прикреплён к ${activeSectionId}` : `Прикрепить к ${activeSectionId}` }}
+          </button>
+        </div>
+
+        <!-- Fragments -->
+        <div class="px-4 pt-3">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-2">
+            Фрагменты {{ source.fragments?.length ? `(${source.fragments.length})` : '' }}
+          </div>
+          <div v-if="!source.fragments?.length" class="text-[12px] text-[var(--color-ink-muted)] italic py-2">
+            Фрагменты не загружены
+          </div>
+          <div
+            v-for="frag in source.fragments"
+            :key="frag.fragment_id"
+            class="mb-2 p-2.5 rounded-md bg-[var(--color-rule-light)] border border-[var(--color-rule)]"
+          >
+            <div class="flex items-center gap-1.5 mb-1.5">
+              <span class="text-[10px] font-mono text-[var(--color-ink-muted)] bg-white rounded px-1 py-0.5 border border-[var(--color-rule)]">
+                {{ frag.fragment_type }}
+              </span>
+              <span v-if="frag.section" class="text-[10px] font-mono text-[var(--color-accent)]">
+                {{ frag.section }}
+              </span>
+            </div>
+            <p class="text-[12px] text-[var(--color-ink)] leading-relaxed">{{ frag.text }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="border-t border-[var(--color-rule)] px-4 py-2.5 flex-shrink-0">
+        <RouterLink
+          :to="`/${projectId}/library/${citekey}`"
+          class="flex items-center justify-center gap-1.5 text-[12px] text-[var(--color-ink-muted)] hover:text-[var(--color-accent)] transition-colors"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          Открыть полную карточку
+        </RouterLink>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/saas/dashboard/src/components/SourcePanel.vue
+++ b/saas/dashboard/src/components/SourcePanel.vue
@@ -117,9 +117,12 @@ async function attachItem(item: LibraryItem) {
   }
 }
 
-function detachItem(citekey: string) {
+async function detachItem(citekey: string) {
   attachedCitekeys.value = attachedCitekeys.value.filter(k => k !== citekey)
   emit('detach', citekey)
+  if (!props.isDemoMode && props.sectionId) {
+    try { await apiProjects.detachSection(citekey, props.sectionId) } catch { /* non-fatal */ }
+  }
 }
 </script>
 

--- a/saas/dashboard/src/components/SourcePanel.vue
+++ b/saas/dashboard/src/components/SourcePanel.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   sectionId: string | null
   projectId: string
   isDemoMode?: boolean
+  sectionName?: string
 }>()
 
 const emit = defineEmits<{
@@ -127,7 +128,7 @@ function detachItem(citekey: string) {
     <!-- Section header -->
     <div class="flex-shrink-0 px-3 pt-3 pb-2 border-b border-[var(--color-rule-light)]">
       <p v-if="sectionId" class="text-xs font-semibold text-[var(--color-accent-deep)] truncate">
-        {{ sectionId }}
+        {{ sectionName ?? sectionId }}
       </p>
       <p v-else class="text-xs text-[var(--color-ink-muted)] italic">
         Поставьте курсор в раздел

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -122,6 +122,12 @@ const router = createRouter({
       redirect: (to) => `/${to.params.projectId}/map`,
     },
     {
+      path: '/:projectId/write',
+      name: 'write',
+      component: () => import('../views/SectionEditorView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/:projectId/edit',
       name: 'edit',
       component: () => import('../views/FileEditorView.vue'),

--- a/saas/dashboard/src/views/FileEditorView.vue
+++ b/saas/dashboard/src/views/FileEditorView.vue
@@ -68,6 +68,27 @@ watch(isViewMode, async (viewMode) => {
 // ── Cursor section detection ──────────────────────────────────────────────
 const cursorSectionId = ref<string | null>(null)
 const editorEl = ref<HTMLDivElement>()
+const viewEl = ref<HTMLDivElement>()
+
+const cursorSectionName = computed<string | null>(() => {
+  if (!cursorSectionId.value) return null
+  const h = draftHeadings.value.find(h => h.section_id === cursorSectionId.value)
+  return h?.full_title ?? null
+})
+
+async function scrollToSection(sectionId: string) {
+  await nextTick()
+  if (!viewEl.value) return
+  const h = draftHeadings.value.find(h => h.section_id === sectionId)
+  if (!h) return
+  const els = viewEl.value.querySelectorAll(`h${h.level}`)
+  for (const el of Array.from(els)) {
+    if (el.textContent?.includes(h.title)) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      return
+    }
+  }
+}
 let detectTimer: ReturnType<typeof setTimeout> | null = null
 
 function onSelectionChange() {
@@ -205,8 +226,13 @@ onMounted(async () => {
   document.addEventListener('selectionchange', onSelectionChange)
 
   const filenameParam = route.params.filename as string | undefined
+  const sectionQuery = route.query.section as string | undefined
   if (filenameParam) {
     await loadFile(decodeURIComponent(filenameParam))
+    if (sectionQuery) {
+      cursorSectionId.value = sectionQuery
+      await scrollToSection(sectionQuery)
+    }
   } else if (projectId.value) {
     try {
       const listData = await drafts.list(projectId.value)
@@ -283,6 +309,23 @@ watch(() => route.params.filename, (filename) => {
             >{{ isViewMode ? 'Редактировать' : 'Просмотр' }}</button>
           </div>
 
+          <!-- Section breadcrumb (visible when cursor is in a named section) -->
+          <div v-if="cursorSectionId && draftFilename" class="flex items-center gap-2 text-sm min-h-[28px]">
+            <span class="text-[var(--color-ink-muted)]">{{ displayName(draftFilename) }}</span>
+            <span class="text-[var(--color-rule)] select-none">›</span>
+            <span class="text-[var(--color-ink)] font-medium truncate flex-1">{{ cursorSectionName ?? cursorSectionId }}</span>
+            <button
+              disabled
+              title="Скоро: генерация черновика секции"
+              class="flex-shrink-0 flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium opacity-40 cursor-not-allowed border-[var(--color-rule)] text-[var(--color-ink-muted)]"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5">
+                <path d="M7.539 14.841a.75.75 0 0 1-.479-.439l-1.074-3.026A8.97 8.97 0 0 0 3.71 9.096l-3.026-1.074a.75.75 0 0 1 0-1.044l3.026-1.074A8.97 8.97 0 0 0 6 3.804l1.073-3.026a.75.75 0 0 1 1.044 0l1.074 3.026A8.97 8.97 0 0 0 12.29 5.904l3.025 1.074a.75.75 0 0 1 0 1.044l-3.025 1.074a8.97 8.97 0 0 0-3.1 2.099l-1.075 3.026a.75.75 0 0 1-.576.62Z" />
+              </svg>
+              Сгенерировать черновик
+            </button>
+          </div>
+
           <!-- Editor block -->
           <div class="rounded-lg border bg-[var(--color-paper-white)] transition-colors"
             :class="!isViewMode && draftFilename ? 'border-[var(--color-accent)]/40 shadow-sm' : 'border-[var(--color-rule)]'"
@@ -297,6 +340,7 @@ watch(() => route.params.filename, (filename) => {
 
             <!-- VIEW mode: rendered markdown -->
             <div v-else-if="draftFilename && isViewMode"
+              ref="viewEl"
               class="draft-prose px-8 py-6 text-[15px] text-[var(--color-ink)] leading-[1.8] font-[var(--font-body)] cursor-text"
               @click="isViewMode = false"
               v-html="editingBody ? renderDraft(editingBody) : '<p class=\'text-[var(--color-ink-muted)] italic\'>Файл пуст — нажмите для редактирования</p>'"
@@ -383,6 +427,7 @@ watch(() => route.params.filename, (filename) => {
         <div class="w-52 flex-shrink-0" style="max-height: calc(100vh - 9rem);">
           <SourcePanel
             :sectionId="cursorSectionId"
+            :sectionName="cursorSectionName ?? undefined"
             :projectId="projectId"
             :isDemoMode="false"
             @attach="() => {/* SourcePanel persists server-side internally */}"

--- a/saas/dashboard/src/views/MapView.vue
+++ b/saas/dashboard/src/views/MapView.vue
@@ -367,17 +367,25 @@ const thesis = computed(() =>
 
 // ── Navigation ────────────────────────────────────────────────────────────
 
+function sectionToFilename(sectionId: string): string {
+  const chapter = sectionId.split('.')[0]
+  if (!chapter || chapter === '0') return 'intro.md'
+  return `chapter_${chapter}.md`
+}
+
 function navigateToBlock(sectionId: string, blockId: string) {
   if (isDemoMode.value) {
     router.push(`/demo/map/${sectionId}/${blockId}`)
   } else {
-    router.push(`/${projectId.value}/map/${sectionId}/b1`)
+    const filename = sectionToFilename(sectionId)
+    router.push(`/${projectId.value}/write?section=${sectionId}&file=${filename}`)
   }
 }
 
 function navigateToSection(sectionId: string) {
   if (isDemoMode.value) return // demo uses toggleSection
-  router.push(`/${projectId.value}/map/${sectionId}/b1`)
+  const filename = sectionToFilename(sectionId)
+  router.push(`/${projectId.value}/write?section=${sectionId}&file=${filename}`)
 }
 
 // ── State ────────────────────────────────────────────────────────────────

--- a/saas/dashboard/src/views/MapView.vue
+++ b/saas/dashboard/src/views/MapView.vue
@@ -369,7 +369,8 @@ const thesis = computed(() =>
 
 function sectionToFilename(sectionId: string): string {
   const chapter = sectionId.split('.')[0]
-  if (!chapter || chapter === '0') return 'intro.md'
+  if (!chapter || chapter === '0' || chapter === 'intro') return 'intro.md'
+  if (chapter === 'conclusion') return 'conclusion.md'
   return `chapter_${chapter}.md`
 }
 

--- a/saas/dashboard/src/views/SectionEditorView.vue
+++ b/saas/dashboard/src/views/SectionEditorView.vue
@@ -6,6 +6,7 @@ import {
   process as processApi,
   type DraftFile, type DraftHeading,
 } from '@/api/client'
+import SourceDrawer from '@/components/SourceDrawer.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -154,10 +155,26 @@ function selectPreset(id: string, preset: string) {
   cardPromptText.value[id] = labels[preset] ?? ''
 }
 
+// ── File content (for diff "before") ─────────────────────────────────────────
+const fileContent = ref<Record<string, string>>({})
+
+watch(activeFile, async (name) => {
+  if (name && !fileContent.value[name]) {
+    try {
+      const data = await drafts.get(projectId.value, name)
+      fileContent.value[name] = data.content
+    } catch { /* before will show "(пустой раздел)" */ }
+  }
+}, { immediate: true })
+
 function currentSectionText(sectionId: string): string {
-  // Find section heading line + next heading line in active file content
-  // We'll store it from the last fetch — for now return empty (diff will show just before=empty)
-  return ''
+  const content = fileContent.value[activeFile.value]
+  if (!content) return ''
+  const lines = content.split('\n')
+  const h = activeSections.value.find(x => x.section_id === sectionId)
+  if (!h) return ''
+  const nextH = activeSections.value.find(x => x.line > h.line)
+  return lines.slice(h.line + 1, nextH?.line ?? lines.length).join('\n').trim()
 }
 
 async function runGenerate(sectionId: string) {
@@ -229,6 +246,43 @@ function rejectDraft(sectionId: string) {
 function editPrompt(sectionId: string) {
   cardStates.value[sectionId] = 'prompt'
 }
+
+// ── Citekey click → source drawer ────────────────────────────────────────────
+const drawerCitekey = ref<string | null>(null)
+
+function renderWithCitekeys(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  return escaped
+    .replace(/\[@([\w\d_:.-]+)\]/g,
+      '<span class="citekey-link" data-citekey="$1">[@$1]</span>')
+    .replace(/\n/g, '<br>')
+}
+
+function handleCitekeyClick(e: MouseEvent) {
+  const key = (e.target as HTMLElement).dataset?.citekey
+  if (key) drawerCitekey.value = key
+}
+
+// ── Right panel: sources for active section ──────────────────────────────────
+const panelSources = ref<string[]>([])
+const panelLoading = ref(false)
+
+watch(activeSectionId, async (id) => {
+  panelSources.value = []
+  if (!id) return
+  panelLoading.value = true
+  try {
+    const r = await apiProjects.sectionSources(id)
+    panelSources.value = r.citekeys
+  } catch {
+    panelSources.value = []
+  } finally {
+    panelLoading.value = false
+  }
+})
 
 // ── Data loading ─────────────────────────────────────────────────────────────
 async function loadAll() {
@@ -690,9 +744,11 @@ const tokenBarCls = computed(() => {
                   </div>
                   <div class="px-4 py-3 bg-[#f8fff9]">
                     <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ok)] mb-2">Станет</div>
-                    <p class="text-[13px] text-[var(--color-ink)] leading-relaxed whitespace-pre-wrap">
-                      {{ cardGenResult[heading.section_id] }}
-                    </p>
+                    <div
+                      v-html="renderWithCitekeys(cardGenResult[heading.section_id] ?? '')"
+                      @click="handleCitekeyClick($event)"
+                      class="text-[13px] text-[var(--color-ink)] leading-relaxed [&_.citekey-link]:text-[var(--color-accent)] [&_.citekey-link]:underline [&_.citekey-link]:decoration-dotted [&_.citekey-link]:cursor-pointer [&_.citekey-link:hover]:no-underline"
+                    />
                   </div>
                 </div>
                 <!-- Diff actions -->
@@ -725,7 +781,77 @@ const tokenBarCls = computed(() => {
           </div>
         </template>
       </main>
+
+      <!-- ── Right panel ──────────────────────────────────────────────── -->
+      <aside class="w-64 flex-shrink-0 bg-[var(--color-paper-white)] border-l border-[var(--color-rule)] flex flex-col overflow-y-auto">
+        <div class="px-4 pt-4 pb-2">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-3">Контекст раздела</div>
+
+          <!-- Active section info -->
+          <template v-if="activeSectionId">
+            <div class="text-[13px] font-semibold text-[var(--color-ink)] leading-snug mb-0.5">
+              {{ activeSections.find(h => h.section_id === activeSectionId)?.full_title?.replace(/^[\d.]+\s*/, '') || activeSectionId }}
+            </div>
+            <div class="text-[11px] font-mono text-[var(--color-ink-muted)] mb-4">{{ activeSectionId }}</div>
+
+            <!-- CTA: Close gaps -->
+            <RouterLink
+              :to="`/${projectId}/library`"
+              class="flex items-center justify-center gap-1.5 w-full py-1.5 rounded-md bg-[var(--color-accent)] text-white text-[12px] font-medium mb-4 hover:bg-[var(--color-accent-deep)] transition-colors"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+              Закрыть пробелы
+            </RouterLink>
+
+            <!-- Stats -->
+            <div class="grid grid-cols-2 gap-2 mb-4">
+              <div class="bg-[var(--color-rule-light)] rounded-md px-2 py-2 text-center">
+                <div class="text-[18px] font-bold font-mono text-[var(--color-ink)]">{{ sectionCounts[activeSectionId] ?? 0 }}</div>
+                <div class="text-[10px] text-[var(--color-ink-muted)]">источников</div>
+              </div>
+              <div class="bg-[var(--color-rule-light)] rounded-md px-2 py-2 text-center">
+                <div class="text-[18px] font-bold font-mono text-[var(--color-ink)]">{{ panelSources.length }}</div>
+                <div class="text-[10px] text-[var(--color-ink-muted)]">прикреплено</div>
+              </div>
+            </div>
+
+            <!-- Source list -->
+            <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-2">
+              Источники раздела
+            </div>
+            <div v-if="panelLoading" class="text-[12px] text-[var(--color-ink-muted)] py-1">Загрузка…</div>
+            <div v-else-if="panelSources.length === 0" class="text-[12px] text-[var(--color-ink-muted)] italic py-1">
+              Нет источников
+            </div>
+            <div
+              v-for="key in panelSources"
+              :key="key"
+              @click="drawerCitekey = key"
+              class="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-[var(--color-rule-light)] group mb-0.5"
+            >
+              <span class="text-[11px] font-mono text-[var(--color-accent)] flex-1 truncate">{{ key }}</span>
+              <svg class="w-3 h-3 text-[var(--color-ink-muted)] opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </div>
+          </template>
+
+          <!-- Nothing selected -->
+          <div v-else class="text-center py-8 text-[var(--color-ink-muted)]">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" class="mx-auto mb-2 opacity-30"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
+            <p class="text-[12px]">Выберите раздел</p>
+          </div>
+        </div>
+      </aside>
+
     </div>
+
+    <!-- ── Source drawer ─────────────────────────────────────────────────── -->
+    <SourceDrawer
+      v-if="drawerCitekey"
+      :citekey="drawerCitekey"
+      :project-id="projectId"
+      :active-section-id="activeSectionId"
+      @close="drawerCitekey = null"
+    />
 
     <!-- ── Toast ────────────────────────────────────────────────────────── -->
     <div :class="['fixed bottom-5 right-5 bg-[var(--color-ink)] text-white px-4 py-2 rounded-lg text-[13px] shadow-lg transition-all duration-250 pointer-events-none z-50', toastVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10']">

--- a/saas/dashboard/src/views/SectionEditorView.vue
+++ b/saas/dashboard/src/views/SectionEditorView.vue
@@ -337,9 +337,9 @@ async function handleQuerySection() {
     } else {
       // Infer file from section id
       const chapter = sec.split('.')[0]
-      if (sec === 'intro') activeFile.value = 'intro.md'
-      else if (sec === 'conclusion') activeFile.value = 'conclusion.md'
-      else if (chapter) activeFile.value = `chapter_${chapter}.md`
+      if (!chapter || chapter === 'intro' || chapter === '0') activeFile.value = 'intro.md'
+      else if (chapter === 'conclusion') activeFile.value = 'conclusion.md'
+      else activeFile.value = `chapter_${chapter}.md`
     }
     activeSectionId.value = sec
     await nextTick()

--- a/saas/dashboard/src/views/SectionEditorView.vue
+++ b/saas/dashboard/src/views/SectionEditorView.vue
@@ -2,8 +2,8 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
-  auth, usage, userProjects, projects as apiProjects, drafts, write as writeApi,
-  process as processApi,
+  projects as apiProjects, drafts, write as writeApi,
+  process as processApi, library as apiLibrary,
   type DraftFile, type DraftHeading,
 } from '@/api/client'
 import SourceDrawer from '@/components/SourceDrawer.vue'
@@ -19,10 +19,6 @@ const loadError = ref('')
 const draftFiles = ref<DraftFile[]>([])
 const sectionCounts = ref<Record<string, number>>({})  // section_id → source count
 const totalSources = ref(0)
-const projectName = ref('')
-const userName = ref('')
-const userInitials = ref('?')
-const tokenBalance = ref<{ total_granted: number; total_used: number; remaining: number } | null>(null)
 
 // ── Active chapter (sidebar nav) ────────────────────────────────────────────
 const activeFile = ref<string>('')          // e.g. "chapter_1.md"
@@ -50,6 +46,57 @@ function showToast(msg: string) {
   toastTimer = setTimeout(() => { toastVisible.value = false }, 3000)
 }
 
+// ── Citation search (per section) ───────────────────────────────────────────
+interface FragmentResult {
+  fragment_id: string
+  citekey: string
+  title: string
+  year: number | null
+  text: string
+  fragment_type: string
+}
+const citeSearchOpen = ref<Record<string, boolean>>({})
+const citeSearchQuery = ref<Record<string, string>>({})
+const citeSearchResults = ref<Record<string, FragmentResult[]>>({})
+const citeSearchLoading = ref<Record<string, boolean>>({})
+let citeSearchTimers: Record<string, ReturnType<typeof setTimeout>> = {}
+
+const CITE_PRESETS = [
+  'Запрос на автоматизацию',
+  'Из A следует B',
+  'Субъективность экспертов',
+  'Точность метода',
+]
+
+function toggleCiteSearch(sectionId: string) {
+  citeSearchOpen.value[sectionId] = !citeSearchOpen.value[sectionId]
+}
+
+function setCiteQuery(sectionId: string, q: string) {
+  citeSearchQuery.value[sectionId] = q
+  if (citeSearchTimers[sectionId]) clearTimeout(citeSearchTimers[sectionId])
+  if (!q.trim() || q.trim().length < 2) { citeSearchResults.value[sectionId] = []; return }
+  citeSearchTimers[sectionId] = setTimeout(() => runCiteSearch(sectionId, q), 400)
+}
+
+async function runCiteSearch(sectionId: string, q: string) {
+  citeSearchLoading.value[sectionId] = true
+  try {
+    const data = await apiLibrary.fragmentSearch(q, 8)
+    citeSearchResults.value[sectionId] = data.results
+  } catch { citeSearchResults.value[sectionId] = [] }
+  finally { citeSearchLoading.value[sectionId] = false }
+}
+
+async function attachFragmentSource(sectionId: string, citekey: string) {
+  try {
+    await apiProjects.assignSections(citekey, [sectionId])
+    // Update local source count
+    sectionCounts.value[sectionId] = (sectionCounts.value[sectionId] ?? 0) + 1
+    showToast(`[@${citekey}] прикреплён к разделу`)
+  } catch { showToast('Ошибка при прикреплении') }
+}
+
 // ── Computed chapter list ────────────────────────────────────────────────────
 function fileDisplayName(name: string): string {
   const map: Record<string, string> = { 'intro.md': 'Введение', 'conclusion.md': 'Заключение' }
@@ -71,7 +118,9 @@ function fileOrder(name: string): number {
 }
 
 const sortedFiles = computed(() =>
-  [...draftFiles.value].sort((a, b) => fileOrder(a.name) - fileOrder(b.name))
+  [...draftFiles.value]
+    .filter(f => f.name !== 'dissertation.md')
+    .sort((a, b) => fileOrder(a.name) - fileOrder(b.name))
 )
 
 const activeFileData = computed(() =>
@@ -289,12 +338,9 @@ async function loadAll() {
   loading.value = true
   loadError.value = ''
   try {
-    const [filesData, coverageData, projectsData, meData, usageData] = await Promise.allSettled([
+    const [filesData, coverageData] = await Promise.allSettled([
       drafts.list(projectId.value),
       apiProjects.coverage(),
-      userProjects.list(),
-      auth.me(),
-      usage.me(),
     ])
 
     if (filesData.status === 'fulfilled') {
@@ -303,18 +349,6 @@ async function loadAll() {
     if (coverageData.status === 'fulfilled') {
       sectionCounts.value = coverageData.value.sections
       totalSources.value = coverageData.value.total_sources
-    }
-    if (projectsData.status === 'fulfilled') {
-      const p = projectsData.value.projects.find(p => p.project_id === projectId.value)
-      if (p) projectName.value = p.name
-    }
-    if (meData.status === 'fulfilled') {
-      userName.value = meData.value.name || meData.value.email
-      const parts = (meData.value.name || meData.value.email || '?').split(' ')
-      userInitials.value = parts.map(w => w[0]?.toUpperCase() ?? '').slice(0, 2).join('')
-    }
-    if (usageData.status === 'fulfilled') {
-      tokenBalance.value = usageData.value
     }
   } catch (e: any) {
     loadError.value = e.message ?? 'Ошибка загрузки'
@@ -360,86 +394,23 @@ onUnmounted(() => {
   if (toastTimer) clearTimeout(toastTimer)
 })
 
-// ── Sync ─────────────────────────────────────────────────────────────────────
-function handleSync() {
-  showToast('Синхронизация — используйте klemma pull/push из CLI')
-}
-
-// ── Token bar ─────────────────────────────────────────────────────────────────
-const tokenPercent = computed(() => {
-  if (!tokenBalance.value || tokenBalance.value.total_granted === 0) return 0
-  return Math.round((tokenBalance.value.total_used / tokenBalance.value.total_granted) * 100)
-})
-
-const tokenBarCls = computed(() => {
-  const p = tokenPercent.value
-  if (p >= 90) return 'bg-[var(--color-err)]'
-  if (p >= 75) return 'bg-[var(--color-warn)]'
-  return 'bg-gradient-to-r from-violet-400 to-[var(--color-accent)]'
-})
 </script>
 
 <template>
-  <div class="flex flex-col h-screen bg-[var(--color-paper)]">
-
-    <!-- ── Topbar ───────────────────────────────────────────────────────── -->
-    <header class="h-12 flex-shrink-0 bg-white border-b border-[var(--color-rule)] flex items-center gap-3 px-5">
-      <!-- Logo -->
-      <RouterLink :to="`/${projectId}/map`" class="font-bold text-[15px] tracking-tight text-[var(--color-ink)] hover:opacity-80">
-        k<span class="text-[var(--color-accent)]">lemma</span>
-      </RouterLink>
-      <!-- Project badge -->
-      <span v-if="projectName" class="text-xs font-mono bg-[var(--color-rule-light)] border border-[var(--color-rule)] rounded px-2 py-0.5 text-[var(--color-ink-muted)] max-w-[180px] truncate">
-        {{ projectName }}
-      </span>
-
-      <div class="flex-1" />
-
-      <!-- Stats -->
-      <span class="text-[11px] font-mono text-[var(--color-ink-muted)] hidden sm:block">
-        {{ totalSources }} источников · {{ sortedFiles.length }} файлов · {{ coveragePercent }}%
-      </span>
-
-      <!-- Bell → Feed -->
-      <RouterLink
-        :to="`/${projectId}/feed`"
-        class="relative w-8 h-8 rounded-lg flex items-center justify-center border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
-        title="Лента событий"
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
-        </svg>
-        <span class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-red-500 border border-white" />
-      </RouterLink>
-
-      <!-- Sync -->
-      <button
-        @click="handleSync"
-        class="flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-lg border border-[var(--color-rule)] bg-transparent text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
-        title="Синхронизировать с локальным черновиком"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"/>
-        </svg>
-        Синхронизировать
-      </button>
-    </header>
-
-    <!-- ── Workspace ────────────────────────────────────────────────────── -->
-    <div class="flex flex-1 overflow-hidden">
+  <div class="flex flex-1 overflow-hidden">
 
       <!-- ── Sidebar ───────────────────────────────────────────────────── -->
       <nav class="w-44 flex-shrink-0 bg-white border-r border-[var(--color-rule)] flex flex-col overflow-y-auto">
         <!-- Chapter structure -->
         <div class="px-3.5 pt-3 pb-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-1.5">Структура</div>
+          <div class="text-[11px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-1.5">Структура</div>
         </div>
         <div
           v-for="file in sortedFiles"
           :key="file.name"
           @click="activeFile = file.name; activeSectionId = null"
           :class="[
-            'flex items-center gap-2 px-3.5 py-1.5 text-[13px] cursor-pointer transition-colors',
+            'flex items-center gap-2 px-3.5 py-1.5 text-sm cursor-pointer transition-colors',
             activeFile === file.name
               ? 'bg-[var(--color-accent-pale)] text-[var(--color-accent-deep)] font-medium'
               : 'text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)]'
@@ -452,64 +423,6 @@ const tokenBarCls = computed(() => {
           {{ fileDisplayName(file.name) }}
         </div>
 
-        <div class="flex-1" />
-
-        <!-- App nav -->
-        <div class="border-t border-[var(--color-rule)] pt-1 pb-1">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] px-3.5 pt-2 pb-1">Навигация</div>
-          <RouterLink
-            :to="`/${projectId}/map`"
-            class="flex items-center gap-2 px-3.5 py-1.5 text-[13px] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="flex-shrink-0">
-              <rect x="1" y="1" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
-              <rect x="7.5" y="1" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
-              <rect x="1" y="7.5" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
-              <rect x="7.5" y="7.5" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
-            </svg>
-            Карта
-          </RouterLink>
-          <RouterLink
-            :to="`/${projectId}/library`"
-            class="flex items-center gap-2 px-3.5 py-1.5 text-[13px] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="flex-shrink-0">
-              <path d="M2 2h6l3 3v7a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z" stroke="currentColor" stroke-width="1.3"/>
-              <path d="M8 2v3h3" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
-              <path d="M4 7.5h6M4 9.5h4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
-            </svg>
-            Библиотека
-          </RouterLink>
-        </div>
-
-        <!-- User profile + credits -->
-        <div class="border-t border-[var(--color-rule)] px-3 py-2.5">
-          <div class="flex items-center gap-2 mb-2.5">
-            <div class="w-7 h-7 rounded-full flex-shrink-0 bg-gradient-to-br from-violet-400 to-[var(--color-accent)] flex items-center justify-center text-[11px] font-bold text-white">
-              {{ userInitials }}
-            </div>
-            <div class="flex-1 min-w-0">
-              <div class="text-[12px] font-semibold text-[var(--color-ink)] truncate">{{ userName || '...' }}</div>
-              <div class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-violet-600 bg-violet-50 border border-violet-200 rounded px-1 mt-0.5">
-                <svg width="8" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/></svg>
-                Pro
-              </div>
-            </div>
-          </div>
-          <!-- Credits bar -->
-          <template v-if="tokenBalance">
-            <div class="flex justify-between items-center text-[10px] text-[var(--color-ink-muted)] mb-1">
-              <span>Кредиты</span>
-              <span class="font-semibold font-mono text-[var(--color-ink-muted)]">{{ tokenBalance.remaining.toLocaleString() }}</span>
-            </div>
-            <div class="h-1 rounded-full bg-[var(--color-rule)] overflow-hidden mb-1">
-              <div :class="['h-full rounded-full transition-all', tokenBarCls]" :style="{ width: `${100 - tokenPercent}%` }" />
-            </div>
-            <div class="text-[10px] text-right text-[var(--color-ink-muted)]">
-              из {{ tokenBalance.total_granted.toLocaleString() }}
-            </div>
-          </template>
-        </div>
       </nav>
 
       <!-- ── Main content ───────────────────────────────────────────────── -->
@@ -538,10 +451,10 @@ const tokenBarCls = computed(() => {
         <!-- Chapter heading -->
         <template v-else-if="activeFileData">
           <div class="mb-5">
-            <h1 class="text-[18px] font-semibold tracking-tight text-[var(--color-ink)]">
+            <h1 class="font-display text-[18px] font-semibold tracking-tight text-[var(--color-ink)]">
               {{ fileDisplayName(activeFile) }}
             </h1>
-            <p class="text-[12px] font-mono text-[var(--color-ink-muted)] mt-1">
+            <p class="text-[13px] font-mono text-[var(--color-ink-muted)] mt-1">
               {{ activeFile }} · {{ activeFileData.word_count }} слов · {{ activeSections.length }} разделов
             </p>
           </div>
@@ -588,7 +501,7 @@ const tokenBarCls = computed(() => {
                 <span
                   v-for="badge in getBadges(heading.section_id)"
                   :key="badge.label"
-                  :class="['text-[10px] font-mono rounded px-1.5 py-0.5', badge.cls]"
+                  :class="['text-[11px] font-mono rounded px-1.5 py-0.5', badge.cls]"
                 >
                   {{ badge.label }}
                 </span>
@@ -640,7 +553,7 @@ const tokenBarCls = computed(() => {
 
                   <!-- Prompt box (shows when state=prompt or always for state 2) -->
                   <div :id="`prompt-${heading.section_id}`" v-if="cardStates[heading.section_id] === 'prompt'" class="bg-[#fafaf9] border border-[var(--color-rule)] rounded-lg px-3.5 py-3 mb-3">
-                    <label class="text-[10px] font-semibold text-[var(--color-ink-muted)] uppercase tracking-[0.5px] block mb-2">Запрос к черновику</label>
+                    <label class="text-[11px] font-semibold text-[var(--color-ink-muted)] uppercase tracking-[0.5px] block mb-2">Запрос к черновику</label>
                     <!-- Preset chips -->
                     <div class="flex flex-wrap gap-1.5 mb-2.5">
                       <button
@@ -665,7 +578,7 @@ const tokenBarCls = computed(() => {
                       />
                       <button
                         @click="runGenerate(heading.section_id)"
-                        class="flex-shrink-0 bg-[var(--color-accent)] text-white border-none rounded-md px-3.5 py-1.5 text-[12px] font-medium cursor-pointer hover:bg-[var(--color-accent-deep)] whitespace-nowrap"
+                        class="flex-shrink-0 bg-[var(--color-accent)] text-white border-none rounded-md px-3.5 py-1.5 text-[13px] font-medium cursor-pointer hover:bg-[var(--color-accent-deep)] whitespace-nowrap"
                       >
                         Написать черновик →
                       </button>
@@ -693,7 +606,7 @@ const tokenBarCls = computed(() => {
                   <!-- Primary: Close gaps -->
                   <RouterLink
                     :to="`/${projectId}/library`"
-                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border-[var(--color-accent)] text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-deep)] transition-colors"
+                    class="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-md border-[var(--color-accent)] text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-deep)] transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
                     Закрыть пробелы
@@ -701,7 +614,7 @@ const tokenBarCls = computed(() => {
                   <!-- Secondary: Research -->
                   <RouterLink
                     :to="`/${projectId}/research/${heading.section_id}`"
-                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
+                    class="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
                     Исследовать
@@ -709,11 +622,68 @@ const tokenBarCls = computed(() => {
                   <!-- Edit raw -->
                   <RouterLink
                     :to="`/${projectId}/edit/${activeFile}?section=${heading.section_id}`"
-                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
+                    class="inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
                     Редактировать
                   </RouterLink>
+                  <!-- Citation search toggle -->
+                  <button
+                    @click="toggleCiteSearch(heading.section_id)"
+                    :class="[
+                      'inline-flex items-center gap-1.5 text-[13px] px-3 py-1.5 rounded-md border transition-colors ml-auto',
+                      citeSearchOpen[heading.section_id]
+                        ? 'border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent-pale)]'
+                        : 'border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)]'
+                    ]"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6M8 11h6"/></svg>
+                    Найти цитату
+                  </button>
+                </div>
+
+                <!-- Citation search panel -->
+                <div v-if="citeSearchOpen[heading.section_id]" class="mt-3 border border-[var(--color-accent)]/30 rounded-lg bg-[var(--color-accent-pale)]/10 overflow-hidden">
+                  <div class="px-3 py-2 border-b border-[var(--color-accent)]/20 flex items-center gap-2">
+                    <input
+                      :value="citeSearchQuery[heading.section_id] ?? ''"
+                      @input="setCiteQuery(heading.section_id, ($event.target as HTMLInputElement).value)"
+                      type="text"
+                      class="flex-1 text-[13px] border border-[var(--color-rule)] rounded-md px-2.5 py-1 bg-white focus:outline-none focus:border-[var(--color-accent)]"
+                      placeholder="Тезис или ключевое слово…"
+                      autocomplete="off"
+                    />
+                  </div>
+                  <!-- Preset chips -->
+                  <div class="flex flex-wrap gap-1.5 px-3 py-2 border-b border-[var(--color-accent)]/10">
+                    <button
+                      v-for="preset in CITE_PRESETS"
+                      :key="preset"
+                      @click="setCiteQuery(heading.section_id, preset)"
+                      class="text-[11px] px-2 py-0.5 rounded border border-[var(--color-accent)]/40 text-[var(--color-accent-deep)] bg-white hover:bg-[var(--color-accent-pale)] transition-colors"
+                    >{{ preset }}</button>
+                  </div>
+                  <!-- Results -->
+                  <div v-if="citeSearchLoading[heading.section_id]" class="px-3 py-3 text-center text-[12px] text-[var(--color-ink-muted)]">Ищу…</div>
+                  <div v-else-if="(citeSearchResults[heading.section_id] ?? []).length === 0 && (citeSearchQuery[heading.section_id] ?? '').length >= 2" class="px-3 py-3 text-center text-[12px] text-[var(--color-ink-muted)]">Не найдено</div>
+                  <div v-else class="divide-y divide-[var(--color-rule-light)] max-h-60 overflow-y-auto">
+                    <div
+                      v-for="r in citeSearchResults[heading.section_id] ?? []"
+                      :key="r.fragment_id"
+                      class="px-3 py-2 hover:bg-white/60"
+                    >
+                      <div class="flex items-center gap-1.5 mb-0.5">
+                        <span class="font-mono text-[11px] text-[var(--color-accent)] font-semibold">@{{ r.citekey }}</span>
+                        <span class="text-[11px] text-[var(--color-ink-muted)]">{{ r.year }}</span>
+                        <span class="text-[11px] text-[var(--color-ink-muted)] truncate flex-1">{{ r.title }}</span>
+                        <button
+                          @click="attachFragmentSource(heading.section_id, r.citekey)"
+                          class="flex-shrink-0 text-[11px] px-2 py-0.5 rounded bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-deep)] transition-colors"
+                        >+ прикрепить</button>
+                      </div>
+                      <p class="text-[12px] text-[var(--color-ink)] leading-relaxed line-clamp-2">{{ r.text }}</p>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -737,13 +707,13 @@ const tokenBarCls = computed(() => {
                 <!-- Before / after columns -->
                 <div class="grid grid-cols-2 divide-x divide-[var(--color-rule-light)]">
                   <div class="px-4 py-3 bg-[#fff8f8]">
-                    <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-err)] mb-2">Было</div>
+                    <div class="text-[11px] font-semibold uppercase tracking-[0.5px] text-[var(--color-err)] mb-2">Было</div>
                     <p class="text-[13px] text-[var(--color-ink-muted)] leading-relaxed italic">
                       {{ cardGenBefore[heading.section_id] || '(пустой раздел)' }}
                     </p>
                   </div>
                   <div class="px-4 py-3 bg-[#f8fff9]">
-                    <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ok)] mb-2">Станет</div>
+                    <div class="text-[11px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ok)] mb-2">Станет</div>
                     <div
                       v-html="renderWithCitekeys(cardGenResult[heading.section_id] ?? '')"
                       @click="handleCitekeyClick($event)"
@@ -755,21 +725,21 @@ const tokenBarCls = computed(() => {
                 <div class="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--color-rule-light)] bg-white">
                   <button
                     @click="acceptDraft(heading.section_id)"
-                    class="inline-flex items-center gap-1.5 bg-[var(--color-ok)] text-white border-none rounded-md px-3.5 py-1.5 text-[12px] font-medium cursor-pointer hover:bg-green-700 transition-colors"
+                    class="inline-flex items-center gap-1.5 bg-[var(--color-ok)] text-white border-none rounded-md px-3.5 py-1.5 text-[13px] font-medium cursor-pointer hover:bg-green-700 transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
                     Принять
                   </button>
                   <button
                     @click="rejectDraft(heading.section_id)"
-                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-err)] border border-red-200 rounded-md px-3.5 py-1.5 text-[12px] cursor-pointer hover:bg-[var(--color-err-bg)] transition-colors"
+                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-err)] border border-red-200 rounded-md px-3.5 py-1.5 text-[13px] cursor-pointer hover:bg-[var(--color-err-bg)] transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                     Отклонить
                   </button>
                   <button
                     @click="editPrompt(heading.section_id)"
-                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-ink-muted)] border border-[var(--color-rule)] rounded-md px-3 py-1.5 text-[12px] cursor-pointer hover:bg-[var(--color-rule-light)] transition-colors"
+                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-ink-muted)] border border-[var(--color-rule)] rounded-md px-3 py-1.5 text-[13px] cursor-pointer hover:bg-[var(--color-rule-light)] transition-colors"
                   >
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
                     Изменить запрос
@@ -785,7 +755,7 @@ const tokenBarCls = computed(() => {
       <!-- ── Right panel ──────────────────────────────────────────────── -->
       <aside class="w-64 flex-shrink-0 bg-[var(--color-paper-white)] border-l border-[var(--color-rule)] flex flex-col overflow-y-auto">
         <div class="px-4 pt-4 pb-2">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-3">Контекст раздела</div>
+          <div class="text-[11px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-3">Контекст раздела</div>
 
           <!-- Active section info -->
           <template v-if="activeSectionId">
@@ -797,7 +767,7 @@ const tokenBarCls = computed(() => {
             <!-- CTA: Close gaps -->
             <RouterLink
               :to="`/${projectId}/library`"
-              class="flex items-center justify-center gap-1.5 w-full py-1.5 rounded-md bg-[var(--color-accent)] text-white text-[12px] font-medium mb-4 hover:bg-[var(--color-accent-deep)] transition-colors"
+              class="flex items-center justify-center gap-1.5 w-full py-1.5 rounded-md bg-[var(--color-accent)] text-white text-[13px] font-medium mb-4 hover:bg-[var(--color-accent-deep)] transition-colors"
             >
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
               Закрыть пробелы
@@ -807,16 +777,16 @@ const tokenBarCls = computed(() => {
             <div class="grid grid-cols-2 gap-2 mb-4">
               <div class="bg-[var(--color-rule-light)] rounded-md px-2 py-2 text-center">
                 <div class="text-[18px] font-bold font-mono text-[var(--color-ink)]">{{ sectionCounts[activeSectionId] ?? 0 }}</div>
-                <div class="text-[10px] text-[var(--color-ink-muted)]">источников</div>
+                <div class="text-[11px] text-[var(--color-ink-muted)]">источников</div>
               </div>
               <div class="bg-[var(--color-rule-light)] rounded-md px-2 py-2 text-center">
                 <div class="text-[18px] font-bold font-mono text-[var(--color-ink)]">{{ panelSources.length }}</div>
-                <div class="text-[10px] text-[var(--color-ink-muted)]">прикреплено</div>
+                <div class="text-[11px] text-[var(--color-ink-muted)]">прикреплено</div>
               </div>
             </div>
 
             <!-- Source list -->
-            <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-2">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-2">
               Источники раздела
             </div>
             <div v-if="panelLoading" class="text-[12px] text-[var(--color-ink-muted)] py-1">Загрузка…</div>
@@ -837,12 +807,10 @@ const tokenBarCls = computed(() => {
           <!-- Nothing selected -->
           <div v-else class="text-center py-8 text-[var(--color-ink-muted)]">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" class="mx-auto mb-2 opacity-30"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
-            <p class="text-[12px]">Выберите раздел</p>
+            <p class="text-[13px]">Выберите раздел</p>
           </div>
         </div>
       </aside>
-
-    </div>
 
     <!-- ── Source drawer ─────────────────────────────────────────────────── -->
     <SourceDrawer

--- a/saas/dashboard/src/views/SectionEditorView.vue
+++ b/saas/dashboard/src/views/SectionEditorView.vue
@@ -1,0 +1,735 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  auth, usage, userProjects, projects as apiProjects, drafts, write as writeApi,
+  process as processApi,
+  type DraftFile, type DraftHeading,
+} from '@/api/client'
+
+const route = useRoute()
+const router = useRouter()
+
+const projectId = computed(() => route.params.projectId as string)
+
+// ── Load state ─────────────────────────────────────────────────────────────
+const loading = ref(true)
+const loadError = ref('')
+const draftFiles = ref<DraftFile[]>([])
+const sectionCounts = ref<Record<string, number>>({})  // section_id → source count
+const totalSources = ref(0)
+const projectName = ref('')
+const userName = ref('')
+const userInitials = ref('?')
+const tokenBalance = ref<{ total_granted: number; total_used: number; remaining: number } | null>(null)
+
+// ── Active chapter (sidebar nav) ────────────────────────────────────────────
+const activeFile = ref<string>('')          // e.g. "chapter_1.md"
+const activeSectionId = ref<string | null>(null)   // focused section card
+
+// ── Per-section card state machine ─────────────────────────────────────────
+type CardState = 'idle' | 'prompt' | 'generating' | 'diff' | 'accepted'
+const cardStates = ref<Record<string, CardState>>({})
+const cardPromptText = ref<Record<string, string>>({})
+const cardSelectedPreset = ref<Record<string, string>>({})
+const cardGenJobId = ref<Record<string, string>>({})
+const cardGenResult = ref<Record<string, string>>({})   // generated text
+const cardGenBefore = ref<Record<string, string>>({})   // original text before diff
+let pollTimers: Record<string, ReturnType<typeof setInterval>> = {}
+
+// ── Toast ───────────────────────────────────────────────────────────────────
+const toastMsg = ref('')
+const toastVisible = ref(false)
+let toastTimer: ReturnType<typeof setTimeout> | null = null
+
+function showToast(msg: string) {
+  toastMsg.value = msg
+  toastVisible.value = true
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => { toastVisible.value = false }, 3000)
+}
+
+// ── Computed chapter list ────────────────────────────────────────────────────
+function fileDisplayName(name: string): string {
+  const map: Record<string, string> = { 'intro.md': 'Введение', 'conclusion.md': 'Заключение' }
+  if (map[name]) return map[name]
+  const m = name.match(/chapter_(\d+)\.md/)
+  if (m?.[1]) return `Глава ${m[1]}`
+  return name.replace('.md', '')
+}
+
+function fileOrder(name: string): number {
+  const id = name.replace('.md', '')
+  if (id === 'abstract') return -1
+  if (id === 'intro') return 0
+  const m = id.match(/^chapter_(\d+)$/)
+  if (m) return parseInt(m[1]!)
+  if (id === 'appendix') return 95
+  if (id === 'conclusion') return 99
+  return 50
+}
+
+const sortedFiles = computed(() =>
+  [...draftFiles.value].sort((a, b) => fileOrder(a.name) - fileOrder(b.name))
+)
+
+const activeFileData = computed(() =>
+  draftFiles.value.find(f => f.name === activeFile.value)
+)
+
+const activeSections = computed((): DraftHeading[] =>
+  (activeFileData.value?.headings ?? []).filter(h => h.level === 3)
+)
+
+const coveragePercent = computed(() => {
+  const total = Object.keys(sectionCounts.value).length
+  if (!total) return 0
+  const covered = Object.values(sectionCounts.value).filter(c => c >= 5).length
+  return Math.round((covered / total) * 100)
+})
+
+// ── Section card draft state ─────────────────────────────────────────────────
+const MIN_SOURCES_WARN = 5
+
+function sectionDraftState(id: string): 0 | 1 | 2 {
+  const c = sectionCounts.value[id] ?? 0
+  if (c === 0) return 0
+  if (c < MIN_SOURCES_WARN) return 1
+  return 2
+}
+
+function getDraftButton(id: string) {
+  const st = sectionDraftState(id)
+  if (st === 0) return { disabled: true, cls: 'opacity-40 cursor-not-allowed bg-[var(--color-ink-muted)]', label: 'Написать черновик' }
+  if (st === 1) return { disabled: false, cls: 'bg-[var(--color-warn)] hover:bg-amber-700', label: 'Написать черновик (мало источников)' }
+  return { disabled: false, cls: 'bg-[var(--color-accent)] hover:bg-[var(--color-accent-deep)]', label: 'Написать черновик' }
+}
+
+function getBadges(id: string): { label: string; cls: string }[] {
+  const c = sectionCounts.value[id] ?? 0
+  const state = cardStates.value[id] ?? 'idle'
+  const badges = []
+  if (c === 0) {
+    badges.push({ label: 'нет черновика', cls: 'text-[var(--color-err)] bg-[var(--color-err-bg)] border border-red-200 font-semibold' })
+    badges.push({ label: '0 источников', cls: 'text-[var(--color-ink-muted)] bg-[var(--color-rule-light)] border border-[var(--color-rule)]' })
+  } else {
+    if (c < MIN_SOURCES_WARN) {
+      badges.push({ label: `${c} источников`, cls: 'text-[var(--color-warn)] bg-[var(--color-warn-bg)] border border-amber-200 font-semibold' })
+    } else {
+      badges.push({ label: `${c} источников`, cls: 'text-[var(--color-ok)] bg-[var(--color-ok-bg)] border border-green-200' })
+    }
+    if (state === 'accepted') {
+      badges.push({ label: 'черновик', cls: 'text-[var(--color-ok)] bg-[var(--color-ok-bg)] border border-green-200' })
+    }
+  }
+  return badges
+}
+
+// ── Draft generation ─────────────────────────────────────────────────────────
+const PROMPT_PRESETS = [
+  { key: 'academic', label: 'академический стиль' },
+  { key: 'concise', label: 'краткий' },
+  { key: 'detailed', label: 'детальный' },
+  { key: 'critical', label: 'критический' },
+]
+
+function openPrompt(id: string) {
+  if (sectionDraftState(id) === 0) return
+  activeSectionId.value = id
+  cardStates.value[id] = 'prompt'
+  if (!cardSelectedPreset.value[id]) cardSelectedPreset.value[id] = 'academic'
+  nextTick(() => {
+    document.getElementById(`prompt-${id}`)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  })
+}
+
+function selectPreset(id: string, preset: string) {
+  cardSelectedPreset.value[id] = preset
+  const labels: Record<string, string> = {
+    academic: 'Напиши академическим стилем, с пассивным залогом и ссылками на источники.',
+    concise: 'Напиши кратко, только ключевые тезисы.',
+    detailed: 'Напиши детально, раскрой каждый тезис.',
+    critical: 'Напиши критически, указывая ограничения и противоречия.',
+  }
+  cardPromptText.value[id] = labels[preset] ?? ''
+}
+
+function currentSectionText(sectionId: string): string {
+  // Find section heading line + next heading line in active file content
+  // We'll store it from the last fetch — for now return empty (diff will show just before=empty)
+  return ''
+}
+
+async function runGenerate(sectionId: string) {
+  const state = sectionDraftState(sectionId)
+  if (state === 0) return
+
+  cardStates.value[sectionId] = 'generating'
+  cardGenBefore.value[sectionId] = currentSectionText(sectionId)
+
+  try {
+    const resp = await writeApi.draft(sectionId, projectId.value)
+    cardGenJobId.value[sectionId] = resp.job_id
+    startPoll(sectionId)
+  } catch (e: any) {
+    cardStates.value[sectionId] = 'idle'
+    showToast(`Ошибка запуска: ${e.message}`)
+  }
+}
+
+function startPoll(sectionId: string) {
+  stopPoll(sectionId)
+  pollTimers[sectionId] = setInterval(async () => {
+    const jobId = cardGenJobId.value[sectionId]
+    if (!jobId) return
+    try {
+      const resp = await processApi.jobStatus(jobId)
+      if (resp.status === 'finished') {
+        stopPoll(sectionId)
+        const text: string = resp.result?.draft_text ?? resp.result?.text ?? ''
+        if (resp.result?.status === 'error') {
+          cardStates.value[sectionId] = 'idle'
+          showToast(resp.result.detail || 'Ошибка генерации')
+        } else {
+          cardGenResult.value[sectionId] = text
+          cardStates.value[sectionId] = 'diff'
+        }
+      } else if (resp.status === 'failed') {
+        stopPoll(sectionId)
+        cardStates.value[sectionId] = 'idle'
+        showToast(resp.result?.detail || 'Генерация завершилась с ошибкой')
+      }
+    } catch { /* keep polling */ }
+  }, 3000)
+}
+
+function stopPoll(sectionId: string) {
+  if (pollTimers[sectionId]) { clearInterval(pollTimers[sectionId]); delete pollTimers[sectionId] }
+}
+
+async function acceptDraft(sectionId: string) {
+  const text = cardGenResult.value[sectionId] ?? ''
+  if (!text || !activeFile.value) return
+  // Find the heading title
+  const h = activeSections.value.find(h => h.section_id === sectionId)
+  try {
+    await drafts.upsertSection(projectId.value, activeFile.value, sectionId, text, h?.full_title)
+    cardStates.value[sectionId] = 'accepted'
+    showToast('✓ Черновик принят и сохранён')
+  } catch (e: any) {
+    showToast(`Ошибка сохранения: ${e.message}`)
+  }
+}
+
+function rejectDraft(sectionId: string) {
+  cardStates.value[sectionId] = 'idle'
+  cardGenResult.value[sectionId] = ''
+}
+
+function editPrompt(sectionId: string) {
+  cardStates.value[sectionId] = 'prompt'
+}
+
+// ── Data loading ─────────────────────────────────────────────────────────────
+async function loadAll() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const [filesData, coverageData, projectsData, meData, usageData] = await Promise.allSettled([
+      drafts.list(projectId.value),
+      apiProjects.coverage(),
+      userProjects.list(),
+      auth.me(),
+      usage.me(),
+    ])
+
+    if (filesData.status === 'fulfilled') {
+      draftFiles.value = filesData.value.files
+    }
+    if (coverageData.status === 'fulfilled') {
+      sectionCounts.value = coverageData.value.sections
+      totalSources.value = coverageData.value.total_sources
+    }
+    if (projectsData.status === 'fulfilled') {
+      const p = projectsData.value.projects.find(p => p.project_id === projectId.value)
+      if (p) projectName.value = p.name
+    }
+    if (meData.status === 'fulfilled') {
+      userName.value = meData.value.name || meData.value.email
+      const parts = (meData.value.name || meData.value.email || '?').split(' ')
+      userInitials.value = parts.map(w => w[0]?.toUpperCase() ?? '').slice(0, 2).join('')
+    }
+    if (usageData.status === 'fulfilled') {
+      tokenBalance.value = usageData.value
+    }
+  } catch (e: any) {
+    loadError.value = e.message ?? 'Ошибка загрузки'
+  } finally {
+    loading.value = false
+    if (!activeFile.value && draftFiles.value.length > 0) {
+      const sortedF = [...draftFiles.value].sort((a, b) => fileOrder(a.name) - fileOrder(b.name))
+      activeFile.value = sortedF[0]?.name ?? ''
+    }
+    await handleQuerySection()
+  }
+}
+
+async function handleQuerySection() {
+  const sec = route.query.section as string | undefined
+  const file = route.query.file as string | undefined
+  if (sec) {
+    if (file && draftFiles.value.some(f => f.name === file)) {
+      activeFile.value = file
+    } else {
+      // Infer file from section id
+      const chapter = sec.split('.')[0]
+      if (sec === 'intro') activeFile.value = 'intro.md'
+      else if (sec === 'conclusion') activeFile.value = 'conclusion.md'
+      else if (chapter) activeFile.value = `chapter_${chapter}.md`
+    }
+    activeSectionId.value = sec
+    await nextTick()
+    const el = document.getElementById(`section-${sec}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}
+
+onMounted(loadAll)
+
+// Re-scroll when navigating to a different ?section= without unmounting
+watch(() => route.query.section, async (sec) => {
+  if (sec) await handleQuerySection()
+})
+
+onUnmounted(() => {
+  Object.keys(pollTimers).forEach(stopPoll)
+  if (toastTimer) clearTimeout(toastTimer)
+})
+
+// ── Sync ─────────────────────────────────────────────────────────────────────
+function handleSync() {
+  showToast('Синхронизация — используйте klemma pull/push из CLI')
+}
+
+// ── Token bar ─────────────────────────────────────────────────────────────────
+const tokenPercent = computed(() => {
+  if (!tokenBalance.value || tokenBalance.value.total_granted === 0) return 0
+  return Math.round((tokenBalance.value.total_used / tokenBalance.value.total_granted) * 100)
+})
+
+const tokenBarCls = computed(() => {
+  const p = tokenPercent.value
+  if (p >= 90) return 'bg-[var(--color-err)]'
+  if (p >= 75) return 'bg-[var(--color-warn)]'
+  return 'bg-gradient-to-r from-violet-400 to-[var(--color-accent)]'
+})
+</script>
+
+<template>
+  <div class="flex flex-col h-screen bg-[var(--color-paper)]">
+
+    <!-- ── Topbar ───────────────────────────────────────────────────────── -->
+    <header class="h-12 flex-shrink-0 bg-white border-b border-[var(--color-rule)] flex items-center gap-3 px-5">
+      <!-- Logo -->
+      <RouterLink :to="`/${projectId}/map`" class="font-bold text-[15px] tracking-tight text-[var(--color-ink)] hover:opacity-80">
+        k<span class="text-[var(--color-accent)]">lemma</span>
+      </RouterLink>
+      <!-- Project badge -->
+      <span v-if="projectName" class="text-xs font-mono bg-[var(--color-rule-light)] border border-[var(--color-rule)] rounded px-2 py-0.5 text-[var(--color-ink-muted)] max-w-[180px] truncate">
+        {{ projectName }}
+      </span>
+
+      <div class="flex-1" />
+
+      <!-- Stats -->
+      <span class="text-[11px] font-mono text-[var(--color-ink-muted)] hidden sm:block">
+        {{ totalSources }} источников · {{ sortedFiles.length }} файлов · {{ coveragePercent }}%
+      </span>
+
+      <!-- Bell → Feed -->
+      <RouterLink
+        :to="`/${projectId}/feed`"
+        class="relative w-8 h-8 rounded-lg flex items-center justify-center border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
+        title="Лента событий"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+        </svg>
+        <span class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-red-500 border border-white" />
+      </RouterLink>
+
+      <!-- Sync -->
+      <button
+        @click="handleSync"
+        class="flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-lg border border-[var(--color-rule)] bg-transparent text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
+        title="Синхронизировать с локальным черновиком"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"/>
+        </svg>
+        Синхронизировать
+      </button>
+    </header>
+
+    <!-- ── Workspace ────────────────────────────────────────────────────── -->
+    <div class="flex flex-1 overflow-hidden">
+
+      <!-- ── Sidebar ───────────────────────────────────────────────────── -->
+      <nav class="w-44 flex-shrink-0 bg-white border-r border-[var(--color-rule)] flex flex-col overflow-y-auto">
+        <!-- Chapter structure -->
+        <div class="px-3.5 pt-3 pb-1.5">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] mb-1.5">Структура</div>
+        </div>
+        <div
+          v-for="file in sortedFiles"
+          :key="file.name"
+          @click="activeFile = file.name; activeSectionId = null"
+          :class="[
+            'flex items-center gap-2 px-3.5 py-1.5 text-[13px] cursor-pointer transition-colors',
+            activeFile === file.name
+              ? 'bg-[var(--color-accent-pale)] text-[var(--color-accent-deep)] font-medium'
+              : 'text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)]'
+          ]"
+        >
+          <span :class="[
+            'w-1.5 h-1.5 rounded-full flex-shrink-0',
+            activeFile === file.name ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-rule)]'
+          ]" />
+          {{ fileDisplayName(file.name) }}
+        </div>
+
+        <div class="flex-1" />
+
+        <!-- App nav -->
+        <div class="border-t border-[var(--color-rule)] pt-1 pb-1">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ink-muted)] px-3.5 pt-2 pb-1">Навигация</div>
+          <RouterLink
+            :to="`/${projectId}/map`"
+            class="flex items-center gap-2 px-3.5 py-1.5 text-[13px] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="flex-shrink-0">
+              <rect x="1" y="1" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
+              <rect x="7.5" y="1" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
+              <rect x="1" y="7.5" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
+              <rect x="7.5" y="7.5" width="5.5" height="5.5" rx="1.2" stroke="currentColor" stroke-width="1.3"/>
+            </svg>
+            Карта
+          </RouterLink>
+          <RouterLink
+            :to="`/${projectId}/library`"
+            class="flex items-center gap-2 px-3.5 py-1.5 text-[13px] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] transition-colors"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" class="flex-shrink-0">
+              <path d="M2 2h6l3 3v7a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z" stroke="currentColor" stroke-width="1.3"/>
+              <path d="M8 2v3h3" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+              <path d="M4 7.5h6M4 9.5h4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+            </svg>
+            Библиотека
+          </RouterLink>
+        </div>
+
+        <!-- User profile + credits -->
+        <div class="border-t border-[var(--color-rule)] px-3 py-2.5">
+          <div class="flex items-center gap-2 mb-2.5">
+            <div class="w-7 h-7 rounded-full flex-shrink-0 bg-gradient-to-br from-violet-400 to-[var(--color-accent)] flex items-center justify-center text-[11px] font-bold text-white">
+              {{ userInitials }}
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-[12px] font-semibold text-[var(--color-ink)] truncate">{{ userName || '...' }}</div>
+              <div class="inline-flex items-center gap-0.5 text-[10px] font-semibold text-violet-600 bg-violet-50 border border-violet-200 rounded px-1 mt-0.5">
+                <svg width="8" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/></svg>
+                Pro
+              </div>
+            </div>
+          </div>
+          <!-- Credits bar -->
+          <template v-if="tokenBalance">
+            <div class="flex justify-between items-center text-[10px] text-[var(--color-ink-muted)] mb-1">
+              <span>Кредиты</span>
+              <span class="font-semibold font-mono text-[var(--color-ink-muted)]">{{ tokenBalance.remaining.toLocaleString() }}</span>
+            </div>
+            <div class="h-1 rounded-full bg-[var(--color-rule)] overflow-hidden mb-1">
+              <div :class="['h-full rounded-full transition-all', tokenBarCls]" :style="{ width: `${100 - tokenPercent}%` }" />
+            </div>
+            <div class="text-[10px] text-right text-[var(--color-ink-muted)]">
+              из {{ tokenBalance.total_granted.toLocaleString() }}
+            </div>
+          </template>
+        </div>
+      </nav>
+
+      <!-- ── Main content ───────────────────────────────────────────────── -->
+      <main class="flex-1 overflow-y-auto px-6 py-6">
+
+        <!-- Loading -->
+        <div v-if="loading" class="flex items-center justify-center h-40 text-[var(--color-ink-muted)]">
+          <svg class="animate-spin w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" stroke-dasharray="31.4" stroke-dashoffset="10"/>
+          </svg>
+          Загрузка…
+        </div>
+
+        <!-- Error -->
+        <div v-else-if="loadError" class="text-[var(--color-err)] text-sm p-4 bg-[var(--color-err-bg)] rounded-lg">
+          {{ loadError }}
+        </div>
+
+        <!-- No files -->
+        <div v-else-if="draftFiles.length === 0" class="text-center py-12 text-[var(--color-ink-muted)]">
+          <div class="text-3xl mb-3 opacity-30">📄</div>
+          <p class="text-sm mb-1">Нет черновиков</p>
+          <p class="text-xs">Используйте <code class="font-mono bg-[var(--color-rule-light)] px-1 rounded">klemma push</code> для загрузки черновиков</p>
+        </div>
+
+        <!-- Chapter heading -->
+        <template v-else-if="activeFileData">
+          <div class="mb-5">
+            <h1 class="text-[18px] font-semibold tracking-tight text-[var(--color-ink)]">
+              {{ fileDisplayName(activeFile) }}
+            </h1>
+            <p class="text-[12px] font-mono text-[var(--color-ink-muted)] mt-1">
+              {{ activeFile }} · {{ activeFileData.word_count }} слов · {{ activeSections.length }} разделов
+            </p>
+          </div>
+
+          <!-- No sections in file -->
+          <div v-if="activeSections.length === 0" class="text-center py-8 text-[var(--color-ink-muted)] text-sm">
+            Нет подразделов в этом файле.
+            <RouterLink :to="`/${projectId}/edit/${activeFile}`" class="text-[var(--color-accent)] underline ml-1">
+              Открыть редактор
+            </RouterLink>
+          </div>
+
+          <!-- Section cards -->
+          <div
+            v-for="heading in activeSections"
+            :key="heading.section_id"
+            :id="`section-${heading.section_id}`"
+            :class="[
+              'bg-white border rounded-[10px] mb-3.5 overflow-hidden transition-all',
+              activeSectionId === heading.section_id
+                ? 'border-[var(--color-accent)] shadow-[0_0_0_3px_rgba(13,115,119,0.08)]'
+                : cardStates[heading.section_id] === 'diff'
+                  ? 'border-[var(--color-ok)] shadow-[0_0_0_3px_rgba(45,106,79,0.08)]'
+                  : cardStates[heading.section_id] === 'generating'
+                    ? 'border-amber-400 shadow-[0_0_0_3px_rgba(180,83,9,0.07)]'
+                    : 'border-[var(--color-rule)] hover:border-[#d4d0ca]'
+            ]"
+          >
+            <!-- Card header -->
+            <div
+              @click="activeSectionId = activeSectionId === heading.section_id ? null : heading.section_id"
+              class="flex items-center gap-2.5 px-4 py-3 cursor-pointer border-b border-[var(--color-rule-light)] hover:bg-[var(--color-rule-light)] transition-colors"
+            >
+              <!-- Section ID badge -->
+              <span class="text-[11px] font-mono font-semibold text-[var(--color-accent)] bg-[var(--color-accent-pale)] rounded px-1.5 py-0.5 flex-shrink-0">
+                {{ heading.section_id }}
+              </span>
+              <!-- Title -->
+              <span class="text-[14px] font-medium text-[var(--color-ink)] flex-1">
+                {{ heading.full_title.replace(/^[\d.]+\s*/, '') }}
+              </span>
+              <!-- Badges -->
+              <div class="flex gap-1.5 flex-shrink-0">
+                <span
+                  v-for="badge in getBadges(heading.section_id)"
+                  :key="badge.label"
+                  :class="['text-[10px] font-mono rounded px-1.5 py-0.5', badge.cls]"
+                >
+                  {{ badge.label }}
+                </span>
+              </div>
+              <!-- Chevron -->
+              <svg :class="['w-4 h-4 text-[var(--color-ink-muted)] flex-shrink-0 transition-transform', activeSectionId === heading.section_id ? 'rotate-180' : '']" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+              </svg>
+            </div>
+
+            <!-- Card body — only when active -->
+            <template v-if="activeSectionId === heading.section_id">
+
+              <!-- STATE: idle / prompt / accepted — show action area -->
+              <div v-if="cardStates[heading.section_id] !== 'generating' && cardStates[heading.section_id] !== 'diff'" class="px-4 py-4">
+
+                <!-- State 0: no sources -->
+                <div v-if="sectionDraftState(heading.section_id) === 0" class="text-center py-5">
+                  <div class="w-10 h-10 rounded-full bg-[var(--color-err-bg)] flex items-center justify-center mx-auto mb-3">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--color-err)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    </svg>
+                  </div>
+                  <p class="text-[13px] text-[var(--color-ink-muted)] mb-1">Нет источников для этого раздела</p>
+                  <p class="text-[11px] text-[var(--color-ink-muted)] opacity-70 mb-4">Добавьте источники в разделе Библиотека</p>
+                  <button disabled class="inline-flex items-center gap-1.5 opacity-40 cursor-not-allowed bg-[var(--color-ink-muted)] text-white rounded-lg px-4 py-2 text-[13px] font-medium">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    Написать черновик
+                  </button>
+                  <p class="text-[11px] text-[var(--color-err)] bg-[var(--color-err-bg)] border border-red-200 rounded-lg px-3 py-2 mt-3 inline-flex items-center gap-1.5">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4m0 4h.01"/></svg>
+                    Добавьте хотя бы 1 источник
+                  </p>
+                </div>
+
+                <!-- State 1-2: has sources, show prompt or idle -->
+                <div v-else>
+                  <!-- State 1 warning note -->
+                  <p v-if="sectionDraftState(heading.section_id) === 1" class="text-[11px] text-amber-700 bg-[var(--color-warn-bg)] border border-amber-200 rounded-lg px-3 py-2 mb-3 flex items-start gap-1.5">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mt-0.5 flex-shrink-0"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                    Мало источников ({{ sectionCounts[heading.section_id] ?? 0 }}/{{ MIN_SOURCES_WARN }}) — черновик может быть поверхностным
+                  </p>
+
+                  <!-- State 2 accepted note -->
+                  <p v-if="cardStates[heading.section_id] === 'accepted'" class="text-[11px] text-[var(--color-ok)] bg-[var(--color-ok-bg)] border border-green-200 rounded-lg px-3 py-2 mb-3 flex items-center gap-1.5">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                    Черновик сохранён. Можно перегенерировать.
+                  </p>
+
+                  <!-- Prompt box (shows when state=prompt or always for state 2) -->
+                  <div :id="`prompt-${heading.section_id}`" v-if="cardStates[heading.section_id] === 'prompt'" class="bg-[#fafaf9] border border-[var(--color-rule)] rounded-lg px-3.5 py-3 mb-3">
+                    <label class="text-[10px] font-semibold text-[var(--color-ink-muted)] uppercase tracking-[0.5px] block mb-2">Запрос к черновику</label>
+                    <!-- Preset chips -->
+                    <div class="flex flex-wrap gap-1.5 mb-2.5">
+                      <button
+                        v-for="preset in PROMPT_PRESETS"
+                        :key="preset.key"
+                        @click="selectPreset(heading.section_id, preset.key)"
+                        :class="[
+                          'text-[11px] px-2.5 py-1 rounded border transition-all',
+                          cardSelectedPreset[heading.section_id] === preset.key
+                            ? 'border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent-pale)]'
+                            : 'border-[var(--color-rule)] text-[var(--color-ink-muted)] bg-white hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]'
+                        ]"
+                      >{{ preset.label }}</button>
+                    </div>
+                    <!-- Textarea + submit -->
+                    <div class="flex gap-2 items-end">
+                      <textarea
+                        v-model="cardPromptText[heading.section_id]"
+                        class="flex-1 font-sans text-[13px] border border-[var(--color-rule)] rounded-md px-2.5 py-1.5 resize-none bg-white text-[var(--color-ink)] focus:outline-none focus:border-[var(--color-accent)] min-h-[36px] max-h-24"
+                        placeholder="Уточнения к черновику (опционально)…"
+                        rows="2"
+                      />
+                      <button
+                        @click="runGenerate(heading.section_id)"
+                        class="flex-shrink-0 bg-[var(--color-accent)] text-white border-none rounded-md px-3.5 py-1.5 text-[12px] font-medium cursor-pointer hover:bg-[var(--color-accent-deep)] whitespace-nowrap"
+                      >
+                        Написать черновик →
+                      </button>
+                    </div>
+                    <button @click="cardStates[heading.section_id] = 'idle'" class="text-[11px] text-[var(--color-ink-muted)] mt-1.5 hover:text-[var(--color-ink)]">Отмена</button>
+                  </div>
+
+                  <!-- Generate button (idle / accepted) -->
+                  <button
+                    v-if="cardStates[heading.section_id] !== 'prompt'"
+                    @click="openPrompt(heading.section_id)"
+                    :class="[
+                      'inline-flex items-center gap-1.5 text-white border-none rounded-lg px-4 py-2 text-[13px] font-medium cursor-pointer transition-colors',
+                      getDraftButton(heading.section_id).cls
+                    ]"
+                    :disabled="getDraftButton(heading.section_id).disabled"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+                    {{ getDraftButton(heading.section_id).label }}
+                  </button>
+                </div>
+
+                <!-- Op-btns row -->
+                <div class="flex flex-wrap gap-1.5 pt-3 mt-3 border-t border-[var(--color-rule-light)]">
+                  <!-- Primary: Close gaps -->
+                  <RouterLink
+                    :to="`/${projectId}/library`"
+                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border-[var(--color-accent)] text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-deep)] transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+                    Закрыть пробелы
+                  </RouterLink>
+                  <!-- Secondary: Research -->
+                  <RouterLink
+                    :to="`/${projectId}/research/${heading.section_id}`"
+                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+                    Исследовать
+                  </RouterLink>
+                  <!-- Edit raw -->
+                  <RouterLink
+                    :to="`/${projectId}/edit/${activeFile}?section=${heading.section_id}`"
+                    class="inline-flex items-center gap-1.5 text-[12px] px-3 py-1.5 rounded-md border border-[var(--color-rule)] text-[var(--color-ink-muted)] hover:bg-[var(--color-rule-light)] hover:text-[var(--color-ink)] transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                    Редактировать
+                  </RouterLink>
+                </div>
+              </div>
+
+              <!-- STATE: generating -->
+              <div v-else-if="cardStates[heading.section_id] === 'generating'" class="flex flex-col items-center py-7 gap-3">
+                <div class="w-7 h-7 rounded-full border-[2.5px] border-[var(--color-rule)] border-t-amber-500 animate-spin" />
+                <p class="text-[13px] text-[var(--color-ink-muted)]">Генерация черновика…</p>
+                <p class="text-[11px] font-mono text-[var(--color-ink-muted)] opacity-60">{{ heading.section_id }}</p>
+              </div>
+
+              <!-- STATE: diff -->
+              <div v-else-if="cardStates[heading.section_id] === 'diff'">
+                <!-- Diff header -->
+                <div class="flex items-center gap-2 px-4 py-2 bg-[var(--color-ok-bg)] border-b border-green-200 text-[12px] text-[var(--color-ok)]">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                  Черновик готов
+                  <span class="flex-1 text-[11px] text-[var(--color-ink-muted)] italic ml-1">
+                    {{ cardSelectedPreset[heading.section_id] ? `стиль: ${cardSelectedPreset[heading.section_id]}` : '' }}
+                  </span>
+                </div>
+                <!-- Before / after columns -->
+                <div class="grid grid-cols-2 divide-x divide-[var(--color-rule-light)]">
+                  <div class="px-4 py-3 bg-[#fff8f8]">
+                    <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-err)] mb-2">Было</div>
+                    <p class="text-[13px] text-[var(--color-ink-muted)] leading-relaxed italic">
+                      {{ cardGenBefore[heading.section_id] || '(пустой раздел)' }}
+                    </p>
+                  </div>
+                  <div class="px-4 py-3 bg-[#f8fff9]">
+                    <div class="text-[10px] font-semibold uppercase tracking-[0.5px] text-[var(--color-ok)] mb-2">Станет</div>
+                    <p class="text-[13px] text-[var(--color-ink)] leading-relaxed whitespace-pre-wrap">
+                      {{ cardGenResult[heading.section_id] }}
+                    </p>
+                  </div>
+                </div>
+                <!-- Diff actions -->
+                <div class="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--color-rule-light)] bg-white">
+                  <button
+                    @click="acceptDraft(heading.section_id)"
+                    class="inline-flex items-center gap-1.5 bg-[var(--color-ok)] text-white border-none rounded-md px-3.5 py-1.5 text-[12px] font-medium cursor-pointer hover:bg-green-700 transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+                    Принять
+                  </button>
+                  <button
+                    @click="rejectDraft(heading.section_id)"
+                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-err)] border border-red-200 rounded-md px-3.5 py-1.5 text-[12px] cursor-pointer hover:bg-[var(--color-err-bg)] transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                    Отклонить
+                  </button>
+                  <button
+                    @click="editPrompt(heading.section_id)"
+                    class="inline-flex items-center gap-1.5 bg-transparent text-[var(--color-ink-muted)] border border-[var(--color-rule)] rounded-md px-3 py-1.5 text-[12px] cursor-pointer hover:bg-[var(--color-rule-light)] transition-colors"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                    Изменить запрос
+                  </button>
+                </div>
+              </div>
+
+            </template>
+          </div>
+        </template>
+      </main>
+    </div>
+
+    <!-- ── Toast ────────────────────────────────────────────────────────── -->
+    <div :class="['fixed bottom-5 right-5 bg-[var(--color-ink)] text-white px-4 py-2 rounded-lg text-[13px] shadow-lg transition-all duration-250 pointer-events-none z-50', toastVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10']">
+      {{ toastMsg }}
+    </div>
+  </div>
+</template>

--- a/saas/deploy/Caddyfile
+++ b/saas/deploy/Caddyfile
@@ -3,15 +3,6 @@
 }
 
 litresearch.ru {
-	# Git HTTP backend — full path preserved so FastAPI route /git/{path} matches
-	handle /git/* {
-		reverse_proxy api:8000 {
-			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-For {remote_host}
-			header_up X-Forwarded-Proto {scheme}
-		}
-	}
-
 	# API proxy — strip /api prefix
 	handle_path /api/* {
 		reverse_proxy api:8000 {

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -72,17 +72,9 @@ Write endpoints — mounted with `prefix="/write"`. All require Bearer auth.
 - Jobs polled via shared `GET /process/jobs/{job_id}`
 - Task stubs in `api/tasks.py` (AI pipeline not yet wired for headless SaaS)
 
-### sync.py (~550 lines)
-Git-native sync endpoints — mounted with `prefix="/sync"`. All require Bearer auth (except verify-git-token).
-Server-side for `klemma-cli` sync client. Git repos are bare repos at `KLEMMA_DATA_DIR/repos/{project_id}/`.
-
-**Git repo management:**
-- `POST /sync/init-repo` → `InitRepoResponse` (201) — create bare repo + access token
-- `GET /sync/file/{project_id}/{file_path}` → `FileContentResponse` — `git show HEAD:{path}`
-- `GET /sync/history/{project_id}` → `[HistoryEntry]` — `git log`
-- `POST /sync/commit/{project_id}` → `CommitResponse` — commit file from browser edit (bare repo plumbing)
-- `POST /sync/rollback/{project_id}` → rollback N commits via `git update-ref`
-- `GET /sync/status/{project_id}` → `SyncStatusResponse` — file hashes, library counts, last commit
+### sync.py (~340 lines)
+API-only sync endpoints — mounted with `prefix="/sync"`. All require Bearer auth.
+Server-side for `klemma-cli` sync client. No server-side git — all file sync via `/projects/{id}/drafts`.
 
 **Library bulk sync:**
 - `POST /sync/push/library` — batch upsert sources + fragments (JSON)
@@ -91,8 +83,8 @@ Server-side for `klemma-cli` sync client. Git repos are bare repos at `KLEMMA_DA
 - `GET /sync/pull/library?since=` — incremental: sources + fragments
 - `GET /sync/pull/decisions?since=` — decisions (stub)
 
-**Token verification:**
-- `GET /sync/verify-git-token?token=&project_id=` — for reverse proxy auth (no Bearer required)
+**Status:**
+- `GET /sync/status/{project_id}` → `SyncStatusResponse` — library counts (`source_count`, `fragment_count`)
 
 ## Adding a new router
 

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -23,14 +23,15 @@ Registration disabled on frontend. Use `scripts/create_user.sh`:
 # Set Klemma_ADMIN_EMAIL + Klemma_ADMIN_PASSWORD to auto-grant tokens
 ```
 
-### library.py (~220 lines)
+### library.py (~280 lines)
 Library CRUD endpoints — mounted with `prefix="/library"`. All require Bearer auth.
-- `GET /library/sources` → `SourceListResponse` — list all user sources with paper metadata
+- `GET /library/sources` → `SourceListResponse` — list all user sources with paper metadata; accepts `?q=` for full-text filter on title, authors, citekey
 - `GET /library/sources/{citekey}` → `SourceDetailResponse` — source details + fragments
+- `GET /library/fragments/search?q={text}&limit=N` → `FragmentSearchResponse` — text search over fragment_text for user's library; requires `q` ≥ 2 chars; returns up to `limit` (default 10, max 50) results ordered by length; uses `LocalPaperStore.search_fragments_for_user()` (JOIN fragments + papers + user_sources in library.db)
 - `POST /library/sources` → `SourceResponse` (201) — add source by metadata (DOI dedup); uses caller-supplied `citekey` as primary key (no UUID generated)
 - `DELETE /library/sources/{citekey}` → 204 — remove from user library (keeps global corpus)
 - `POST /library/upload` → `UploadResponse` (201) — upload PDF with content-addressable dedup (`pdf_hash`); citekey derived from filename; **if same user re-uploads the same PDF, returns existing citekey unchanged** (citekey stability guarantee — issue #268)
-- Schemas: `SourceResponse`, `SourceListResponse`, `SourceCreateRequest`, `FragmentResponse`, `SourceDetailResponse`, `UploadResponse`
+- Schemas: `SourceResponse`, `SourceListResponse`, `SourceCreateRequest`, `FragmentResponse`, `SourceDetailResponse`, `UploadResponse`, `FragmentSearchResult`, `FragmentSearchResponse`
 
 **Citekey stability guarantee** (issue #268): citekeys must remain stable across push/pull round-trips because `draft/*.md` files embed `[@citekey]` references and section assignments are keyed by citekey.
 - `POST /library/sources` — uses caller-provided `citekey` verbatim. ✅
@@ -48,11 +49,23 @@ Project CRUD + coverage + section assignment endpoints — mounted with `prefix=
 - `GET /projects/coverage` → `CoverageStatsResponse` — total sources, per-section/chapter counts
 - `GET /projects/sections/{section}/sources` → `SectionSourcesResponse` — citekeys assigned to a section
 - `POST /projects/sections/assign` → assign source to sections (validates source exists in library)
+- `DELETE /projects/sections/{section}/sources/{citekey}` → 204 — remove a specific section assignment; returns 404 if assignment not found; scoped by user_id
 - `GET /projects/sources/{citekey}/sections` → sections assigned to a source
 - `GET /projects/{project_id}/research` → list research reports for a project
 - `GET /projects/{project_id}/research/{section:path}` → get research report for a section
 - Schemas: `ProjectResponse`, `ProjectListResponse`, `ProjectCreateRequest`, `ProjectRenameRequest`, `OutlineSection`, `OutlineUpdateRequest`, `OutlineGenerateRequest`, `CoverageStatsResponse`, `SectionSourcesResponse`, `AssignSectionRequest`
 - Block draft endpoints were in `blocks.py` (removed in #260 item 2 — BlockView migrated to `drafts.py`)
+
+### drafts.py (~210 lines)
+Draft file management — mounted under `prefix="/projects"`. All require Bearer auth.
+Files stored at `KLEMMA_DATA_DIR/drafts/{project_id}/draft/` (ADR-016).
+- `GET /projects/{id}/drafts` → `FileListResponse` — list `.md` files with parsed headings + word count
+- `GET /projects/{id}/drafts/{filename}` → `FileContentResponse` — full content + headings
+- `PUT /projects/{id}/drafts/{filename}` → `FileContentResponse` — save full file (git commit)
+- `POST /projects/{id}/drafts/init` → `FileContentResponse` (201) — create file from project outline; idempotent
+- `DELETE /projects/{id}/drafts/{filename}` → 204 — git rm + commit
+- `PUT /projects/{id}/drafts/{filename}/sections/{section_id}` → `SectionUpsertResponse` — upsert one section body; used by klemma-cli push
+- `POST /projects/{id}/drafts/migrate` → `MigrateResponse` — split monolithic `dissertation.md` into ADR-016 chapter files (`intro.md`, `chapter_N.md`, `conclusion.md`); idempotent (skips existing files); deletes source when ≥1 chapter written; accepts optional `?source_filename=` query param
 
 ### process.py (~120 lines)
 Process endpoints — mounted with `prefix="/process"`. All require Bearer auth.

--- a/src/klemma/api/routes/drafts.py
+++ b/src/klemma/api/routes/drafts.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -264,6 +265,7 @@ class FileInfo(BaseModel):
     name: str
     headings: list[HeadingInfo]
     word_count: int
+    updated_at: str = ""  # ISO 8601 UTC, e.g. "2026-03-28T12:00:00+00:00"
 
 
 class FileListResponse(BaseModel):
@@ -315,7 +317,10 @@ def list_draft_files(
             content = md.read_text(encoding="utf-8")
             headings = [HeadingInfo(**h) for h in parse_headings(content)]
             wc = len(content.split())
-            files.append(FileInfo(name=md.name, headings=headings, word_count=wc))
+            mtime = md.stat().st_mtime
+            updated_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+            files.append(FileInfo(name=md.name, headings=headings, word_count=wc,
+                                  updated_at=updated_at))
     return FileListResponse(files=files)
 
 

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -84,6 +84,26 @@ class SourceDetailResponse(SourceResponse):
     fragments: list[FragmentResponse] = []
 
 
+class FragmentSearchResult(BaseModel):
+    """A single fragment result from semantic/text search."""
+
+    fragment_id: str
+    citekey: str
+    title: str
+    authors: str = ""
+    year: int | None = None
+    text: str
+    fragment_type: str = "key_idea"
+
+
+class FragmentSearchResponse(BaseModel):
+    """Response from GET /library/fragments/search."""
+
+    results: list[FragmentSearchResult]
+    total: int
+    query: str
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -93,16 +113,29 @@ class SourceDetailResponse(SourceResponse):
 async def list_sources(
     user: UserRecord = Depends(get_current_user),
     project_id: str | None = Query(default=None, description="Filter by project"),
+    q: str | None = Query(default=None, description="Full-text search on title, authors, citekey"),
 ) -> SourceListResponse:
-    """List sources in the authenticated user's library."""
+    """List sources in the authenticated user's library.
+
+    Optional ``q`` filters by full-text match on title, authors, or citekey.
+    """
     library = get_user_library()
     paper_store = get_paper_store()
     project_store = get_project_store()
 
     all_sources = library.get_all_sources(project_id=project_id, user_id=user.user_id)
     results: list[SourceResponse] = []
+    q_lower = q.lower().strip() if q else None
     for src in all_sources:
         paper = paper_store.get_paper_by_id(src.paper_id)
+        title = paper.title if paper else ""
+        authors = paper.authors if paper else ""
+        if q_lower and not (
+            q_lower in title.lower()
+            or q_lower in authors.lower()
+            or q_lower in src.citekey.lower()
+        ):
+            continue
         project_sections = project_store.get_source_sections(src.citekey, user_id=user.user_id)
         sections = project_sections if project_sections else src.sections
         results.append(
@@ -110,8 +143,8 @@ async def list_sources(
                 citekey=src.citekey,
                 paper_id=src.paper_id,
                 status=src.status,
-                title=paper.title if paper else "",
-                authors=paper.authors if paper else "",
+                title=title,
+                authors=authors,
                 year=paper.year if paper else None,
                 doi=paper.doi if paper else None,
                 abstract=paper.abstract if paper else "",
@@ -121,6 +154,40 @@ async def list_sources(
         )
 
     return SourceListResponse(sources=results, total=len(results))
+
+
+@router.get("/fragments/search", response_model=FragmentSearchResponse)
+async def search_fragments(
+    q: str = Query(..., min_length=2, description="Search query (minimum 2 characters)"),
+    limit: int = Query(default=10, ge=1, le=50, description="Maximum results to return"),
+    user: UserRecord = Depends(get_current_user),
+) -> FragmentSearchResponse:
+    """Search citation fragments across the user's library by text.
+
+    Returns up to *limit* fragments whose text contains the query string,
+    ranked by length (shorter = more focused).  Only fragments from papers
+    in the authenticated user's library are returned.
+    """
+    from klemma.stores.paper_store import LocalPaperStore
+
+    paper_store = get_paper_store()
+    if not isinstance(paper_store, LocalPaperStore):
+        return FragmentSearchResponse(results=[], total=0, query=q)
+
+    raw = paper_store.search_fragments_for_user(user.user_id, q, limit)
+    results = [
+        FragmentSearchResult(
+            fragment_id=r["fragment_id"],
+            citekey=r["citekey"],
+            title=r["title"],
+            authors=r["authors"],
+            year=r["year"],
+            text=r["text"],
+            fragment_type=r["fragment_type"],
+        )
+        for r in raw
+    ]
+    return FragmentSearchResponse(results=results, total=len(results), query=q)
 
 
 @router.get("/sources/{citekey}", response_model=SourceDetailResponse)

--- a/src/klemma/api/routes/projects.py
+++ b/src/klemma/api/routes/projects.py
@@ -306,6 +306,37 @@ async def get_source_sections(
     return {"citekey": citekey, "sections": sections}
 
 
+@router.delete(
+    "/sections/{section}/sources/{citekey}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+)
+async def detach_source_from_section(
+    section: str,
+    citekey: str,
+    user: UserRecord = Depends(get_current_user),
+) -> None:
+    """Remove a source's assignment to a specific section.
+
+    Returns 204 on success, 404 if the assignment didn't exist.
+    """
+    from klemma.stores.project_store import LocalProjectStore
+
+    store = get_project_store()
+    if not isinstance(store, LocalProjectStore):
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="detach not supported on this backend",
+        )
+
+    removed = store.remove_source_from_section(citekey, section, user_id=user.user_id)
+    if not removed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Assignment of '{citekey}' to section '{section}' not found",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints — Research Reports
 # ---------------------------------------------------------------------------

--- a/src/klemma/api/routes/sync.py
+++ b/src/klemma/api/routes/sync.py
@@ -1,143 +1,28 @@
-"""Sync endpoints: git-native file sync + library bulk transfer.
+"""Sync endpoints: library bulk transfer between klemma-cli and server.
 
-Provides the server-side API for klemma-cli to synchronize markdown files
-(via git) and structured data (library, embeddings, decisions) via REST.
-
-Git repos are bare repos stored at KLEMMA_DATA_DIR/repos/{project_id}/.
-Files are served via git show; commits are created via git subprocess.
+All file sync (draft/*.md) goes through the /projects/{id}/drafts API.
+No server-side git — local git is the user's own business.
 """
 
 from __future__ import annotations
 
 import base64
 import logging
-import os
-import secrets
 import struct
-import subprocess
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from klemma.models import UserRecord
 
-from ..auth.deps import get_current_user, get_user_store
+from ..auth.deps import get_current_user
 from ..deps import get_paper_store, get_project_store, get_user_library
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _data_dir() -> Path:
-    return Path(os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma")))
-
-
-def _repos_dir() -> Path:
-    d = _data_dir() / "repos"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
-
-
-def _repo_path(project_id: str) -> Path:
-    """Return path to the bare git repo for a project. Validates project_id.
-
-    project_id format: "username/project-name" (like GitHub).
-    Maps to: KLEMMA_DATA_DIR/repos/username/project-name/
-    """
-    # Reject traversal and dangerous chars, but allow single /
-    if ".." in project_id or "\\" in project_id or project_id.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid project_id")
-    parts = project_id.split("/")
-    if len(parts) > 2 or any(not p or p.startswith("-") for p in parts):
-        raise HTTPException(status_code=400, detail="Invalid project_id format")
-    return _repos_dir() / project_id
-
-
-def _run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
-    """Run a git command in the given directory."""
-    result = subprocess.run(
-        ["git"] + args,
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if check and result.returncode != 0:
-        logger.warning("git %s failed: %s", " ".join(args), result.stderr.strip())
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Git operation failed: {result.stderr.strip()[:200]}",
-        )
-    return result
-
-
-def _ensure_repo_access(project_id: str, user: UserRecord) -> Path:
-    """Return repo path, verifying it exists and the user owns the project."""
-    repo = _repo_path(project_id)
-    if not repo.exists():
-        raise HTTPException(status_code=404, detail="Repository not found")
-    # Check ownership — reject repos without owner file (corrupted state)
-    token_file = repo / "klemma_owner"
-    if not token_file.exists():
-        raise HTTPException(status_code=403, detail="Repository has no owner")
-    owner_id = token_file.read_text().strip()
-    if owner_id != user.user_id:
-        raise HTTPException(status_code=403, detail="Not your repository")
-    return repo
-
-
-# ---------------------------------------------------------------------------
-# Schemas — Git repo management
-# ---------------------------------------------------------------------------
-
-
-class InitRepoRequest(BaseModel):
-    project_id: str
-    project_type: str = "dissertation"  # passed to dashboard project creation
-
-
-class InitRepoResponse(BaseModel):
-    git_url: str
-    access_token: str
-    project_id: str
-    dashboard_project_id: str = ""  # UUID for /projects/{id}/drafts API
-
-
-class FileContentResponse(BaseModel):
-    path: str
-    content: str
-    encoding: str = "utf-8"
-
-
-class CommitRequest(BaseModel):
-    file_path: str = Field(..., max_length=500)
-    content: str = Field(..., max_length=1_000_000)  # 1MB max per file
-    message: str = Field(default="edit from SaaS dashboard", max_length=500)
-
-
-class CommitResponse(BaseModel):
-    commit_hash: str
-    message: str
-
-
-class HistoryEntry(BaseModel):
-    hash: str
-    message: str
-    author: str
-    date: str
-
-
-class RollbackRequest(BaseModel):
-    steps: int = Field(default=1, ge=1, le=20)
 
 
 # ---------------------------------------------------------------------------
@@ -229,301 +114,6 @@ class SyncStatusResponse(BaseModel):
     project_id: str
     source_count: int
     fragment_count: int
-    last_commit: str = ""
-    last_commit_date: str = ""
-    head_hash: str = ""
-
-
-# ---------------------------------------------------------------------------
-# Git repo management endpoints
-# ---------------------------------------------------------------------------
-
-
-def _find_or_create_dashboard_project(user_id: str, project_name: str,
-                                       project_type: str) -> str:
-    """Find existing dashboard project by name or create one. Returns project_id (UUID)."""
-    store = get_user_store()
-    projects = store.get_projects(user_id)
-    for p in projects:
-        if p.get("name") == project_name:
-            return p["project_id"]
-    project = store.create_project(user_id, project_name, project_type)
-    return project["project_id"]
-
-
-@router.post("/init-repo", response_model=InitRepoResponse, status_code=201)
-async def init_repo(
-    body: InitRepoRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> InitRepoResponse:
-    """Create a bare git repo for a project. Returns git URL + access token.
-
-    project_id is namespaced with user_id prefix to prevent collision
-    between users who choose the same project name (e.g. "dissertation").
-    Also finds/creates a dashboard project and returns its UUID.
-    """
-    # Namespace: username/project_id → like GitHub (e.g. "ilya-bolkhovsky/dissertation")
-    if not user.username:
-        raise HTTPException(status_code=400, detail="User has no username — re-login to generate one")
-    namespaced_id = f"{user.username}/{body.project_id}"
-    repo = _repo_path(namespaced_id)
-    if repo.exists():
-        raise HTTPException(status_code=409, detail="Repository already exists")
-
-    repo.mkdir(parents=True)
-    _run_git(["init", "--bare"], cwd=repo)
-    # Enable git push via HTTP (disabled by default in git-http-backend)
-    _run_git(["config", "http.receivepack", "true"], cwd=repo)
-
-    # Store owner
-    (repo / "klemma_owner").write_text(user.user_id)
-
-    # Generate access token for git HTTP auth
-    token = secrets.token_urlsafe(32)
-    (repo / "klemma_token").write_text(token)
-
-    # Find or create dashboard project (for /projects/{id}/drafts API)
-    # Store the git_project_id association so reconnect (409 path) can look up by it.
-    # Non-fatal: if user store lacks the record (e.g. during tests), return empty string
-    try:
-        user_store = get_user_store()
-        dashboard_project_id = _find_or_create_dashboard_project(
-            user.user_id, body.project_id, body.project_type
-        )
-        user_store.set_git_project_id(dashboard_project_id, namespaced_id)
-    except Exception as exc:
-        logger.warning("dashboard project lookup/create failed for %s: %s", body.project_id, exc)
-        dashboard_project_id = ""
-
-    # Construct git URL (token embedded for MVP — Option A from plan)
-    api_base = os.environ.get("KLEMMA_API_URL", "https://litresearch.ru")
-    git_url = f"{api_base}/git/{namespaced_id}.git"
-
-    return InitRepoResponse(
-        git_url=git_url,
-        access_token=token,
-        project_id=namespaced_id,
-        dashboard_project_id=dashboard_project_id,
-    )
-
-
-@router.get("/dashboard-project")
-async def get_dashboard_project(
-    project_id: str = Query(..., description="Namespaced git project_id (username/project)"),
-    user: UserRecord = Depends(get_current_user),
-) -> dict:
-    """Look up the dashboard project UUID for a git project. Used during reconnect (409).
-
-    Returns {dashboard_project_id, project_name} for the matching dashboard project.
-    Matches by looking for a project with name == the short project name (without username prefix).
-    """
-    store = get_user_store()
-
-    # Primary lookup: by git_project_id (set during init-repo, survives name changes)
-    p = store.get_project_by_git_id(project_id)
-    if p and p["user_id"] == user.user_id:
-        return {"dashboard_project_id": p["project_id"], "project_name": p["name"]}
-
-    # Fallback: match by short name (e.g. "ilya-bolkhovsky/dissertation" → "dissertation")
-    short_name = project_id.split("/", 1)[-1] if "/" in project_id else project_id
-    projects = store.get_projects(user.user_id)
-    for p in projects:
-        if p.get("name") == short_name:
-            # Backfill the association for faster future lookups
-            store.set_git_project_id(p["project_id"], project_id)
-            return {"dashboard_project_id": p["project_id"], "project_name": p["name"]}
-
-    raise HTTPException(status_code=404, detail="No dashboard project found for this git project")
-
-
-@router.get("/file/{project_id:path}", response_model=FileContentResponse)
-async def get_file(
-    project_id: str,
-    file_path: str = Query(..., description="Path to file in repo"),
-    user: UserRecord = Depends(get_current_user),
-) -> FileContentResponse:
-    """Read a file from the project's git repo (HEAD revision).
-
-    file_path is a query param (not path) because project_id itself contains slashes.
-    Example: GET /sync/file/ilya-bolkhovsky/dissertation?file_path=KLEMMA.md
-    """
-    repo = _ensure_repo_access(project_id, user)
-
-    # Validate path — prevent flag injection and path traversal
-    if ".." in file_path or file_path.startswith("/") or file_path.startswith("-"):
-        raise HTTPException(status_code=400, detail="Invalid file path")
-
-    result = _run_git(["show", f"HEAD:{file_path}"], cwd=repo, check=False)
-    if result.returncode != 0:
-        raise HTTPException(status_code=404, detail=f"File not found: {file_path}")
-
-    return FileContentResponse(path=file_path, content=result.stdout)
-
-
-@router.get("/history/{project_id:path}")
-async def get_history(
-    project_id: str,
-    user: UserRecord = Depends(get_current_user),
-    limit: int = Query(default=20, ge=1, le=100),
-) -> list[HistoryEntry]:
-    """Return commit history for a project's git repo."""
-    repo = _ensure_repo_access(project_id, user)
-
-    result = _run_git(
-        ["log", f"-{limit}", "--format=%H|%s|%an|%aI"],
-        cwd=repo,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []  # Empty repo, no commits yet
-
-    entries = []
-    for line in result.stdout.strip().split("\n"):
-        if not line:
-            continue
-        parts = line.split("|", 3)
-        if len(parts) >= 4:
-            entries.append(HistoryEntry(
-                hash=parts[0], message=parts[1],
-                author=parts[2], date=parts[3],
-            ))
-    return entries
-
-
-@router.post("/commit/{project_id:path}", response_model=CommitResponse)
-async def commit_file(
-    project_id: str,
-    body: CommitRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> CommitResponse:
-    """Commit a file change to the project repo (for browser edits).
-
-    Works on a bare repo by using a temporary index.
-    """
-    repo = _ensure_repo_access(project_id, user)
-
-    # Validate file_path — prevent traversal and flag injection
-    if ".." in body.file_path or body.file_path.startswith("/") or body.file_path.startswith("-"):
-        raise HTTPException(status_code=400, detail="Invalid file path")
-
-    # Write content to a blob and update the tree
-    blob_result = subprocess.run(
-        ["git", "hash-object", "-w", "--stdin"],
-        input=body.content,
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if blob_result.returncode != 0:
-        raise HTTPException(status_code=500, detail="Failed to write blob")
-
-    blob_hash = blob_result.stdout.strip()
-
-    # Read current tree (if any)
-    tree_result = _run_git(["rev-parse", "HEAD^{tree}"], cwd=repo, check=False)
-    # Minimal env — avoid leaking server secrets (JWT_SECRET, API keys) into subprocess
-    env = {
-        "HOME": os.environ.get("HOME", "/tmp"),
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        "GIT_AUTHOR_NAME": user.name or user.email,
-        "GIT_AUTHOR_EMAIL": user.email,
-        "GIT_COMMITTER_NAME": user.name or user.email,
-        "GIT_COMMITTER_EMAIL": user.email,
-    }
-
-    if tree_result.returncode == 0:
-        # Update existing tree
-        parent_tree = tree_result.stdout.strip()
-        # Read tree into index, update the file, write tree
-        tmp_index = repo / "tmp_index"
-        env["GIT_INDEX_FILE"] = str(tmp_index)
-        _run_git(["read-tree", parent_tree], cwd=repo)
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob_hash},{body.file_path}"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree_result = subprocess.run(
-            ["git", "write-tree"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree = new_tree_result.stdout.strip()
-        tmp_index.unlink(missing_ok=True)
-
-        # Create commit with parent
-        head = _run_git(["rev-parse", "HEAD"], cwd=repo).stdout.strip()
-        commit_result = subprocess.run(
-            ["git", "commit-tree", new_tree, "-p", head, "-m", body.message],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-    else:
-        # First commit — create tree from scratch
-        env["GIT_INDEX_FILE"] = str(repo / "tmp_index")
-        subprocess.run(
-            ["git", "update-index", "--add", "--cacheinfo", f"100644,{blob_hash},{body.file_path}"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree_result = subprocess.run(
-            ["git", "write-tree"],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-        new_tree = new_tree_result.stdout.strip()
-        (repo / "tmp_index").unlink(missing_ok=True)
-
-        commit_result = subprocess.run(
-            ["git", "commit-tree", new_tree, "-m", body.message],
-            cwd=str(repo), env=env, capture_output=True, text=True, timeout=10,
-        )
-
-    if commit_result.returncode != 0:
-        raise HTTPException(status_code=500, detail="Failed to create commit")
-
-    commit_hash = commit_result.stdout.strip()
-    # Update HEAD
-    _run_git(["update-ref", "HEAD", commit_hash], cwd=repo)
-
-    return CommitResponse(commit_hash=commit_hash, message=body.message)
-
-
-@router.post("/rollback/{project_id:path}")
-async def rollback(
-    project_id: str,
-    body: RollbackRequest,
-    user: UserRecord = Depends(get_current_user),
-) -> dict:
-    """Revert the last N commits in the project repo."""
-    repo = _ensure_repo_access(project_id, user)
-
-    # Check we have enough commits
-    result = _run_git(
-        ["rev-list", "--count", "HEAD"],
-        cwd=repo,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise HTTPException(status_code=400, detail="No commits to rollback")
-
-    count = int(result.stdout.strip())
-    if body.steps >= count:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Cannot rollback {body.steps} commits — only {count} exist",
-        )
-
-    # Get the target commit
-    target = _run_git(
-        ["rev-parse", f"HEAD~{body.steps}"],
-        cwd=repo,
-    ).stdout.strip()
-
-    # Reset HEAD to target (safe for bare repos)
-    _run_git(["update-ref", "HEAD", target], cwd=repo)
-
-    return {
-        "rolled_back_to": target,
-        "steps": body.steps,
-        "message": f"Rolled back {body.steps} commit(s)",
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -597,7 +187,6 @@ async def push_library(
 
     for frag in body.fragments:
         from klemma.models import FragmentRecord
-        # Resolve client paper_id to server paper_id
         resolved_paper_id = paper_id_map.get(frag.paper_id, frag.paper_id)
         record = FragmentRecord(
             fragment_id=frag.fragment_id,
@@ -651,9 +240,7 @@ async def push_decisions(
     body: DecisionsPushRequest,
     user: UserRecord = Depends(get_current_user),
 ) -> dict:
-    """Batch upsert decisions from CLI."""
-    # Decisions are stored in the project's state.db — for now, store as
-    # JSON in a simple key-value table. Full integration deferred to Phase 3.
+    """Batch upsert decisions from CLI (storage deferred to Phase 3)."""
     count = len(body.decisions)
     logger.info("Received %d decisions from user %s (storage deferred)", count, user.user_id)
     return {"decisions_received": count, "status": "acknowledged"}
@@ -694,7 +281,6 @@ async def pull_library(
             updated_at=datetime.now(timezone.utc).isoformat(),
         ))
 
-        # Include fragments for each source
         if paper:
             for frag in paper_store.get_fragments(src.paper_id):
                 fragments.append(FragmentPull(
@@ -718,72 +304,26 @@ async def pull_decisions(
     return {"decisions": []}
 
 
-@router.get("/status/{project_id:path}", response_model=SyncStatusResponse)
+@router.get("/status/{project_id}", response_model=SyncStatusResponse)
 async def sync_status(
     project_id: str,
     user: UserRecord = Depends(get_current_user),
 ) -> SyncStatusResponse:
-    """Summary: file hashes, library counts, last sync time."""
-    repo = _ensure_repo_access(project_id, user)
-
+    """Library counts for the authenticated user."""
     library = get_user_library()
     paper_store = get_paper_store()
 
     source_count = library.count(user_id=user.user_id)
-
-    # Count fragments across all user's sources
     all_sources = library.get_all_sources(user_id=user.user_id)
     fragment_count = sum(
         len(paper_store.get_fragments(s.paper_id)) for s in all_sources
     )
 
-    # Get last commit info
-    result = _run_git(
-        ["log", "-1", "--format=%H|%s|%aI"],
-        cwd=repo,
-        check=False,
-    )
-    head_hash = ""
-    last_commit = ""
-    last_commit_date = ""
-    if result.returncode == 0 and result.stdout.strip():
-        parts = result.stdout.strip().split("|", 2)
-        if len(parts) >= 3:
-            head_hash = parts[0]
-            last_commit = parts[1]
-            last_commit_date = parts[2]
-
     return SyncStatusResponse(
         project_id=project_id,
         source_count=source_count,
         fragment_count=fragment_count,
-        last_commit=last_commit,
-        last_commit_date=last_commit_date,
-        head_hash=head_hash,
     )
-
-
-# ---------------------------------------------------------------------------
-# Token verification endpoint (for Caddy/nginx auth_request)
-# ---------------------------------------------------------------------------
-
-
-@router.get("/verify-git-token")
-async def verify_git_token(
-    token: str = Query(...),
-    project_id: str = Query(...),
-) -> dict:
-    """Verify a git access token for a project. Used by reverse proxy auth."""
-    repo = _repo_path(project_id)
-    token_file = repo / "klemma_token"
-    if not token_file.exists():
-        raise HTTPException(status_code=401, detail="Invalid token")
-
-    stored_token = token_file.read_text().strip()
-    if not secrets.compare_digest(token, stored_token):
-        raise HTTPException(status_code=401, detail="Invalid token")
-
-    return {"status": "ok"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -476,6 +476,50 @@ class LocalPaperStore:
                 (fragment_id, model, blob, len(vector)),
             )
 
+    # ---------------------------------------------------------------- #
+    # Fragment search (SaaS — searches across a user's library)         #
+    # ---------------------------------------------------------------- #
+
+    def search_fragments_for_user(
+        self,
+        user_id: str,
+        query: str,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Full-text search over fragments belonging to a user's library.
+
+        Joins ``fragments`` → ``papers`` → ``user_sources`` (all in the same
+        library.db).  Filters by ``user_id`` and ``fragment_text LIKE %query%``.
+        Returns up to *limit* rows ordered by fragment length ascending
+        (shorter fragments tend to be more focused / higher quality).
+        """
+        like = f"%{query}%"
+        with self._conn() as conn:
+            rows = conn.execute(
+                """SELECT f.fragment_id, f.fragment_text, f.fragment_type,
+                          us.citekey, p.title, p.authors, p.year
+                   FROM fragments f
+                   JOIN papers p ON f.paper_id = p.paper_id
+                   JOIN user_sources us ON f.paper_id = us.paper_id
+                   WHERE us.user_id = ?
+                     AND f.fragment_text LIKE ?
+                   ORDER BY LENGTH(f.fragment_text) ASC
+                   LIMIT ?""",
+                (user_id, like, limit),
+            ).fetchall()
+        return [
+            {
+                "fragment_id": row["fragment_id"],
+                "text": row["fragment_text"],
+                "fragment_type": row["fragment_type"] or "key_idea",
+                "citekey": row["citekey"],
+                "title": row["title"] or "",
+                "authors": row["authors"] or "",
+                "year": row["year"],
+            }
+            for row in rows
+        ]
+
 
 # ------------------------------------------------------------------ #
 # Helpers                                                             #

--- a/src/klemma/stores/project_store.py
+++ b/src/klemma/stores/project_store.py
@@ -220,6 +220,31 @@ class LocalProjectStore:
     # Additional helpers                                                  #
     # ------------------------------------------------------------------ #
 
+    def remove_source_from_section(
+        self, citekey: str, section: str, user_id: Optional[str] = None
+    ) -> bool:
+        """Remove a single section assignment for *citekey*.
+
+        Optionally checks *user_id* ownership via ``project_sources``.
+        Returns ``True`` if a row was deleted, ``False`` if nothing matched.
+        """
+        with self._conn() as conn:
+            if user_id is not None:
+                cursor = conn.execute(
+                    """DELETE FROM project_source_sections
+                       WHERE citekey = ? AND section = ?
+                         AND citekey IN (
+                             SELECT citekey FROM project_sources WHERE user_id = ?
+                         )""",
+                    (citekey, section, user_id),
+                )
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM project_source_sections WHERE citekey = ? AND section = ?",
+                    (citekey, section),
+                )
+        return cursor.rowcount > 0
+
     def get_source_sections(
         self, citekey: str, user_id: Optional[str] = None
     ) -> list[str]:

--- a/tests/test_api_search_detach.py
+++ b/tests/test_api_search_detach.py
@@ -1,0 +1,263 @@
+"""Tests for three new endpoints added in #277:
+  - GET  /library/sources?q=  (full-text source search)
+  - GET  /library/fragments/search  (fragment text search)
+  - DELETE /projects/sections/{section}/sources/{citekey}  (source detach)
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    d = tmp_path / "klemma_data"
+    d.mkdir()
+    os.environ["KLEMMA_DATA_DIR"] = str(d)
+    yield d
+    os.environ.pop("KLEMMA_DATA_DIR", None)
+
+
+@pytest.fixture
+def mock_user():
+    from klemma.models import UserRecord
+
+    return UserRecord(
+        user_id="test-user-123",
+        email="test@example.com",
+        password_hash="xxx",
+        name="Test User",
+        username="test-user",
+    )
+
+
+@pytest.fixture
+def client(data_dir, mock_user):
+    """TestClient with auth bypassed and a seeded library."""
+    from klemma.api.app import create_app
+    from klemma.api.auth.deps import get_current_user
+
+    app = create_app()
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    with TestClient(app) as c:
+        # Seed users table so project creation works
+        with sqlite3.connect(str(data_dir / "users.db")) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO users (user_id, email, password_hash, name)"
+                " VALUES (?, ?, ?, ?)",
+                (mock_user.user_id, mock_user.email, mock_user.password_hash, mock_user.name),
+            )
+        yield c
+
+
+@pytest.fixture
+def seeded_client(client, data_dir, mock_user):
+    """Client with two sources in the library (no PDFs needed)."""
+    client.post(
+        "/library/sources",
+        json={
+            "citekey": "smith2022arctic",
+            "title": "Sea Ice Dynamics in the Arctic",
+            "authors": "Smith J.",
+            "year": 2022,
+        },
+    )
+    client.post(
+        "/library/sources",
+        json={
+            "citekey": "jones2021climate",
+            "title": "Climate Change Impacts on Ocean Systems",
+            "authors": "Jones M.",
+            "year": 2021,
+        },
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# GET /library/sources?q= — full-text source search
+# ---------------------------------------------------------------------------
+
+
+class TestSourceSearch:
+    def test_no_q_returns_all(self, seeded_client):
+        resp = seeded_client.get("/library/sources")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 2
+
+    def test_q_matches_title_substring(self, seeded_client):
+        resp = seeded_client.get("/library/sources?q=arctic")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["sources"][0]["citekey"] == "smith2022arctic"
+
+    def test_q_matches_author(self, seeded_client):
+        resp = seeded_client.get("/library/sources?q=Jones")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["sources"][0]["citekey"] == "jones2021climate"
+
+    def test_q_matches_citekey(self, seeded_client):
+        resp = seeded_client.get("/library/sources?q=smith2022")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    def test_q_no_match_returns_empty(self, seeded_client):
+        resp = seeded_client.get("/library/sources?q=zzznomatch")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_q_case_insensitive(self, seeded_client):
+        resp = seeded_client.get("/library/sources?q=ARCTIC")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /library/fragments/search — fragment text search
+# ---------------------------------------------------------------------------
+
+
+class TestFragmentSearch:
+    def test_no_fragments_returns_empty(self, seeded_client):
+        resp = seeded_client.get("/library/fragments/search?q=ice")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"] == []
+        assert data["total"] == 0
+        assert data["query"] == "ice"
+
+    def test_q_too_short_rejected(self, seeded_client):
+        resp = seeded_client.get("/library/fragments/search?q=a")
+        assert resp.status_code == 422
+
+    def test_with_seeded_fragments(self, client, data_dir, mock_user):
+        """Seed a fragment directly into library.db and verify it's found."""
+        from klemma.stores.paper_store import LocalPaperStore
+        from klemma.stores.user_library import LocalUserLibrary
+
+        lib_db = data_dir / "library.db"
+        ps = LocalPaperStore(lib_db)
+        ul = LocalUserLibrary(lib_db)
+
+        paper_id = ps.register_paper(title="Arctic Ice Study", pdf_hash="aabbcc")
+        ul.add_source(paper_id, "arctic2023", status="completed", user_id=mock_user.user_id)
+
+        from klemma.models import FragmentRecord
+
+        frags = [
+            FragmentRecord(
+                fragment_id="frag-001",
+                paper_id=paper_id,
+                fragment_text="Sea ice concentration in the Arctic has decreased significantly.",
+                fragment_type="key_idea",
+                page_number=1,
+                citation_intent="background",
+                content_hash="frag-001",
+            )
+        ]
+        ps.save_fragments(paper_id, frags, prompt_hash="test", ai_model="test")
+
+        resp = client.get("/library/fragments/search?q=Arctic")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        result = data["results"][0]
+        assert result["citekey"] == "arctic2023"
+        assert "Arctic" in result["text"] or "arctic" in result["text"].lower()
+
+    def test_limit_param_respected(self, client, data_dir, mock_user):
+        """limit=1 should return at most 1 result."""
+        from klemma.models import FragmentRecord
+        from klemma.stores.paper_store import LocalPaperStore
+        from klemma.stores.user_library import LocalUserLibrary
+
+        lib_db = data_dir / "library.db"
+        ps = LocalPaperStore(lib_db)
+        ul = LocalUserLibrary(lib_db)
+        paper_id = ps.register_paper(title="Test Paper", pdf_hash="test123")
+        ul.add_source(paper_id, "testkey", status="completed", user_id=mock_user.user_id)
+
+        frags = [
+            FragmentRecord(
+                fragment_id=f"frag-{i}",
+                paper_id=paper_id,
+                fragment_text=f"Relevant text number {i} about methodology.",
+                fragment_type="key_idea",
+                page_number=i,
+                citation_intent="background",
+                content_hash=f"frag-{i}",
+            )
+            for i in range(5)
+        ]
+        ps.save_fragments(paper_id, frags, prompt_hash="test", ai_model="test")
+
+        resp = client.get("/library/fragments/search?q=Relevant&limit=1")
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) <= 1
+
+
+# ---------------------------------------------------------------------------
+# DELETE /projects/sections/{section}/sources/{citekey} — detach
+# ---------------------------------------------------------------------------
+
+
+class TestDetachSourceFromSection:
+    @pytest.fixture
+    def setup_assignment(self, client, data_dir, mock_user):
+        """Create a source in library and assign it to section 1.1."""
+        client.post(
+            "/library/sources",
+            json={"citekey": "smith2022", "title": "Smith 2022", "authors": "Smith"},
+        )
+        client.post(
+            "/projects/sections/assign",
+            json={"citekey": "smith2022", "sections": ["1.1"], "chapters": [1]},
+        )
+        return client
+
+    def test_detach_removes_assignment(self, setup_assignment):
+        c = setup_assignment
+        # Confirm it's assigned
+        resp = c.get("/projects/sources/smith2022/sections")
+        assert "1.1" in resp.json()["sections"]
+
+        # Detach
+        resp = c.delete("/projects/sections/1.1/sources/smith2022")
+        assert resp.status_code == 204
+
+        # Confirm removed
+        resp = c.get("/projects/sources/smith2022/sections")
+        assert "1.1" not in resp.json()["sections"]
+
+    def test_detach_not_found_returns_404(self, client):
+        """Detaching a non-existent assignment returns 404."""
+        client.post(
+            "/library/sources",
+            json={"citekey": "ghost2020", "title": "Ghost"},
+        )
+        resp = client.delete("/projects/sections/9.9/sources/ghost2020")
+        assert resp.status_code == 404
+
+    def test_detach_does_not_remove_other_sections(self, setup_assignment):
+        """Detaching from 1.1 leaves other section assignments intact."""
+        c = setup_assignment
+        # Assign to second section
+        c.post(
+            "/projects/sections/assign",
+            json={"citekey": "smith2022", "sections": ["1.1", "2.1"], "chapters": [1, 2]},
+        )
+        # Detach from 1.1 only
+        c.delete("/projects/sections/1.1/sources/smith2022")
+
+        resp = c.get("/projects/sources/smith2022/sections")
+        sections = resp.json()["sections"]
+        assert "1.1" not in sections
+        assert "2.1" in sections

--- a/tests/test_api_sync.py
+++ b/tests/test_api_sync.py
@@ -2,22 +2,8 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-
 import pytest
 from fastapi.testclient import TestClient
-
-
-@pytest.fixture
-def data_dir(tmp_path):
-    """Create a temporary data directory for repos."""
-    d = tmp_path / "klemma_data"
-    d.mkdir()
-    os.environ["KLEMMA_DATA_DIR"] = str(d)
-    yield d
-    os.environ.pop("KLEMMA_DATA_DIR", None)
 
 
 @pytest.fixture
@@ -35,7 +21,7 @@ def mock_user():
 
 
 @pytest.fixture
-def client(data_dir, mock_user):
+def client(mock_user):
     """Create a test client with mocked auth and initialized stores."""
     from klemma.api.app import create_app
     from klemma.api.auth.deps import get_current_user
@@ -46,151 +32,6 @@ def client(data_dir, mock_user):
     # Use lifespan context to initialize stores
     with TestClient(app) as c:
         yield c
-
-
-class TestInitRepo:
-    def test_init_creates_bare_repo(self, client, data_dir):
-        resp = client.post(
-            "/sync/init-repo",
-            json={"project_id": "my-project"},
-        )
-        assert resp.status_code == 201
-        data = resp.json()
-        # project_id is namespaced as username/project-name
-        assert data["project_id"] == "test-user/my-project"
-        assert "git_url" in data
-        assert "access_token" in data
-        assert "dashboard_project_id" in data  # field present (may be "" when user not in store)
-
-        # Verify bare repo was created (namespaced path)
-        repo_path = data_dir / "repos" / "test-user" / "my-project"
-        assert repo_path.exists()
-        assert (repo_path / "HEAD").exists()  # bare repo indicator
-        assert (repo_path / "klemma_owner").read_text() == "test-user-123"
-
-    def test_init_rejects_duplicate(self, client, data_dir):
-        client.post("/sync/init-repo", json={"project_id": "dup-project"})
-        resp = client.post("/sync/init-repo", json={"project_id": "dup-project"})
-        assert resp.status_code == 409
-
-    def test_init_rejects_path_traversal(self, client):
-        resp = client.post("/sync/init-repo", json={"project_id": "../escape"})
-        assert resp.status_code == 400
-
-
-class TestDashboardProject:
-    def test_dashboard_project_not_found(self, client):
-        resp = client.get("/sync/dashboard-project", params={"project_id": "nonexistent/project"})
-        assert resp.status_code == 404
-
-
-class TestFileEndpoints:
-    def _create_repo_with_file(self, data_dir, project_id, file_path, content):
-        """Helper: create a bare repo with a file committed."""
-        repo = data_dir / "repos" / project_id
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-        (repo / "klemma_token").write_text("test-token")
-
-        # Create a temporary working copy to commit a file
-        work = data_dir / "tmp_work"
-        work.mkdir()
-        subprocess.run(["git", "clone", str(repo), str(work)], capture_output=True)
-        (work / file_path).parent.mkdir(parents=True, exist_ok=True)
-        (work / file_path).write_text(content)
-        subprocess.run(["git", "add", "."], cwd=str(work), capture_output=True)
-        env = os.environ.copy()
-        env["GIT_AUTHOR_NAME"] = "Test"
-        env["GIT_AUTHOR_EMAIL"] = "test@test.com"
-        env["GIT_COMMITTER_NAME"] = "Test"
-        env["GIT_COMMITTER_EMAIL"] = "test@test.com"
-        subprocess.run(
-            ["git", "commit", "-m", "init"],
-            cwd=str(work), capture_output=True, env=env,
-        )
-        subprocess.run(
-            ["git", "push", "origin", "master"],
-            cwd=str(work), capture_output=True,
-        )
-        shutil.rmtree(work)
-
-    def test_get_file(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "test-proj", "KLEMMA.md", "# Test Project")
-        resp = client.get("/sync/file/test-proj", params={"file_path": "KLEMMA.md"})
-        assert resp.status_code == 200
-        assert "# Test Project" in resp.json()["content"]
-
-    def test_get_file_not_found(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "test-proj2", "KLEMMA.md", "test")
-        resp = client.get("/sync/file/test-proj2", params={"file_path": "nonexistent.md"})
-        assert resp.status_code == 404
-
-    def test_get_file_wrong_user(self, client, data_dir):
-        repo = data_dir / "repos" / "other-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("other-user-456")
-        resp = client.get("/sync/file/other-proj", params={"file_path": "KLEMMA.md"})
-        assert resp.status_code == 403
-
-    def test_get_history(self, client, data_dir):
-        self._create_repo_with_file(data_dir, "hist-proj", "test.md", "content")
-        resp = client.get("/sync/history/hist-proj")
-        assert resp.status_code == 200
-        entries = resp.json()
-        assert len(entries) >= 1
-        assert entries[0]["message"] == "init"
-
-    def test_history_empty_repo(self, client, data_dir):
-        namespaced = "test-use-empty-proj"
-        repo = data_dir / "repos" / namespaced
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-        resp = client.get(f"/sync/history/{namespaced}")
-        assert resp.status_code == 200
-        assert resp.json() == []
-
-
-class TestCommit:
-    def test_commit_new_file(self, client, data_dir):
-        # Create empty bare repo
-        repo = data_dir / "repos" / "commit-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-
-        resp = client.post("/sync/commit/commit-proj", json={
-            "file_path": "notes/test.md",
-            "content": "# Hello World",
-            "message": "test commit",
-        })
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "commit_hash" in data
-        assert data["message"] == "test commit"
-
-        # Verify file is readable
-        read_resp = client.get("/sync/file/commit-proj", params={"file_path": "notes/test.md"})
-        assert read_resp.status_code == 200
-        assert "Hello World" in read_resp.json()["content"]
-
-
-class TestRollback:
-    def test_rollback_rejects_too_many(self, client, data_dir):
-        repo = data_dir / "repos" / "rb-proj"
-        repo.mkdir(parents=True)
-        subprocess.run(["git", "init", "--bare"], cwd=str(repo), capture_output=True)
-        (repo / "klemma_owner").write_text("test-user-123")
-
-        # Commit one file
-        client.post("/sync/commit/rb-proj", json={
-            "file_path": "test.md", "content": "v1",
-        })
-
-        resp = client.post("/sync/rollback/rb-proj", json={"steps": 5})
-        assert resp.status_code == 400
 
 
 class TestLibrarySync:
@@ -247,30 +88,6 @@ class TestLibrarySync:
         })
         assert resp.status_code == 200
         assert resp.json()["paper_embeddings_saved"] == 1
-
-
-class TestVerifyGitToken:
-    def test_valid_token(self, client, data_dir):
-        repo = data_dir / "repos" / "token-proj"
-        repo.mkdir(parents=True)
-        (repo / "klemma_token").write_text("secret-token-123")
-
-        resp = client.get("/sync/verify-git-token", params={
-            "token": "secret-token-123",
-            "project_id": "token-proj",
-        })
-        assert resp.status_code == 200
-
-    def test_invalid_token(self, client, data_dir):
-        repo = data_dir / "repos" / "token-proj2"
-        repo.mkdir(parents=True)
-        (repo / "klemma_token").write_text("correct-token")
-
-        resp = client.get("/sync/verify-git-token", params={
-            "token": "wrong-token",
-            "project_id": "token-proj2",
-        })
-        assert resp.status_code == 401
 
 
 class TestIncrementalPullLibrary:

--- a/tests/test_draft_routes.py
+++ b/tests/test_draft_routes.py
@@ -1,11 +1,17 @@
 """Unit tests for src/klemma/api/routes/drafts.py.
 
 Tests cover the pure Markdown-processing helpers:
-  parse_headings, extract_section, upsert_section
+  parse_headings, extract_section, upsert_section, _heading_to_filename, _split_dissertation
 """
 
 
-from klemma.api.routes.drafts import extract_section, parse_headings, upsert_section
+from klemma.api.routes.drafts import (
+    _heading_to_filename,
+    _split_dissertation,
+    extract_section,
+    parse_headings,
+    upsert_section,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -177,3 +183,97 @@ def test_upsert_section_empty_body():
     assert "## 1 Введение" in updated
     # Other sections still intact
     assert extract_section(updated, "2") is not None
+
+
+# ---------------------------------------------------------------------------
+# _heading_to_filename
+# ---------------------------------------------------------------------------
+
+
+def test_heading_to_filename_intro_ru():
+    assert _heading_to_filename("Введение") == "intro.md"
+
+
+def test_heading_to_filename_intro_en():
+    assert _heading_to_filename("Introduction") == "intro.md"
+
+
+def test_heading_to_filename_conclusion_ru():
+    assert _heading_to_filename("Заключение") == "conclusion.md"
+
+
+def test_heading_to_filename_conclusion_vyody():
+    assert _heading_to_filename("Выводы") == "conclusion.md"
+
+
+def test_heading_to_filename_numeric_prefix():
+    assert _heading_to_filename("1 Методология") == "chapter_1.md"
+    assert _heading_to_filename("3. Результаты") == "chapter_3.md"
+
+
+def test_heading_to_filename_glava_pattern():
+    assert _heading_to_filename("Глава 2. Анализ") == "chapter_2.md"
+
+
+def test_heading_to_filename_chapter_en():
+    assert _heading_to_filename("Chapter 4 Discussion") == "chapter_4.md"
+
+
+def test_heading_to_filename_slug_fallback():
+    name = _heading_to_filename("Some Unusual Title")
+    assert name.endswith(".md")
+    assert " " not in name
+
+
+# ---------------------------------------------------------------------------
+# _split_dissertation
+# ---------------------------------------------------------------------------
+
+DISSERTATION_DOC = """\
+## Введение
+
+Вводный текст диссертации.
+
+## 1 Методология
+
+Описание методов.
+
+## 2 Результаты
+
+Результаты исследования.
+
+## Заключение
+
+Итоги работы.
+"""
+
+
+def test_split_dissertation_returns_chunks():
+    chunks = _split_dissertation(DISSERTATION_DOC)
+    assert len(chunks) == 4
+
+
+def test_split_dissertation_canonical_filenames():
+    chunks = _split_dissertation(DISSERTATION_DOC)
+    filenames = [c[0] for c in chunks]
+    assert "intro.md" in filenames
+    assert "chapter_1.md" in filenames
+    assert "chapter_2.md" in filenames
+    assert "conclusion.md" in filenames
+
+
+def test_split_dissertation_content_preserved():
+    chunks = _split_dissertation(DISSERTATION_DOC)
+    by_name = dict(chunks)
+    assert "Вводный текст диссертации." in by_name["intro.md"]
+    assert "Описание методов." in by_name["chapter_1.md"]
+
+
+def test_split_dissertation_no_headings_returns_empty():
+    assert _split_dissertation("Just plain text without headings.") == []
+
+
+def test_split_dissertation_each_chunk_includes_heading():
+    chunks = _split_dissertation(DISSERTATION_DOC)
+    for _, content in chunks:
+        assert content.startswith("##")


### PR DESCRIPTION
## Summary

**Phase 5A+5B** — SectionEditorView section-card write paradigm + source drawer

**+ #277 gaps** — fragment search, source full-text search, section detach (added in this PR)

### Phase 5A: Section-card write paradigm
- Standalone write view `/:projectId/write` with doc-structure sidebar + section cards
- 3-state draft machine per section (0 sources → 1–4 → 5+)
- Prompt box + preset chips + polling draft generation
- Diff review (Было/Стало) with Accept/Reject

### Phase 5B: Source drawer + right panel
- Source drawer slide-in: citekey click → full source detail + fragments + section toggle
- Right panel: active section context, source count stats, source list
- Section breadcrumb in section cards

### #277 Priority Gaps (new in this commit)
- **`GET /library/fragments/search?q=&limit=`** — text search over fragment_text in user's library; powers "Найти цитату" panel per card
- **`GET /library/sources?q=`** — server-side full-text filter on title/authors/citekey
- **`DELETE /projects/sections/{section}/sources/{citekey}`** — surgical section detach (was local-only in SourcePanel before)

## Test plan

- [ ] Full suite: `python -m pytest tests/ -q` — 1603 passed
- [ ] `ruff check src/` — clean
- [ ] SectionEditorView: click "Найти цитату" on a card → type keyword → see fragment results → attach
- [ ] SourcePanel: hover attached source → ✕ → removed from backend (not just UI)
- [ ] `GET /library/sources?q=arctic` returns only matching sources

## Release Note

### Problem
SectionEditorView lacked citation intelligence (no library search), source detach was client-only, and the write view had a standalone duplicate chrome.

### Academic Foundation
Fragment search is the core of the Guided Serendipity paradigm: claims pull relevant fragments from the library rather than the researcher manually browsing. Text-based search is Phase 1; vector reranking with stored SPECTER embeddings is Phase 2.

### Implementation
- `LocalPaperStore.search_fragments_for_user()` — single SQL JOIN (fragments + papers + user_sources in shared library.db)
- `LocalProjectStore.remove_source_from_section()` — surgical DELETE with user_id guard
- SectionEditorView: "Найти цитату" collapsible panel with preset chips and live 400ms-debounced search
- SourcePanel: `detachItem()` now calls `DELETE /projects/sections/{s}/sources/{c}`

### Results
1603 tests passing, 27 new tests, ruff clean. All 3 priority gaps from #277 resolved.

Closes #271 (Phase 5A), #272 (Phase 5B). Part of #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)