### PR TITLE
fix(saas): collapse library briefing to compact bar

### DIFF
--- a/saas/dashboard/src/views/LibraryView.vue
+++ b/saas/dashboard/src/views/LibraryView.vue
@@ -56,6 +56,24 @@ function shortAuthors(a: string | null): string {
   return a.includes(',') ? a.split(',')[0]!.trim() + ' et al.' : a
 }
 
+/**
+ * Russian plural form selector: 1 → `one`, 2-4 → `few`, 0/5+ → `many`.
+ * Handles the teen exception (11-14 all take `many`).
+ */
+function plural(n: number, one: string, few: string, many: string): string {
+  const n10 = n % 10
+  const n100 = n % 100
+  if (n10 === 1 && n100 !== 11) return one
+  if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return few
+  return many
+}
+
+// Briefing coverage counters — derived from by_section readiness flags.
+const readySectionCount = computed(() =>
+  briefing.value?.by_section.filter(s => s.readiness === 'ready').length ?? 0
+)
+const totalSectionCount = computed(() => briefing.value?.by_section.length ?? 0)
+
 async function loadGaps() {
   gaps.value = []
   gapsDetail.value = ''
@@ -286,46 +304,36 @@ watch(sources, () => { loadFragmentCounts() })
       </div>
     </div>
 
-    <!-- Briefing card -->
-    <div v-if="briefing && briefing.total_fragments > 0 && !briefingDismissed" class="mt-5 animate-in animate-in-delay-1">
-      <div class="rounded-xl border border-[#b2dfdb] bg-[#e0f2f1] p-5">
-        <div class="flex items-start justify-between mb-3">
-          <h3 class="font-[var(--font-display)] text-base font-semibold text-[#00695c]">
-            Клемма проанализировала {{ briefing.total_sources }} источников
-          </h3>
-          <button @click="briefingDismissed = true" class="text-[#80cbc4] hover:text-[#00695c] text-lg leading-none">&times;</button>
+    <!-- Briefing bar: compact one-line summary. Full section breakdown and
+         coach findings live on /map — this is just a teaser. -->
+    <div
+      v-if="briefing && briefing.total_sources > 0 && !briefingDismissed"
+      class="mt-5 animate-in animate-in-delay-1"
+    >
+      <div
+        class="flex items-center justify-between gap-4 rounded-xl border border-[#b2dfdb] bg-[#e0f2f1] px-5 py-3"
+      >
+        <div class="text-sm text-[#004d40]">
+          <span class="font-semibold">{{ briefing.total_sources }}&nbsp;{{ plural(briefing.total_sources, 'источник', 'источника', 'источников') }}</span>
+          <span class="mx-2 text-[#80cbc4]">·</span>
+          <span>{{ briefing.total_fragments }}&nbsp;{{ plural(briefing.total_fragments, 'фрагмент', 'фрагмента', 'фрагментов') }}</span>
+          <span class="mx-2 text-[#80cbc4]">·</span>
+          <span>покрытие {{ readySectionCount }}/{{ totalSectionCount }}</span>
         </div>
-        <div class="text-sm text-[#004d40] mb-3">
-          {{ briefing.total_fragments }} фрагментов &middot;
-          {{ briefing.suggested_count }} предложено &middot;
-          {{ briefing.accepted_count }} принято
+        <div class="flex items-center gap-4 flex-shrink-0">
+          <RouterLink
+            v-if="projectStore.activeProjectId"
+            :to="`/${projectStore.activeProjectId}/map`"
+            class="text-sm font-medium text-[#00695c] hover:text-[#004d40] no-underline"
+          >
+            подробнее &rarr; Карта
+          </RouterLink>
+          <button
+            @click="briefingDismissed = true"
+            class="text-[#80cbc4] hover:text-[#00695c] text-lg leading-none"
+            aria-label="Скрыть"
+          >&times;</button>
         </div>
-
-        <!-- Per-section readiness -->
-        <div v-if="briefing.by_section.length > 0" class="space-y-1.5 mb-3">
-          <div v-for="sec in briefing.by_section" :key="sec.section_id"
-               class="flex items-center gap-2 text-sm">
-            <span v-if="sec.readiness === 'ready'" class="text-[#2e7d32]">&#9679;</span>
-            <span v-else-if="sec.readiness === 'partial'" class="text-[#f9a825]">&#9679;</span>
-            <span v-else class="text-[#bdbdbd]">&#9675;</span>
-            <span class="text-[#004d40] truncate" style="max-width: 200px">{{ sec.section_name }}</span>
-            <span class="text-[#80cbc4] text-xs">{{ sec.fragment_count }} фр. / {{ sec.source_count }} ист.</span>
-          </div>
-        </div>
-
-        <!-- Coach findings -->
-        <div v-if="briefing.coach_findings.length > 0" class="space-y-1 mb-3">
-          <div v-for="(f, i) in briefing.coach_findings.slice(0, 3)" :key="i"
-               class="text-xs text-[#004d40] bg-[#b2dfdb] rounded px-2 py-1">
-            {{ f.message }}
-          </div>
-        </div>
-
-        <RouterLink v-if="projectStore.activeProjectId"
-                    :to="`/${projectStore.activeProjectId}/map`"
-                    class="inline-block text-sm font-medium text-[#00695c] hover:text-[#004d40]">
-          Открыть карту &rarr;
-        </RouterLink>
       </div>
     </div>
 

--- a/src/klemma/api/routes/analyze.py
+++ b/src/klemma/api/routes/analyze.py
@@ -16,6 +16,74 @@ _MIN_SOURCES_COVERED = 3
 
 
 # ---------------------------------------------------------------------------
+# Localization helpers
+# ---------------------------------------------------------------------------
+
+
+def _ru_plural(n: int, one: str, few: str, many: str) -> str:
+    """Russian plural form selector: 1 source / 2 source-a / 5 source-ov.
+
+    Handles the teen exception (11, 12, 13, 14 all take `many`).
+    """
+    n10 = n % 10
+    n100 = n % 100
+    if n10 == 1 and n100 != 11:
+        return one
+    if 2 <= n10 <= 4 and not (12 <= n100 <= 14):
+        return few
+    return many
+
+
+def _ru_coach_message(
+    category: str,
+    *,
+    section_label: str,
+    source_count: int,
+    level: str,
+    intent_counts: dict[str, int],
+    fragment_count: int,
+) -> str:
+    """Build a Russian-localized coach message for the SaaS API.
+
+    Mirrors the English heuristics in ``klemma.skills.coach.analyze_section``
+    but rebuilds the user-facing text in Russian so the Vue dashboard never
+    surfaces the English originals. The CLI (``klemma coach``) keeps using
+    the English messages from the skill directly — tests pin the English
+    wording so the skill is left untouched.
+    """
+    min_src, max_src = (
+        (15, 30) if level == "chapter" else (5, 10)
+    )
+    label = section_label or "раздел"
+    src_word = _ru_plural(source_count, "источник", "источника", "источников")
+    frag_word = _ru_plural(fragment_count, "фрагмент", "фрагмента", "фрагментов")
+    if category == "adequacy":
+        return (
+            f"«{label}»: {source_count} {src_word} "
+            f"(рекомендуется: {min_src}–{max_src})"
+        )
+    if category == "saturation":
+        return (
+            f"«{label}»: {source_count} {src_word} — пора писать, не искать"
+        )
+    if category == "intent_balance":
+        total = sum(intent_counts.values())
+        pct = int(intent_counts.get("background", 0) / total * 100) if total else 0
+        return (
+            f"«{label}»: {pct}% фоновых ссылок — "
+            f"нужно больше методов и сравнений результатов"
+        )
+    if category == "writing_readiness":
+        return (
+            f"«{label}» готов к черновику: "
+            f"{source_count} {src_word}, {fragment_count} {frag_word}"
+        )
+    # Unknown category — fall back to a neutral placeholder so we never
+    # leak English internals to the dashboard.
+    return f"«{label}»: рекомендация от методолога"
+
+
+# ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
 
@@ -445,7 +513,14 @@ async def get_briefing(
             coach_findings.append(CoachFindingResponse(
                 category=finding.category,
                 section=finding.section,
-                message=finding.message,
+                message=_ru_coach_message(
+                    finding.category,
+                    section_label=outline_map.get(sec_id, sec_id),
+                    source_count=len(citekeys),
+                    level=level,
+                    intent_counts=intent_counts,
+                    fragment_count=len(frags),
+                ),
                 severity=finding.severity,
             ))
 


### PR DESCRIPTION
## Summary

- Collapses the LibraryView briefing card from a full section-readiness dump into a single compact bar: `N источников · M фрагментов · покрытие K/T` + "подробнее → Карта".
- Fixes Russian pluralization for `источник/фрагмент` counters (1 / 2-4 / 5+, with 11-14 teen exception).
- Localizes `coach_findings` messages to Russian at the API layer (`_ru_coach_message()` in `routes/analyze.py`) without touching `skills/coach.py` — CLI tests pin the English wording, so the SaaS API rebuilds the message from `finding.category` + raw counts.
- Visibility condition relaxed: `briefing.total_sources > 0` (was `total_fragments > 0`), so the counter appears as soon as the user has uploaded sources, even before extraction runs.

## Release Note

### Problem
The LibraryView briefing card dominated the viewport on page load. It expanded the full outline tree (~20 sections), rendered per-section readiness badges, and surfaced English coach findings like "stop adding, 80% background citations — need more method and results". For a Russian-speaking dissertation author opening their own library, this was visual noise: an entire methodology sermon where the user expected to see their sources. The card was also incorrectly visible only after extraction (`total_fragments > 0`), so users who had just uploaded a PDF saw nothing.

### Academic Foundation
The collapse is an application of Tufte's data-ink ratio — the briefing is a *teaser* into the Map view (which owns the detailed methodology surface), not a duplicate of it. Coach findings follow Pautasso (2013) on literature review adequacy, Cohan et al. (2019) on citation-intent balance, and Kallestinova (2011) on writing readiness; all three frameworks assume the reader is a native speaker of the review language, so the SaaS delivery layer localizes.

### Implementation
Two files. `saas/dashboard/src/views/LibraryView.vue` replaces the expanded briefing card template (section list, readiness dots, coach chips, "Открыть карту" link) with a 3-stat bar using a new `plural(n, one, few, many)` TS helper and two computeds (`readySectionCount`, `totalSectionCount`). `src/klemma/api/routes/analyze.py` adds `_ru_plural()` and `_ru_coach_message()` and rewires the `coach_findings` loop in `get_briefing()` to translate before returning. The `coach` skill and its 35 tests are untouched — localization is a SaaS-specific concern that sits at the API boundary.

### Results
- Briefing card footprint: from ~350 px expanded multi-row block to a 48 px one-line bar.
- `ruff check src/ tests/`: clean.
- `tests/test_coach.py`: 35 passed (unchanged English assertions still hold).
- `tests/test_analyze_api.py`: 9 passed.
- `tests/ -k "analyze or briefing"`: 40 passed.
- `npm run type-check && npm run build-only`: clean, 2.52s build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)