### PR TITLE
fix(saas): session isolation on logout/login + cleanup

### DIFF
--- a/saas/dashboard/src/App.vue
+++ b/saas/dashboard/src/App.vue
@@ -33,12 +33,12 @@ function switchProject(id: string) {
   projectStore.setActive(id)
   const currentParam = route.params.projectId as string | undefined
   if (currentParam) {
-    const modules = ['feed', 'library', 'health', 'outline', 'coverage', 'research', 'write']
+    const modules = ['feed', 'library', 'health', 'outline', 'coverage', 'research', 'map', 'write']
     const suffix = route.path.slice(currentParam.length + 2)
-    const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'write'
+    const module = modules.find(m => suffix === m || suffix.startsWith(m + '/')) ?? 'library'
     router.push(`/${id}/${module}`)
   } else {
-    router.push(`/${id}/write`)
+    router.push(`/${id}/library`)
   }
 }
 
@@ -52,7 +52,8 @@ const tokenPercent = computed(() => {
 })
 const tokenBarLow = computed(() => tokenPercent.value >= 80)
 
-onMounted(async () => {
+async function loadProfile() {
+  profileLoaded.value = false
   try {
     const [me, bal] = await Promise.all([auth.me(), usage.me()])
     userName.value = me.name ?? me.email.split('@')[0]
@@ -66,11 +67,19 @@ onMounted(async () => {
   const pid = route.params.projectId as string | undefined
   if (pid) projectStore.setActive(pid)
   await projectStore.loadProjects()
+}
+
+onMounted(loadProfile)
+
+// Re-fetch profile + projects after login (route leaves login/register → app)
+watch(isPublicRoute, (isPublic, wasPublic) => {
+  if (wasPublic && !isPublic) loadProfile()
 })
 
 function logout() {
   localStorage.removeItem('access_token')
   localStorage.removeItem('refresh_token')
+  projectStore.$reset()
   router.push('/login')
 }
 

--- a/saas/dashboard/src/stores/project.ts
+++ b/saas/dashboard/src/stores/project.ts
@@ -61,5 +61,12 @@ export const useProjectStore = defineStore('project', () => {
     if (idx !== -1) projects.value[idx] = updated
   }
 
-  return { projects, activeProjectId, activeProject, activeOutline, loading, loadProjects, createProject, renameProject, setActive, updateOutline }
+  function $reset() {
+    projects.value = []
+    activeProjectId.value = null
+    localStorage.removeItem(ACTIVE_KEY)
+    loading.value = false
+  }
+
+  return { projects, activeProjectId, activeProject, activeOutline, loading, loadProjects, createProject, renameProject, setActive, updateOutline, $reset }
 })

--- a/saas/dashboard/src/views/LibraryView.vue
+++ b/saas/dashboard/src/views/LibraryView.vue
@@ -45,36 +45,7 @@ const gapsDetail = ref('')
 
 // Curation stats per citekey: { accepted, total }
 const curationStats = ref<Record<string, { accepted: number; total: number }>>({})
-const totalAccepted = ref(0)
 
-// Coverage filter
-const activeSectionFilter = ref<string | null>(null)
-
-const outline = computed(() => projectStore.activeOutline ?? [])
-
-// Coverage cells: count accepted fragments per section
-const coverageCells = computed(() => {
-  return outline.value.map(s => {
-    const count = curatedBySection.value[s.id] || 0
-    return { id: s.id, name: s.name, count }
-  })
-})
-
-// Curated fragments grouped by section
-const curatedBySection = ref<Record<string, number>>({})
-
-const coveragePct = computed(() => {
-  if (outline.value.length === 0) return 0
-  const covered = outline.value.filter(s => (curatedBySection.value[s.id] || 0) > 0).length
-  return Math.round((covered / outline.value.length) * 100)
-})
-
-const filteredSources = computed(() => {
-  if (!activeSectionFilter.value) return sources.value
-  return sources.value.filter(s =>
-    s.sections && s.sections.includes(activeSectionFilter.value!)
-  )
-})
 
 function shortAuthors(a: string | null): string {
   if (!a) return '—'
@@ -112,26 +83,17 @@ async function loadCurationStats() {
     // Get all curated (accepted + rejected) to compute per-source stats
     const data = await curation.curated(pid)
     const stats: Record<string, { accepted: number; total: number }> = {}
-    const bySection: Record<string, number> = {}
-    let accepted = 0
 
     for (const f of data.fragments) {
       if (!stats[f.citekey]) stats[f.citekey] = { accepted: 0, total: 0 }
       stats[f.citekey]!.total++
       if (f.verdict === 'accepted') {
         stats[f.citekey]!.accepted++
-        accepted++
-        const sec = f.assigned_section || ''
-        if (sec) bySection[sec] = (bySection[sec] || 0) + 1
       }
     }
     curationStats.value = stats
-    curatedBySection.value = bySection
-    totalAccepted.value = accepted
   } catch {
     curationStats.value = {}
-    curatedBySection.value = {}
-    totalAccepted.value = 0
   }
 }
 
@@ -259,9 +221,6 @@ function onFileInput(e: Event) {
   input.value = ''
 }
 
-function filterBySection(sectionId: string) {
-  activeSectionFilter.value = activeSectionFilter.value === sectionId ? null : sectionId
-}
 
 async function loadAll() {
   await loadSources()
@@ -305,27 +264,6 @@ watch(sources, () => { loadFragmentCounts() })
       </div>
     </div>
 
-    <!-- Coverage bar -->
-    <div v-if="outline.length > 0 && sources.length > 0" class="mt-5 animate-in animate-in-delay-1">
-      <div class="coverage-filter">
-        <div class="flex items-center gap-3 flex-wrap">
-          <span class="text-[14px] font-semibold text-[var(--color-ink)]">Покрытие по разделам</span>
-          <select
-            class="coverage-select"
-            :value="activeSectionFilter || ''"
-            @change="activeSectionFilter = ($event.target as HTMLSelectElement).value || null"
-          >
-            <option value="">Все разделы</option>
-            <option v-for="cell in coverageCells" :key="cell.id" :value="cell.id">
-              {{ cell.name || cell.id }} ({{ cell.count }})
-            </option>
-          </select>
-          <span class="text-sm text-[var(--color-ink-muted)]">
-            {{ totalAccepted }} цитат принято &middot; {{ coveragePct }}% покрыто
-          </span>
-        </div>
-      </div>
-    </div>
 
     <!-- Sources table -->
     <div class="mt-5 animate-in animate-in-delay-2">
@@ -376,7 +314,7 @@ watch(sources, () => { loadFragmentCounts() })
         </div>
 
         <div class="text-base font-semibold text-[var(--color-ink)] mb-2.5 flex items-center gap-2">
-          Мои источники <span class="text-sm font-semibold text-[var(--color-ink-muted)] bg-[var(--color-rule-light)] px-2 py-0.5 rounded-full">{{ filteredSources.length }}</span>
+          Мои источники <span class="text-sm font-semibold text-[var(--color-ink-muted)] bg-[var(--color-rule-light)] px-2 py-0.5 rounded-full">{{ sources.length }}</span>
         </div>
         <table class="source-table">
           <thead>
@@ -389,7 +327,7 @@ watch(sources, () => { loadFragmentCounts() })
             </tr>
           </thead>
           <tbody>
-            <tr v-for="src in filteredSources" :key="src.citekey">
+            <tr v-for="src in sources" :key="src.citekey">
               <td>
                 <RouterLink
                   :to="`/${route.params.projectId}/library/${src.citekey}`"
@@ -495,30 +433,6 @@ watch(sources, () => { loadFragmentCounts() })
 .upload-label { font-size: 16px; font-weight: 500; color: var(--color-ink-2); }
 .upload-hint { font-size: 14px; color: var(--color-ink-muted); margin-top: 4px; }
 
-/* Coverage */
-.coverage-filter {
-  background: white;
-  border: 1px solid var(--color-rule);
-  border-radius: 10px;
-  padding: 10px 16px;
-}
-.coverage-select {
-  font-size: 14px;
-  color: var(--color-accent-deep);
-  background: var(--color-accent-pale);
-  border: 1px solid var(--color-accent);
-  border-radius: 6px;
-  padding: 5px 28px 5px 10px;
-  cursor: pointer;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%230d7377'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 8px center;
-  max-width: 320px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
 /* Sources table */
 .source-table { width: 100%; border-collapse: collapse; }


### PR DESCRIPTION
### **User description**
## Summary
- **Fix user session leak**: after logout→login as different user, old name/initials/projects were displayed until page refresh. Root cause: App.vue cached profile data in component state and never re-fetched on login transition.
- **Project switch default**: changed from `/write` to `/library` when switching projects in header dropdown.
- **Remove coverage from LibraryView**: "Покрытие по разделам" section removed — this data belongs in MapView.

## Changes
- `App.vue`: extract `loadProfile()`, add `watch(isPublicRoute)` to re-fetch on login, add `projectStore.$reset()` to logout
- `project.ts`: add `$reset()` method to clear projects array + localStorage
- `LibraryView.vue`: remove coverage filter UI, related computed properties, and CSS (−70 lines)

## Test plan
- [ ] Login as user A → see A's name/projects
- [ ] Logout → login as user B → see B's name/projects (no stale data)
- [ ] Switch project in header → lands on `/library` (not `/write`)
- [ ] LibraryView shows no coverage section
- [ ] MapView coverage still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix stale profile after re-login

- Reset project state on logout

- Default project switching to `library`

- Simplify `LibraryView` source listing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  auth["Leave public auth routes"]
  load["Reload profile and project list"]
  logout["Logout action"]
  reset["Clear project store state"]
  switcher["Project switch handler"]
  library["Navigate to library by default"]
  auth -- "triggers" --> load
  logout -- "calls" --> reset
  switcher -- "routes to" --> library
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Reload app state on auth transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/App.vue

<ul><li>Extract <code>loadProfile()</code> for reusable app initialization<br> <li> Re-fetch user and projects after leaving public routes<br> <li> Clear <code>projectStore</code> state during logout<br> <li> Route project switches to <code>library</code> and support <code>map</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/281/files#diff-0fd306a5e8adf21eef584d4e55c6d30f4fe3ff11f9e8eb6d7477bde6579eb948">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project.ts</strong><dd><code>Add reset support to project store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/stores/project.ts

<ul><li>Add <code>$reset()</code> to clear projects and active selection<br> <li> Remove persisted active project from local storage<br> <li> Expose reset logic for logout cleanup flows</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/281/files#diff-395d08d9e41591175485edf5f9f5b74df0c792cf849d77e1397ca674414f2d4b">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LibraryView.vue</strong><dd><code>Remove coverage filtering from library sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

saas/dashboard/src/views/LibraryView.vue

<ul><li>Remove section-based coverage filtering state and handlers<br> <li> Keep curation stats focused on per-source counts<br> <li> Render the table directly from <code>sources</code><br> <li> Drop library-specific coverage UI and styles</ul>


</details>


  </td>
  <td><a href="https://github.com/bolkhovsky/klemma/pull/281/files#diff-a300e8120a4e4e1e4c5d1462b69c2044e8ae579cec51594a5eb9b6519cae952f">+2/-88</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

