### PR TITLE
feat(ci): CI/CD hardening — frontend CI, rollback, auto-deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: /saas/dashboard
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Bump version
         run: python scripts/bump_version.py ${{ github.event.inputs.bump }}
 
-      - name: Commit and push
+      - name: Commit, tag, and push
         run: |
+          NEW_VERSION=$(python -c 'import re; print(re.search(r"version = .(.+?).", open("pyproject.toml").read()).group(1))')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/klemma/__init__.py
-          git commit -m "chore: bump version to $(python -c 'import re; print(re.search(r\"version = .(.+?).\", open(\"pyproject.toml\").read()).group(1))')"
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
           git push
+          git push --tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_call:  # Allow deploy.yml to call this workflow
 
 jobs:
   lint:
@@ -31,3 +32,19 @@ jobs:
           cache: "pip"
       - run: pip install -e ".[dev,api]"
       - run: pytest -v
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: saas/dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: saas/dashboard/package-lock.json
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run build-only

--- a/.github/workflows/codex-auto-fix.yml
+++ b/.github/workflows/codex-auto-fix.yml
@@ -73,8 +73,18 @@ jobs:
         if: steps.check-key.outputs.skip != 'true'
         run: pytest -q
 
-      - name: Create pull request with fixes
+      - name: Check for changes
         if: steps.check-key.outputs.skip != 'true' && success()
+        id: check-changes
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request with fixes
+        if: steps.check-key.outputs.skip != 'true' && success() && steps.check-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "fix(ci): auto-fix failing checks via Codex"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,26 +11,54 @@ on:
         options:
           - production
           - staging
+  push:
+    branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.claude/**'
+
+env:
+  DEPLOY_ENV: ${{ github.event.inputs.environment || 'production' }}
 
 # Only one deploy at a time
 concurrency:
-  group: deploy-${{ github.event.inputs.environment }}
+  group: deploy-${{ github.event.inputs.environment || 'production' }}
   cancel-in-progress: false
 
 jobs:
+  ci:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/ci.yml
+
   build-and-deploy:
+    needs: [ci]
+    if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment || 'production' }}
     steps:
       - uses: actions/checkout@v6
 
+      # Build frontend
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: saas/dashboard/package-lock.json
+      - name: Build frontend
+        run: cd saas/dashboard && npm ci && npm run build
+
+      # Build Docker image (with layer caching)
+      - uses: docker/setup-buildx-action@v3
       - name: Build Docker image
-        run: |
-          docker build \
-            -t klemma-api:${{ github.sha }} \
-            -t klemma-api:latest \
-            -f saas/deploy/Dockerfile \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: saas/deploy/Dockerfile
+          tags: klemma-api:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Save Docker image
         run: docker save klemma-api:latest | gzip > klemma-api.tar.gz
@@ -57,27 +85,79 @@ jobs:
           # Transfer compose files
           scp $SCP_OPTS -r saas/deploy/ "${VPS_USER}@${VPS_HOST}:/opt/klemma/"
 
-          # Deploy on VPS
+          # Transfer built dashboard (contents of dist/, not the dir itself)
+          ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" "mkdir -p /opt/klemma/dashboard"
+          scp $SCP_OPTS -r saas/dashboard/dist/* "${VPS_USER}@${VPS_HOST}:/opt/klemma/dashboard/"
+
+          # Deploy on VPS with rollback support
           ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" << 'DEPLOY_SCRIPT'
             set -e
             cd /opt/klemma/deploy
+
+            # Backup current state for rollback
+            docker image inspect klemma-api:latest >/dev/null 2>&1 && \
+              docker tag klemma-api:latest klemma-api:previous || true
+            [ -d /opt/klemma/dashboard ] && \
+              cp -r /opt/klemma/dashboard /opt/klemma/dashboard.previous || true
+            for db in /data/klemma/*.db; do
+              [ -f "$db" ] && cp "$db" "${db}.pre-deploy"
+            done
 
             # Load new image
             sudo docker load < /tmp/klemma-api.tar.gz
             rm /tmp/klemma-api.tar.gz
 
-            # Pull latest Redis/Caddy images
+            # Restart services
             sudo docker compose pull redis caddy
-
-            # Restart with new image
             sudo docker compose up -d --force-recreate api worker
             sudo docker compose up -d
 
-            # Verify health
+            # Health check with retries (5 attempts, 3s apart)
+            for i in 1 2 3 4 5; do
+              sleep 3
+              if curl -sf http://localhost/health; then
+                echo ""
+                echo "Deploy successful (attempt $i)"
+                # Clean up previous backups
+                docker image rm klemma-api:previous 2>/dev/null || true
+                rm -rf /opt/klemma/dashboard.previous
+                rm -f /data/klemma/*.db.pre-deploy
+                exit 0
+              fi
+              echo "Health check attempt $i failed..."
+            done
+
+            # ROLLBACK
+            echo "ROLLING BACK"
+            docker tag klemma-api:previous klemma-api:latest 2>/dev/null || true
+            [ -d /opt/klemma/dashboard.previous ] && \
+              rm -rf /opt/klemma/dashboard && \
+              mv /opt/klemma/dashboard.previous /opt/klemma/dashboard
+            for db in /data/klemma/*.db.pre-deploy; do
+              [ -f "$db" ] && mv "$db" "${db%.pre-deploy}"
+            done
+            sudo docker compose up -d --force-recreate api worker
             sleep 5
-            curl -sf http://localhost/health || exit 1
-            echo "Deploy successful"
+            curl -sf http://localhost/health || echo "WARNING: rollback also failed"
+            exit 1
           DEPLOY_SCRIPT
+
+      - name: Notify deploy result
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          [ -z "$TELEGRAM_BOT_TOKEN" ] && exit 0
+          STATUS="${{ job.status }}"
+          SHA="${{ github.sha }}"
+          if [ "$STATUS" = "success" ]; then
+            MSG="Klemma deployed to ${DEPLOY_ENV} (${SHA:0:7})"
+          else
+            MSG="Deploy FAILED (${DEPLOY_ENV}) — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="$TELEGRAM_CHAT_ID" -d text="$MSG"
 
       - name: Cleanup SSH key
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,12 @@ jobs:
           # Transfer compose files
           scp $SCP_OPTS -r saas/deploy/ "${VPS_USER}@${VPS_HOST}:/opt/klemma/"
 
+          # Backup current dashboard BEFORE uploading new one (so rollback has the old version)
+          ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" "\
+            [ -d /opt/klemma/dashboard ] && \
+              rm -rf /opt/klemma/dashboard.previous && \
+              cp -r /opt/klemma/dashboard /opt/klemma/dashboard.previous || true"
+
           # Transfer built dashboard (contents of dist/, not the dir itself)
           ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" "mkdir -p /opt/klemma/dashboard"
           scp $SCP_OPTS -r saas/dashboard/dist/* "${VPS_USER}@${VPS_HOST}:/opt/klemma/dashboard/"
@@ -94,14 +100,16 @@ jobs:
             set -e
             cd /opt/klemma/deploy
 
-            # Backup current state for rollback
+            # Backup Docker image for rollback
             docker image inspect klemma-api:latest >/dev/null 2>&1 && \
               docker tag klemma-api:latest klemma-api:previous || true
-            [ -d /opt/klemma/dashboard ] && \
-              cp -r /opt/klemma/dashboard /opt/klemma/dashboard.previous || true
-            for db in /data/klemma/*.db; do
-              [ -f "$db" ] && cp "$db" "${db}.pre-deploy"
-            done
+
+            # Backup databases from named volume via temporary container
+            rm -rf /opt/klemma/db-backup
+            docker run --rm \
+              -v klemma-data:/data:ro \
+              -v /opt/klemma/db-backup:/backup \
+              alpine sh -c "cp -r /data/* /backup/" 2>/dev/null || true
 
             # Load new image
             sudo docker load < /tmp/klemma-api.tar.gz
@@ -121,7 +129,7 @@ jobs:
                 # Clean up previous backups
                 docker image rm klemma-api:previous 2>/dev/null || true
                 rm -rf /opt/klemma/dashboard.previous
-                rm -f /data/klemma/*.db.pre-deploy
+                rm -rf /opt/klemma/db-backup
                 exit 0
               fi
               echo "Health check attempt $i failed..."
@@ -133,9 +141,13 @@ jobs:
             [ -d /opt/klemma/dashboard.previous ] && \
               rm -rf /opt/klemma/dashboard && \
               mv /opt/klemma/dashboard.previous /opt/klemma/dashboard
-            for db in /data/klemma/*.db.pre-deploy; do
-              [ -f "$db" ] && mv "$db" "${db%.pre-deploy}"
-            done
+            # Restore databases into named volume
+            if [ -d /opt/klemma/db-backup ]; then
+              docker run --rm \
+                -v klemma-data:/data \
+                -v /opt/klemma/db-backup:/backup:ro \
+                alpine sh -c "rm -rf /data/* && cp -r /backup/* /data/"
+            fi
             sudo docker compose up -d --force-recreate api worker
             sleep 5
             curl -sf http://localhost/health || echo "WARNING: rollback also failed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,11 +105,15 @@ jobs:
               docker tag klemma-api:latest klemma-api:previous || true
 
             # Backup databases from named volume via temporary container
+            # Resolve actual volume name (compose prefixes with project name)
+            DATA_VOLUME=$(docker volume ls -q --filter "name=klemma-data" | head -1)
             rm -rf /opt/klemma/db-backup
-            docker run --rm \
-              -v klemma-data:/data:ro \
-              -v /opt/klemma/db-backup:/backup \
-              alpine sh -c "cp -r /data/* /backup/" 2>/dev/null || true
+            if [ -n "$DATA_VOLUME" ]; then
+              docker run --rm \
+                -v "$DATA_VOLUME":/data:ro \
+                -v /opt/klemma/db-backup:/backup \
+                alpine sh -c "cp -r /data/* /backup/" 2>/dev/null || true
+            fi
 
             # Load new image
             sudo docker load < /tmp/klemma-api.tar.gz
@@ -142,9 +146,10 @@ jobs:
               rm -rf /opt/klemma/dashboard && \
               mv /opt/klemma/dashboard.previous /opt/klemma/dashboard
             # Restore databases into named volume
-            if [ -d /opt/klemma/db-backup ]; then
+            DATA_VOLUME=$(docker volume ls -q --filter "name=klemma-data" | head -1)
+            if [ -d /opt/klemma/db-backup ] && [ -n "$DATA_VOLUME" ]; then
               docker run --rm \
-                -v klemma-data:/data \
+                -v "$DATA_VOLUME":/data \
                 -v /opt/klemma/db-backup:/backup:ro \
                 alpine sh -c "rm -rf /data/* && cp -r /backup/* /data/"
             fi

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -23,5 +23,5 @@ jobs:
         id: pragent
         uses: qodo-ai/pr-agent@v0.32
         env:
-          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/saas/deploy/Dockerfile
+++ b/saas/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS deps
 
 WORKDIR /app
 
@@ -8,13 +8,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy source first (required by hatchling build)
+# Install Python deps (cached unless pyproject.toml changes)
 COPY pyproject.toml README.md ./
+COPY src/klemma/__init__.py ./src/klemma/
+RUN pip install --no-cache-dir ".[api,recommended]"
+
+FROM deps AS app
+
+# Copy full source and reinstall klemma (deps already cached, --no-deps = fast)
 COPY src/ ./src/
 COPY prompts/ ./prompts/
-
-# Install Python deps (non-editable for production)
-RUN pip install --no-cache-dir ".[api,recommended]"
+RUN pip install --no-cache-dir --no-deps .
 
 # Create data directory
 RUN mkdir -p /data/klemma

--- a/saas/deploy/docker-compose.yml
+++ b/saas/deploy/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'klemma.api.worker' || exit 1"]
+      test: ["CMD", "python", "-c", "import os; os.kill(1, 0)"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/saas/deploy/docker-compose.yml
+++ b/saas/deploy/docker-compose.yml
@@ -42,6 +42,11 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'klemma.api.worker' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary

- **Phase 1**: Frontend CI job (type-check + build) catches TypeScript errors on every PR; deploy.yml now builds and transfers the Vue dashboard to VPS
- **Phase 2**: Deploy with rollback — backs up Docker image, dashboard files, and SQLite DBs before deploy; retries health check 5x; auto-rolls back on failure. Worker gets healthcheck.
- **Phase 3**: Auto-deploy on push to master (gated by CI passing); Telegram notification on success/failure
- **Phase 4**: Git version tags created automatically on `bump-version` workflow
- **Phase 5**: Dependabot for pip/npm/GH Actions; empty PR guard for Codex auto-fix; unified `OPENAI_API_KEY` secret
- **Phase 6**: Multi-stage Dockerfile + GHA build cache for faster deploys

## Test plan

- [ ] CI runs on this PR (lint + test + **new frontend job**)
- [ ] After merge: push to master triggers auto-deploy via `push.branches: [master]`
- [ ] Telegram notification arrives on deploy success/failure
- [ ] Verify `OPENAI_API_KEY` secret exists in repo settings (PR Agent needs it after secret unification)
- [ ] Dependabot PRs appear within a week
- [ ] Next version bump creates a git tag (`v0.X.Y`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)