### PR TITLE
feat(storage): default-local notes + raw PDF sidecars (ADR-016)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ pip install -e .
   - `pip install klemma[recommended]` — LiteLLM: 100+ провайдеров (рекомендуется)
   - `pip install klemma[openai]` — OpenAI API / Ollama / vLLM / LM Studio
   - Claude Code CLI (`claude` в PATH) — без дополнительных пакетов
-- Obsidian vault с заметками источников
-- Zotero с BetterBibTeX plugin (JSON auto-export)
+- Zotero с BetterBibTeX plugin (JSON auto-export) — опционально, для автоматического поиска PDF
+- Obsidian vault — *опционально*. По умолчанию klemma хранит аннотированные заметки и raw-дампы PDF внутри проекта в `.klemma/notes/` и `.klemma/pdfs/`. Obsidian-интеграция включается одной строкой в `config.yaml` — см. [User Guide § 2.8](docs/USER_GUIDE.md#28-куда-klemma-сохраняет-данные).
 
 ### Опциональные зависимости
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,19 +11,24 @@ instance:
   name: "my-dissertation"
   type: "academic"
 
-zotero:
-  library_id: "YOUR_LIBRARY_ID"       # Zotero library ID (from Settings → Feeds/API)
-  library_type: "user"                 # "user" or "group"
-  api_key_env: "ZOTERO_API_KEY"        # env var holding your Zotero API key
-  local: false
-  library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
-  storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
+# Zotero (optional — enables auto-discovery of BBT citekeys and PDF storage).
+# zotero:
+#   library_id: "YOUR_LIBRARY_ID"       # Zotero library ID (from Settings → Feeds/API)
+#   library_type: "user"                 # "user" or "group"
+#   api_key_env: "ZOTERO_API_KEY"        # env var holding your Zotero API key
+#   local: false
+#   library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
+#   storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
 
-obsidian:
-  vault_path: "/path/to/your/obsidian/vault"
-  notes_folder: "References"           # folder with @citekey.md notes
-  tags_folder: "Tags"                  # optional folder for tag notes
-  use_cli: null
+# Obsidian override (optional — only for power users who read annotated
+# @citekey.md notes inside an Obsidian vault). When unset, klemma writes
+# annotated notes and raw PDF sidecars to `.klemma/notes/` and
+# `.klemma/pdfs/` inside the project directory.
+# obsidian:
+#   vault_path: "/path/to/your/obsidian/vault"
+#   notes_folder: "References"           # folder with @citekey.md notes
+#   tags_folder: "Tags"                  # optional folder for tag notes
+#   use_cli: null
 
 ai:
   language: "ru"                       # AI response language: "en", "ru", "de", etc.

--- a/config.project.example.yaml
+++ b/config.project.example.yaml
@@ -8,14 +8,19 @@
 
 # --- Shared resources (inherited from parent if nested) ---
 
-zotero:
-  library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
-  storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
+# Zotero (optional — enables auto-discovery of BBT citekeys).
+# zotero:
+#   library_json: "/path/to/your/bibtex-export.json"  # BetterBibTeX JSON export
+#   storage_path: "/path/to/Zotero/storage"            # Zotero attachment storage
 
-obsidian:
-  vault_path: "/path/to/your/obsidian/vault"
-  notes_folder: "References"           # folder with @citekey.md notes
-  tags_folder: "Tags"                  # optional folder for tag notes
+# Obsidian override (optional — only for power users who read annotated
+# @citekey.md notes inside an Obsidian vault). When unset, klemma writes
+# annotated notes and raw PDF sidecars to `.klemma/notes/` and
+# `.klemma/pdfs/` inside the project directory.
+# obsidian:
+#   vault_path: "/path/to/your/obsidian/vault"
+#   notes_folder: "References"           # folder with @citekey.md notes
+#   tags_folder: "Tags"                  # optional folder for tag notes
 
 ai:
   language: "ru"                       # AI response language

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -15,7 +15,7 @@ Klemma — AI-ассистент для академического письм�
 - AI-powered research briefings, библиотечный аудит, ежедневное планирование
 - Вложенные проекты (диссертация + отдельные статьи)
 
-**Как работает**: Zotero (библиотека) → BetterBibTeX (JSON-экспорт) → klemma (AI-анализ PDF) → SQLite (фрагменты, статистика) + Obsidian vault (заметки).
+**Как работает**: Zotero (библиотека) → BetterBibTeX (JSON-экспорт) → klemma (AI-анализ PDF) → SQLite (фрагменты, статистика) + локальные заметки `.klemma/notes/` (опционально — Obsidian vault для power-users).
 
 ---
 
@@ -25,8 +25,8 @@ Klemma — AI-ассистент для академического письм�
 
 - **Python 3.11+**
 - **Zotero** с плагином [BetterBibTeX](https://retorque.re/zotero-better-bibtex/) — для автоматического JSON-экспорта библиотеки
-- **Obsidian** vault — хранение заметок по источникам и отчётов
 - **AI-бэкенд** — Claude Code CLI (по умолчанию), или OpenAI/Ollama/LiteLLM
+- **Obsidian** vault — *опционально*. По умолчанию заметки и raw-дампы PDF сохраняются локально в `.klemma/notes/` и `.klemma/pdfs/`. Obsidian-интеграция включается через `obsidian.vault_path` в `config.yaml`.
 
 ### 2.2 Установка
 
@@ -55,9 +55,11 @@ klemma init --outline        # сгенерировать outline после ini
 
 Мастер задаст вопросы:
 - Тип проекта (dissertation / paper / thesis)
-- Путь к Obsidian vault (обнаруживается автоматически)
-- Путь к BetterBibTeX JSON
+- Название и описание
+- Путь к BetterBibTeX JSON (если есть)
 - AI-бэкенд
+
+Вопросов про Obsidian мастер не задаёт — заметки по умолчанию сохраняются локально внутри проекта. Если нужна интеграция с Obsidian, пропишите `obsidian.vault_path` в `.klemma/config.yaml` вручную.
 
 Создаётся:
 ```
@@ -66,6 +68,8 @@ my-thesis/
 └── .klemma/
     ├── config.yaml    # конфигурация
     ├── tags.yaml      # таксономия тегов
+    ├── notes/         # аннотированные заметки @<citekey>.md
+    ├── pdfs/          # raw-дампы PDF (frontmatter + текст по страницам)
     └── data/
         └── klemma.db  # SQLite база
 ```
@@ -125,12 +129,30 @@ ai:
 
 `language` влияет на язык всех AI-генерированных отчётов (план, брифинг, аудит). `json_mode` полезен при интеграции с OpenAI-совместимыми бэкендами, поддерживающими structured output.
 
-### 2.8 Куда сохраняются отчёты
+### 2.8 Куда klemma сохраняет данные
 
-- AI-отчёты (`outline`, `research`, `library`, `ask`) → корень проекта (`project_root/`)
-- Vault-заметки `@citekey.md` → папка `obsidian.notes_folder` в vault
+По умолчанию всё живёт внутри проекта. Никакой внешней настройки не требуется.
 
-Это значит, что research briefing для раздела 2.3 окажется в `~/research/my-thesis/`, а заметка по источнику — в `~/vault/2 - Refs/@smithML2020.md`.
+| Что | Куда (default) | Куда (Obsidian override) |
+|-----|----------------|--------------------------|
+| AI-отчёты (`outline`, `research`, `library`, `ask`) | `<project_root>/notes/research/` | то же самое |
+| Аннотированные заметки `@<citekey>.md` | `<project_root>/.klemma/notes/` | `<vault_path>/<notes_folder>/` |
+| Raw-дампы PDF (frontmatter + текст по страницам) | `<project_root>/.klemma/pdfs/` | то же самое *(всегда локально)* |
+| SQLite база, tags, кэш | `<project_root>/.klemma/data/` | то же самое |
+
+**Raw-дамп PDF** — это feynman-style sidecar: YAML-like frontmatter (citekey, авторы, год, DOI, источник), `---`, затем чистый текст с разделителями `<!-- Page N -->` между страницами. Формат стабильный и удобный для `grep`.
+
+**Obsidian override.** Если вы читаете заметки в Obsidian, добавьте в `.klemma/config.yaml`:
+
+```yaml
+obsidian:
+  vault_path: "/Users/you/Documents/Obsidian Vault"
+  notes_folder: "References"   # опционально; пусто = корень vault
+```
+
+После этого `@<citekey>.md` будет писаться в vault, а raw-дампы PDF останутся локальными (это отладочный артефакт уровня проекта, не контент для чтения в Obsidian).
+
+> **Замечание для существующих Obsidian-пользователей.** После этого изменения `vault.get_tags()` / `search()` / `_find_daily_dir()` сканируют только папку с заметками (`notes_folder`), а не весь vault. Это соответствует реальному использованию в klemma, но если вы держали связанные файлы вне `notes_folder`, они больше не попадут в результаты поиска.
 
 ---
 
@@ -199,12 +221,13 @@ klemma process --serial
 
 **Что происходит при `process`**:
 1. Находит PDF (BBT lookup → Zotero storage → fuzzy search)
-2. Извлекает текст (PyMuPDF, до 50K символов)
-3. AI-анализ: scaffold prompting → фрагменты с citation intent → vault note
+2. Извлекает текст (PyMuPDF, до 50K символов для AI)
+3. AI-анализ: scaffold prompting → фрагменты с citation intent → аннотированная заметка
 4. Сохраняет фрагменты в SQLite
-5. Создаёт `@citekey.md` в Obsidian (summary, methodology, key references)
-6. Записывает reference gaps + citation links
-7. Генерирует embedding (если настроен бэкенд)
+5. Создаёт `@citekey.md` в `.klemma/notes/` (summary, methodology, key references) — или в Obsidian vault, если он настроен
+6. Пишет raw-дамп PDF в `.klemma/pdfs/<citekey>.md` (frontmatter + текст по страницам) — всегда локально
+7. Записывает reference gaps + citation links
+8. Генерирует embedding (если настроен бэкенд)
 
 **Совет**: обрабатывайте пакетами (накопите 5-10 источников, затем `klemma process`).
 

--- a/docs/adr/ADR-016-default-local-notes-and-pdf-sidecars.md
+++ b/docs/adr/ADR-016-default-local-notes-and-pdf-sidecars.md
@@ -1,0 +1,105 @@
+# ADR-016: Default-local notes and raw PDF sidecars
+
+- **Status**: Accepted
+- **Date**: 2026-04-11
+- **Depends on**: ADR-014 (Three-tier library split)
+- **Supersedes**: None
+
+## Context
+
+Two independent but intertwined frictions had accumulated around how klemma stores data on disk:
+
+1. **Obsidian was mandatory at init time.** The `klemma init` wizard asked every new user for a vault path, notes folder, and tags folder — and hard-failed at `klemma process` when those were missing. In practice, 90%+ of the people klemma serves (PhD students, early-career researchers, downstream tool users) don't have an Obsidian vault and have no reason to set one up just to try the tool. Existing power users who *do* use Obsidian are a valuable but small minority.
+2. **Raw PDF text had no on-disk trace.** At `klemma process` time the full PDF text was extracted into memory, fed to the AI for fragment extraction, and discarded. There was no human-readable artifact to grep, diff, or debug. The upcoming semantic citation drift checker (planned, separate PR) needs a cheap local source of primary-source passages — not a `fitz`-re-open on every check and not a `WebFetch` to the original URL.
+
+At the same time, klemma's competitor-adjacent tool feynman's `/lit` dump format (flat prose + `<!-- Page N -->` markers + a small frontmatter block) had demonstrated itself as a surprisingly effective format for grep-level workflows. It is trivial to produce, trivial to consume, and pairs cleanly with klemma's existing `.klemma/` project-scoped storage.
+
+## Decisions
+
+### 1. Default-local layout for annotated notes
+
+**Decision**: Fresh projects write `@<citekey>.md` to `<project_root>/.klemma/notes/` by default. Obsidian integration is an opt-in override.
+
+**How**: `klemma init` no longer prompts for `vault_path`, `notes_folder`, or `tags_folder`. It pre-creates `.klemma/notes/` and `.klemma/pdfs/`. The fresh `config.yaml` has no `obsidian:` section. Existing projects with `obsidian.vault_path` set continue to work unchanged — the override kicks in whenever the user has written it to `config.yaml` by hand.
+
+**Override**: add to `.klemma/config.yaml`:
+```yaml
+obsidian:
+  vault_path: "/path/to/vault"
+  notes_folder: "References"
+```
+
+### 2. Raw PDF sidecar at `<project_root>/.klemma/pdfs/<citekey>.md`
+
+**Decision**: On every successful PDF extraction, klemma writes a raw-text sidecar in feynman-style format: YAML-like frontmatter + `---` + flat prose + `<!-- Page N -->` markers between pages.
+
+**Rationale**:
+- **Debuggability**: users can see exactly what text the AI received when a fragment looks wrong
+- **Provenance**: the sidecar is the canonical on-disk trace of "what was in the PDF when we processed it" — cheaper than re-opening with `fitz` every time and more stable than the source PDF (which can be moved/renamed)
+- **Downstream consumer**: the semantic citation drift checker (planned) will grep these sidecars as its primary-source passage store; it is the second consumer after `write_pdf_sidecar()` itself
+
+### 3. The raw sidecar is *always* local
+
+**Decision**: The Obsidian override applies only to annotated `@<citekey>.md` notes. Raw dumps always land in `<project_root>/.klemma/pdfs/`, regardless of whether a vault is configured.
+
+**Rationale**: The raw dump is a project-level debugging artifact, not content read in Obsidian. Mixing gigabytes of raw PDF text into someone's Obsidian vault would degrade their vault experience for zero gain. Keeping it project-local also means reproducibility (you can tar up a project and its raw traces go with it) and downstream tools can hardcode the path.
+
+### 4. `VaultAdapter` re-rooted at the notes directory
+
+**Decision**: `VaultAdapter` is now constructed with the *resolved notes directory* as its root, not the vault root. A module-level helper `resolve_notes_root(config, project_root) -> Path` is the single source of truth for where annotated notes land.
+
+**Rationale**: Before this change, every call site re-appended `cfg.obsidian.notes_folder` to a vault-root adapter via `folder=...` args. In local mode there *is* no vault root, so either every call site would need a fallback or we re-root the adapter. Re-rooting is smaller and kills the folder arg from every call site. `_resolve_folder(None)` returns `self.vault_path` which is exactly what we want.
+
+**Resolver logic**:
+- `config.obsidian.vault_path` set (non-whitespace) → `Path(vault_path).expanduser() / notes_folder` (joined path; `notes_folder=""` yields the vault root, preserving the flat-vault edge case)
+- Otherwise → `project_root / ".klemma" / "notes"`
+
+**Known semantic narrowing**: `vault.get_tags()`, `vault.search()`, and `vault._find_daily_dir()` used to scan the whole vault. They now scan only the notes directory. This matches what those helpers are *actually used for* in klemma (citekey-note operations and tag inventory of `@<citekey>.md` files), but it is a behavior change worth flagging in release notes for existing Obsidian users.
+
+### 5. Three format contracts for downstream consumers
+
+The raw PDF sidecar is infrastructure for the planned semantic citation drift checker (and any future tool that wants to read processed PDF text). This ADR locks in three format contracts that must not drift without a version bump:
+
+**Contract 1 — Sidecar path.** The sidecar for `<citekey>` in project `<root>` is always at `<root>/.klemma/pdfs/<citekey>.md`. No config override. Downstream consumers can hardcode this path.
+
+**Contract 2 — Page delimiter.** The delimiter between pages is exactly `\n<!-- Page N -->\n` where `N = 2, 3, ...` (page 1 has no marker — it starts immediately after the frontmatter `---`). The regex `\n<!-- Page (\d+) -->\n` is a stable split point.
+
+**Contract 3 — Frontmatter field set.** The stable fields are `Citekey`, `Authors`, `Year`, `DOI`, `Pages`, `Source`. Additions are allowed (append-only). Renames and removals require a version bump note in the sidecar header and a migration path.
+
+`PDFExtractor.extract_pages()` is also part of the public API — signature `(pdf_path: Path) -> list[str]`, one cleaned string per page, no truncation. The semantic citation checker is the second consumer of this method, so the signature is load-bearing.
+
+## Consequences
+
+### Positive
+
+- **Onboarding friction**: zero Obsidian questions in the wizard; zero "you must set vault_path" hard-failures at `process` time
+- **Debuggability**: every processed PDF leaves a grep-able trace
+- **Downstream infrastructure**: the semantic citation checker has a stable, project-local, cheap fetch source
+- **No config migration**: existing Obsidian projects keep working because the resolver feeds their old layout into the adapter unchanged
+- **`migrate-frontmatter` and `import --with-queue` become mode-agnostic**: they used to hard-fail when `vault is None`, now they always have a valid `kctx.vault`
+
+### Negative
+
+- **`get_tags()` / `search()` / `_find_daily_dir()` scope narrowing** (see Decision 4). Documented in the release note for existing Obsidian users.
+- **Disk usage**: raw PDF sidecars add text-file-scale overhead per processed source (~50-500KB per paper). Projects with hundreds of sources will see tens of MB in `.klemma/pdfs/`. Acceptable — text compresses well if the user wants to clean up, and the files are never loaded into memory all at once.
+- **Citekey validation surface**: `write_pdf_sidecar()` must reject `..`, `/`, `\`, and empty citekeys. Pattern mirrors `LocalFileStore._file_path()`.
+
+## Alternatives considered
+
+- **Rip out `ObsidianConfig` entirely.** Rejected — power users who already have working Obsidian integrations should not be forced to migrate, and keeping the override path is nearly free.
+- **Config override for `pdfs_dir`.** Rejected — hardcoding `.klemma/pdfs/` makes downstream consumers simpler and avoids a "where is my raw text" support surface.
+- **Page-number tagging on extracted fragments.** Deferred — requires threading page info through `skills/extractor.py` and the extraction prompt. Tracked under issue #299 (provenance sidecars).
+- **Splitting `VaultAdapter` into `NotesAdapter` + `VaultAdapter`.** Rejected as premature. The single-adapter-reroot approach is smaller and sufficient. Revisit if a future feature needs both vault-wide and notes-scoped operations simultaneously.
+
+## Implementation notes
+
+- `src/klemma/literature/pdf.py` — `PDFExtractor.extract_pages()` reuses `fitz.open()` + `_clean_text()`, returns unbounded `list[str]`
+- `src/klemma/literature/sidecar.py` — new module; `write_pdf_sidecar()` uses the atomic-write pattern from `save_klemma_md()` (tempfile + `os.replace` + try/except unlink)
+- `src/klemma/vault.py` — `resolve_notes_root()` is module-level; every `VaultAdapter` construction goes through it
+- `src/klemma/setup.py` — `init_project()` creates both `.klemma/notes/` and `.klemma/pdfs/`; `_build_project_config()` skips the `obsidian:` section when `values.vault_path` is empty
+- `config.project.example.yaml` / `config.example.yaml` — the `obsidian:` and `zotero:` blocks are commented out, not live defaults
+
+See also:
+- `src/klemma/literature/CLAUDE.md` — documents the three format contracts
+- `src/klemma/CLAUDE.md` — documents `resolve_notes_root()` and the narrowed `get_tags()`/`search()` scope
+- `docs/USER_GUIDE.md § 2.8` — user-facing storage documentation

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -62,11 +62,12 @@ Key models: `KlemmaConfig`, `ZoteroConfig`, `ObsidianConfig`, `AIConfig` (with `
 
 ### setup.py (338 lines)
 `klemma init` logic — creates per-directory `.klemma/` projects, `~/.klemma/` system config, and `~/.klemmarc.yaml` global config. Interactive wizard with auto-discovery; non-interactive mode via CLI flags.
-- `init_project(project_dir, project_type, values?)` — creates `.klemma/`, `KLEMMA.md` (with YAML frontmatter for content fields), updates `.gitignore`; `config.yaml` has infrastructure only (no `project:` section)
+- `init_project(project_dir, project_type, values?)` — creates `.klemma/`, including pre-created `.klemma/notes/` and `.klemma/pdfs/` directories (ADR-016 default-local layout), `KLEMMA.md` (with YAML frontmatter for content fields), updates `.gitignore`; `config.yaml` has infrastructure only (no `project:` section)
 - `migrate_content_to_klemma_md(project_root)` — reads content fields from `config.yaml project:`/`dissertation:`, writes to KLEMMA.md frontmatter, strips content from `config.yaml`; returns `{"migrated_fields": [...], "warnings": [...]}`
 - `init_system(system_home)` — creates `~/.klemmarc.yaml` (0600, with api_keys template) + `~/.klemma/config.yaml` (legacy fallback)
 - `init_klemma_home()` — legacy alias for `init_system()`
-- Interactive mode: auto-discovers Obsidian vaults, Zotero exports via `discovery.py`
+- Interactive mode: auto-discovers Zotero exports via `discovery.py`. The wizard **no longer prompts for Obsidian** — it's an opt-in override added to `config.yaml` by hand (ADR-016). `discover_obsidian_vault()` still ships for programmatic callers.
+- `_build_project_config()` skips the `obsidian:` section unless `values.vault_path` is explicitly set — fresh local-mode projects have a clean `config.yaml`
 
 ### section_types.py (~290 lines)
 Semantic section vocabulary — cross-project labels for dissertation/paper sections.
@@ -219,11 +220,13 @@ Klemma error taxonomy for AI backends.
 - `base_url` passthrough for custom endpoints (Ollama, vLLM, etc.)
 
 ### vault.py (263 lines)
-`VaultAdapter` — Obsidian vault file I/O.
+`VaultAdapter` — file I/O for annotated `@<citekey>.md` notes. Since ADR-016 the adapter is re-rooted at the *resolved notes directory*, not the Obsidian vault root — `resolve_notes_root()` is the single source of truth for where notes land.
+- `resolve_notes_root(config, project_root) -> Path` — module-level helper: returns `Path(vault_path).expanduser() / notes_folder` when `config.obsidian.vault_path` is set (non-whitespace), else `project_root / ".klemma" / "notes"`. `notes_folder=""` joins to the vault root (flat-vault edge case).
 - `read_note()` / `write_note()` — file read/write
 - `update_section()` — replace content between markdown heading markers
 - `get_properties()` — parse YAML frontmatter
-- `list_notes()` — enumerate vault notes
+- `list_notes()` — enumerate notes in the adapter root
+- **Scope narrowing for existing Obsidian users**: `get_tags()`, `search()`, `_find_daily_dir()` used to scan the whole vault. They now scan only the notes directory (the adapter root). Matches how klemma actually uses these helpers (citekey-note operations + tag inventory of `@*.md`), but downstream scripts relying on whole-vault scans must move files into the notes folder or use a separate tool.
 
 ### library_provider.py (86 lines)
 `LibraryProvider` protocol with LocalLibrary backend:

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1450,6 +1450,7 @@ def _process_single(
     # Online source: fetch URL text instead of PDF
     source_type = source.get("source_type", "") if source else ""
     pdf_path = None
+    pdf_pages: list[str] = []
     if source_type == "online":
         source_url = source.get("url", "") if source else ""
         if not source_url:
@@ -1560,8 +1561,10 @@ def _process_single(
             except Exception as _e:
                 logger.debug("Library dedup check failed for %s: %s", citekey, _e)
 
-        # Extract text
-        pdf_text = pdf_extractor.extract(pdf_path)
+        # Extract text — single fitz.open call; `pdf_pages` is reused
+        # below for the raw-sidecar write so we don't re-parse the PDF.
+        pdf_pages = pdf_extractor.extract_pages(pdf_path)
+        pdf_text = pdf_extractor.format_for_ai(pdf_pages) if pdf_pages else None
         if not pdf_text or len(pdf_text) < cfg.processing.min_pdf_length:
             if not quiet:
                 console.print("  [red]PDF extraction failed or text too short[/red]")
@@ -1617,26 +1620,27 @@ def _process_single(
 
     # Raw PDF sidecar — written once fragments have been saved, so the
     # dump is a stable artifact aligned with the latest extraction run.
-    # Online sources have no PDF — skip. See literature/sidecar.py for the
-    # format contract relied on by the semantic citation check pipeline.
-    if source_type != "online" and pdf_path and klemma_home:
+    # `pdf_pages` was extracted above as part of the AI-bound text flow,
+    # so no second fitz.open is required. Online sources have no PDF —
+    # their `pdf_pages` stays empty and this block is a no-op.
+    # See literature/sidecar.py for the format contract relied on by the
+    # semantic citation check pipeline.
+    if pdf_pages and pdf_path and klemma_home:
         try:
             from .literature.sidecar import write_pdf_sidecar
 
-            pages = pdf_extractor.extract_pages(pdf_path)
-            if pages:
-                write_pdf_sidecar(
-                    klemma_home.parent,
-                    citekey,
-                    pages,
-                    {
-                        "title": entry.title or "",
-                        "authors": entry.authors_str or "",
-                        "year": entry.year,
-                        "doi": getattr(entry, "doi", None) or "",
-                        "source": str(pdf_path),
-                    },
-                )
+            write_pdf_sidecar(
+                klemma_home.parent,
+                citekey,
+                pdf_pages,
+                {
+                    "title": entry.title or "",
+                    "authors": entry.authors_str or "",
+                    "year": entry.year,
+                    "doi": entry.DOI or "",
+                    "source": str(pdf_path),
+                },
+            )
         except (OSError, ValueError) as _e:
             logger.warning("PDF sidecar write failed for %s: %s", citekey, _e)
             console.print(
@@ -1661,7 +1665,7 @@ def _process_single(
                     title=entry.title or citekey,
                     authors=entry.authors_str or "",
                     year=entry.year,
-                    doi=getattr(entry, "doi", None) or None,
+                    doi=entry.DOI or None,
                     abstract=entry.abstract or "",
                     pdf_hash=_pdf_hash,
                 )

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -22,7 +22,7 @@ from .context import KlemmaContext
 from .embeddings import create_embeddings
 from .library_provider import create_library
 from .state import StateManager
-from .vault import VaultAdapter
+from .vault import VaultAdapter, resolve_notes_root
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -194,13 +194,9 @@ def _init_components(config_path: str | None = None) -> KlemmaContext:
 
     state = StateManager(db_path)
 
-    vault = VaultAdapter(cfg.obsidian.vault_path, use_cli=cfg.obsidian.use_cli)
-    if cfg.obsidian.vault_path and cfg.obsidian.notes_folder:
-        if not vault.check_folder(cfg.obsidian.notes_folder):
-            console.print(
-                f"[yellow]Warning: notes_folder '{cfg.obsidian.notes_folder}' "
-                f"not found in vault. Sync and note creation will not work.[/yellow]"
-            )
+    notes_root = resolve_notes_root(cfg, project_root)
+    notes_root.mkdir(parents=True, exist_ok=True)
+    vault = VaultAdapter(str(notes_root), use_cli=cfg.obsidian.use_cli)
     library = create_library(cfg)
 
     # Embeddings: create provider if configured
@@ -403,8 +399,7 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
     cfg, state, vault = ctx.config, ctx.state, ctx.vault
     from .literature.note_factory import auto_classify
 
-    notes_folder = cfg.obsidian.notes_folder
-    note_names = vault.list_notes(notes_folder)
+    note_names = vault.list_notes(None)
 
     # 1. Parse vault frontmatter for all @citekey notes
     vault_data = []
@@ -460,7 +455,7 @@ def _sync_sections(ctx: KlemmaContext, quiet=False) -> dict:
                 "priority": props.get("priority", "medium"),
                 "nr1": props.get("relevance_nr1", 0) or 0,
                 "nr2": props.get("relevance_nr2", 0) or 0,
-                "note_path": f"{notes_folder}/{note_name}.md",
+                "note_path": f"{vault.vault_path}/{note_name}.md",
             }
         )
 
@@ -1033,7 +1028,6 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
     """
     from .discovery import (
         discover_bbt_json,
-        discover_obsidian_vault,
         discover_zotero_storage,
     )
     from .setup import InitValues
@@ -1221,44 +1215,10 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
         plan_data=plan_data,
     )
 
-    # Obsidian vault
-    prefill_vault = pf.get("vault_path", "")
-    vault = discover_obsidian_vault()
-    discovered_vault = str(vault) if vault else ""
-    # Use prefill if available, otherwise use discovery
-    effective_vault = prefill_vault or discovered_vault
-
-    if effective_vault:
-        click.echo(f"  + Obsidian vault: {effective_vault}")
-        if not click.confirm("    Use this path?", default=True):
-            vault_str = click.prompt("    Obsidian vault path", default="")
-            values.vault_path = vault_str
-        else:
-            values.vault_path = effective_vault
-    else:
-        vault_str = click.prompt(
-            "  ? Obsidian vault not found. Path (empty to skip)",
-            default="",
-            show_default=False,
-        )
-        values.vault_path = vault_str
-
-    if values.vault_path:
-        from .discovery import discover_vault_folders
-        auto_notes, auto_tags = discover_vault_folders(Path(values.vault_path))
-        if auto_notes and not values.notes_folder:
-            values.notes_folder = auto_notes
-        if auto_tags and not values.tags_folder:
-            values.tags_folder = auto_tags
-        if values.notes_folder:
-            notes_dir = Path(values.vault_path) / values.notes_folder
-            if not notes_dir.is_dir():
-                console.print(
-                    f"[yellow]  Warning: '{values.notes_folder}' not found in vault.[/yellow]"
-                )
-                console.print(
-                    "[dim]  Fix notes_folder in .klemma/config.yaml after init.[/dim]"
-                )
+    # Notes land in .klemma/notes/ by default. Obsidian integration is
+    # an opt-in power-user feature — users can set obsidian.vault_path in
+    # config.yaml after init to redirect notes into a vault. The wizard
+    # no longer prompts for vault paths to keep onboarding friction-free.
 
     # Zotero storage
     prefill_storage = pf.get("zotero_storage", "")
@@ -1489,6 +1449,7 @@ def _process_single(
 
     # Online source: fetch URL text instead of PDF
     source_type = source.get("source_type", "") if source else ""
+    pdf_path = None
     if source_type == "online":
         source_url = source.get("url", "") if source else ""
         if not source_url:
@@ -1653,6 +1614,31 @@ def _process_single(
             console.print(f" → @{citekey}")
         else:
             console.print(" [dim](DB only)[/dim]")
+
+    # Raw PDF sidecar — written once fragments have been saved, so the
+    # dump is a stable artifact aligned with the latest extraction run.
+    # Online sources have no PDF — skip. See literature/sidecar.py for the
+    # format contract relied on by the semantic citation check pipeline.
+    if source_type != "online" and pdf_path and klemma_home:
+        try:
+            from .literature.sidecar import write_pdf_sidecar
+
+            pages = pdf_extractor.extract_pages(pdf_path)
+            if pages:
+                write_pdf_sidecar(
+                    klemma_home.parent,
+                    citekey,
+                    pages,
+                    {
+                        "title": entry.title or "",
+                        "authors": entry.authors_str or "",
+                        "year": entry.year,
+                        "doi": getattr(entry, "doi", None) or "",
+                        "source": str(pdf_path),
+                    },
+                )
+        except Exception as _e:
+            logger.debug("PDF sidecar write failed for %s: %s", citekey, _e)
 
     # Phase 1B dual-write: also persist to library.db (ADR-014)
     # online sources have no PDF hash — skip dual-write
@@ -2303,8 +2289,7 @@ def add(ctx, input_value, section, title, authors, year, no_process, no_embed, m
         # Update vault note frontmatter if note exists
         if kctx.vault:
             note_name = f"@{citekey}"
-            notes_folder = kctx.config.obsidian.notes_folder or None
-            kctx.vault.update_frontmatter_sections(note_name, sections, folder=notes_folder)
+            kctx.vault.update_frontmatter_sections(note_name, sections, folder=None)
         console.print(f"  [dim]sections: {', '.join(sections)}[/dim]")
 
     # --- Process (if not suppressed and we have a citekey) ---

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1637,8 +1637,11 @@ def _process_single(
                         "source": str(pdf_path),
                     },
                 )
-        except Exception as _e:
-            logger.debug("PDF sidecar write failed for %s: %s", citekey, _e)
+        except (OSError, ValueError) as _e:
+            logger.warning("PDF sidecar write failed for %s: %s", citekey, _e)
+            console.print(
+                f"[dim yellow]  raw sidecar skipped for {citekey}: {_e}[/dim yellow]"
+            )
 
     # Phase 1B dual-write: also persist to library.db (ADR-014)
     # online sources have no PDF hash — skip dual-write

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -425,8 +425,10 @@ def info(ctx):
         info_parts.append(f"Focus: {project.current_focus}")
     info_parts.append(f"Chapters: {len(project.chapters)}")
     info_parts.append(f"DB: {kctx.config.state.db_path}")
+    notes_root = kctx.vault.vault_path if kctx.vault else (project_root / ".klemma" / "notes")
+    info_parts.append(f"Notes: {notes_root}")
     if kctx.config.obsidian.vault_path:
-        info_parts.append(f"Vault: {kctx.config.obsidian.vault_path}")
+        info_parts.append(f"Obsidian vault: {kctx.config.obsidian.vault_path}")
 
     console.print(
         Panel(
@@ -480,15 +482,11 @@ def info(ctx):
         f"[bold]Research notes[/bold]: {project_root}/notes/research/",
         f"[bold]Library reports[/bold]: {project_root}/notes/library/",
     ]
+    conv_parts.append(f"[bold]Reference notes[/bold]: {notes_root}/")
     if kctx.config.obsidian.vault_path:
-        nf = kctx.config.obsidian.notes_folder
-        tf = kctx.config.obsidian.tags_folder
-        nf_ok = kctx.vault.check_folder(nf)
-        tf_ok = kctx.vault.check_folder(tf)
-        nf_s = "[green]\u2713[/green]" if nf_ok else "[red]\u2717 not found[/red]"
-        tf_s = "[green]\u2713[/green]" if tf_ok else "[red]\u2717 not found[/red]"
-        conv_parts.append(f"[bold]Reference notes[/bold]: vault {nf}/ {nf_s}")
-        conv_parts.append(f"[bold]Tags[/bold]: vault {tf}/ {tf_s}")
+        conv_parts.append(
+            f"[bold]Obsidian vault[/bold]: {kctx.config.obsidian.vault_path} (override)"
+        )
     console.print(
         Panel(
             "\n".join(conv_parts),
@@ -797,7 +795,6 @@ def reassign(ctx, citekey, target_section, threshold, min_delta, cross_type_pena
     # --- Direct apply: citekey + target_section bypasses interactive review ---
     if citekey and target_section:
         vault = kctx.vault
-        notes_folder = kctx.config.obsidian.notes_folder
 
         # Only move fragments that embeddings suggest belong to target_section
         frag_ids_to_move: list[int] = []
@@ -845,7 +842,7 @@ def reassign(ctx, citekey, target_section, threshold, min_delta, cross_type_pena
             if target_section not in current:
                 merged = current | {target_section}
                 ok = vault.update_frontmatter_sections(
-                    note_name, list(merged), folder=notes_folder,
+                    note_name, list(merged), folder=None,
                 )
                 if ok:
                     vault_updated = True
@@ -1234,14 +1231,8 @@ def migrate_frontmatter(ctx, dry_run):
 
     kctx = _get_context(ctx)
     vault = kctx.vault
-    config = kctx.config
 
-    if vault is None:
-        console.print("[red]No Obsidian vault configured. Set obsidian.vault_path.[/red]")
-        raise SystemExit(1)
-
-    notes_folder = config.obsidian.notes_folder or ""
-    note_names = vault.list_notes(folder=notes_folder)
+    note_names = vault.list_notes(None)
     citekey_notes = [n for n in note_names if n.startswith("@")]
 
     updated = 0
@@ -1280,12 +1271,11 @@ def migrate_frontmatter(ctx, dry_run):
             updated += 1
             continue
 
-        # Rewrite the note's frontmatter via vault adapter
-        if notes_folder:
-            target = vault._resolve_folder(notes_folder) / f"{note_name}.md"
-        else:
-            found = list(vault.vault_path.rglob(f"{note_name}.md"))
-            target = found[0] if found else None
+        # Rewrite the note's frontmatter via vault adapter. The adapter's
+        # root is the resolved notes directory, so rglob finds the file
+        # regardless of whether the user uses local mode or an Obsidian vault.
+        found = list(vault.vault_path.rglob(f"{note_name}.md"))
+        target = found[0] if found else None
 
         if not target or not target.exists():
             skipped += 1
@@ -1364,8 +1354,7 @@ def import_vault(ctx, with_queue):
 
     # Reading queue from high-priority sources
     if with_queue:
-        notes_folder = cfg.obsidian.notes_folder
-        note_names = vault.list_notes(notes_folder)
+        note_names = vault.list_notes(None)
         queue_added = 0
         for note_name in note_names:
             if not note_name.startswith("@"):

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -304,8 +304,8 @@ class ZoteroConfig(BaseModel):
 
 class ObsidianConfig(BaseModel):
     vault_path: str = ""
-    notes_folder: str = "2 - Refs"
-    tags_folder: str = "3 - Tags"
+    notes_folder: str = ""
+    tags_folder: str = ""
     use_cli: Optional[bool] = None
 
 

--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -30,11 +30,41 @@ All Pydantic models for the data layer:
 
 ### pdf.py (202 lines)
 `PDFExtractor` — PyMuPDF-based text extraction with BBT JSON integration.
-- `extract()` — text with `[Page N]` markers, truncated to `max_chars`
+- `extract()` — text with `[Page N]` markers, truncated to `max_chars` (fed to the AI extraction prompt)
+- `extract_pages(pdf_path: Path) -> list[str]` — **public API, stable signature**. One cleaned string per page, no truncation, no inline `[Page N]` markers. Used by `write_pdf_sidecar()` and (planned) the semantic citation drift checker. Returns `[]` for missing files, `[""]` for an empty page.
 - `find_pdf()` — 3-tier PDF finding (see data flows below)
 - `load_pdf_lookup()` — citekey → pdf_path from BBT JSON
 - `load_entry_lookup()` — citekey → `ZoteroEntry` from BBT JSON
 - CamelCase splitting: `wagnerSeaiceInformation2020` → `[wagner, seaice, information, 2020]`
+
+### sidecar.py (~90 lines)
+Raw PDF text sidecar writer — feynman-style format at `<project_root>/.klemma/pdfs/<citekey>.md`. Introduced in ADR-016 as the on-disk trace of processed PDFs and the primary-source passage store for downstream tooling.
+- `write_pdf_sidecar(project_root, citekey, pages, metadata) -> Path` — atomic write via `tempfile.mkstemp` + `os.fdopen` + `os.replace`; rejects `..`, `/`, `\\`, empty citekeys (pattern mirrors `LocalFileStore._file_path()`); idempotent (reprocessing overwrites cleanly); creates missing `.klemma/pdfs/` directory
+
+**Format contracts** (must not drift without a version bump — the planned semantic citation drift checker is the second consumer):
+1. **Path**: always `<project_root>/.klemma/pdfs/<citekey>.md`. No config override. Downstream consumers can hardcode.
+2. **Page delimiter**: exactly `\n<!-- Page N -->\n` between pages, where `N = 2, 3, ...`. Page 1 has no marker — it starts right after the frontmatter `---`. Regex `\n<!-- Page (\d+) -->\n` is a stable split point.
+3. **Frontmatter fields**: stable set is `Citekey`, `Authors`, `Year`, `DOI`, `Pages`, `Source`. Additions allowed (append-only). Renames/removals require a version bump note in the sidecar header.
+
+Layout:
+```markdown
+# <title>
+
+> Citekey: <citekey>
+> Authors: <authors>
+> Year: <year>
+> DOI: <doi>
+> Pages: <N>
+> Source: <pdf_path>
+
+---
+
+<page 1 prose>
+
+<!-- Page 2 -->
+
+<page 2 prose>
+```
 
 ### note_factory.py (470 lines)
 Vault note creation pipeline — largest module in the package:

--- a/src/klemma/literature/note_factory.py
+++ b/src/klemma/literature/note_factory.py
@@ -452,9 +452,7 @@ def create_vault_note(
     body = render_note_body(entry, annotation=annotation)
     content = frontmatter + "\n\n" + body
 
-    path = vault.create_note(
-        f"@{citekey}", content, folder=config.obsidian.notes_folder
-    )
+    path = vault.create_note(f"@{citekey}", content)
 
     # 5. Register in DB
     if state is not None:

--- a/src/klemma/literature/pdf.py
+++ b/src/klemma/literature/pdf.py
@@ -94,25 +94,16 @@ class PDFExtractor:
         return lookup
 
     def extract(self, pdf_path: Path) -> Optional[str]:
-        """Extract text from PDF with page markers."""
-        if not pdf_path.exists():
-            return None
-        try:
-            doc = fitz.open(pdf_path)
-            pages_text = []
-            for page_num, page in enumerate(doc):
-                text = page.get_text("text")
-                text = self._clean_text(text)
-                pages_text.append(f"[Page {page_num + 1}]\n{text}")
-            doc.close()
+        """Extract text from PDF with page markers, truncated to `max_chars`.
 
-            combined = "\n\n".join(pages_text)
-            if len(combined) > self.max_chars:
-                combined = combined[: self.max_chars] + "\n\n[...content truncated...]"
-            return combined
-        except Exception as e:
-            print(f"PDF extraction error for {pdf_path}: {e}")
+        Thin formatter over `extract_pages()` — the single `fitz.open` call
+        lives there so callers that need both a page list and an AI-bound
+        string can reuse the result.
+        """
+        pages = self.extract_pages(pdf_path)
+        if not pages:
             return None
+        return self.format_for_ai(pages)
 
     def extract_pages(self, pdf_path: Path) -> list[str]:
         """Extract full text as one cleaned string per page.
@@ -121,14 +112,33 @@ class PDFExtractor:
         and does not insert inline `[Page N]` markers. The caller receives
         structured per-page content, suitable for sidecar generation and
         downstream citation-drift verification.
+
+        Returns `[]` for missing files or unreadable PDFs. Fitz errors are
+        caught and logged so the caller can fall through gracefully.
         """
         if not pdf_path.exists():
             return []
-        doc = fitz.open(pdf_path)
+        try:
+            doc = fitz.open(pdf_path)
+        except Exception as e:
+            print(f"PDF extraction error for {pdf_path}: {e}")
+            return []
         try:
             return [self._clean_text(page.get_text("text")) for page in doc]
         finally:
             doc.close()
+
+    def format_for_ai(self, pages: list[str]) -> str:
+        """Format extracted pages into `[Page N]`-marked, truncated text
+        suitable for the extraction prompt. Callers that already have a
+        `pages` list from `extract_pages()` use this to avoid re-opening
+        the PDF.
+        """
+        blocks = [f"[Page {i + 1}]\n{text}" for i, text in enumerate(pages)]
+        combined = "\n\n".join(blocks)
+        if len(combined) > self.max_chars:
+            combined = combined[: self.max_chars] + "\n\n[...content truncated...]"
+        return combined
 
     def _clean_text(self, text: str) -> str:
         text = text.replace("\x00", "")

--- a/src/klemma/literature/pdf.py
+++ b/src/klemma/literature/pdf.py
@@ -114,6 +114,22 @@ class PDFExtractor:
             print(f"PDF extraction error for {pdf_path}: {e}")
             return None
 
+    def extract_pages(self, pdf_path: Path) -> list[str]:
+        """Extract full text as one cleaned string per page.
+
+        Unlike `extract()`, this method does not truncate to `max_chars`
+        and does not insert inline `[Page N]` markers. The caller receives
+        structured per-page content, suitable for sidecar generation and
+        downstream citation-drift verification.
+        """
+        if not pdf_path.exists():
+            return []
+        doc = fitz.open(pdf_path)
+        try:
+            return [self._clean_text(page.get_text("text")) for page in doc]
+        finally:
+            doc.close()
+
     def _clean_text(self, text: str) -> str:
         text = text.replace("\x00", "")
         text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)

--- a/src/klemma/literature/sidecar.py
+++ b/src/klemma/literature/sidecar.py
@@ -1,0 +1,108 @@
+"""Raw PDF text sidecar writer.
+
+Produces a human-readable dump of a processed PDF alongside the
+structured fragments the AI extractor emits. The dump lands at
+``<project_root>/.klemma/pdfs/<citekey>.md`` and is a stable,
+regex-greppable format intended for two consumers:
+
+1. Humans debugging why a given fragment was (or wasn't) extracted.
+2. Downstream tooling (semantic citation drift checker) that needs
+   the primary-source text without re-opening the PDF.
+
+Three format contracts that downstream consumers may rely on:
+
+* The sidecar path is fixed at ``<project_root>/.klemma/pdfs/<citekey>.md``.
+* Pages are separated by exactly ``\\n<!-- Page N -->\\n`` (``N >= 2``).
+  Page 1 has no marker — it starts immediately after the ``---`` divider.
+* Frontmatter lines for ``Citekey``, ``Authors``, ``Year``, ``DOI``,
+  ``Pages``, and ``Source`` form the stable set. Additions are allowed;
+  renames or removals require a version bump note.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def _validate_citekey(citekey: str) -> None:
+    if not citekey or ".." in citekey or "/" in citekey or "\\" in citekey:
+        raise ValueError(f"Invalid citekey: {citekey!r}")
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(v) for v in value if v is not None and str(v))
+    return str(value)
+
+
+def _render_frontmatter(citekey: str, pages: int, metadata: Mapping[str, Any]) -> list[str]:
+    title = _format_value(metadata.get("title") or citekey)
+    lines = [
+        f"# {title}",
+        "",
+        f"> Citekey: {citekey}",
+        f"> Authors: {_format_value(metadata.get('authors'))}",
+        f"> Year: {_format_value(metadata.get('year'))}",
+        f"> DOI: {_format_value(metadata.get('doi'))}",
+        f"> Pages: {pages}",
+        f"> Source: {_format_value(metadata.get('source'))}",
+        "",
+        "---",
+        "",
+    ]
+    return lines
+
+
+def _render_body(pages: list[str]) -> str:
+    if not pages:
+        return ""
+    chunks: list[str] = [pages[0].rstrip()]
+    for page_num, page_text in enumerate(pages[1:], start=2):
+        chunks.append(f"<!-- Page {page_num} -->")
+        chunks.append(page_text.rstrip())
+    return "\n\n".join(chunks) + "\n"
+
+
+def write_pdf_sidecar(
+    project_root: Path,
+    citekey: str,
+    pages: list[str],
+    metadata: Mapping[str, Any],
+) -> Path:
+    """Write a raw PDF sidecar for ``citekey`` under ``project_root``.
+
+    The write is atomic: content is staged in a temp file next to the
+    final destination and swapped in via ``os.replace``. Reprocessing a
+    source overwrites the existing sidecar cleanly.
+    """
+    _validate_citekey(citekey)
+
+    pdfs_dir = Path(project_root) / ".klemma" / "pdfs"
+    pdfs_dir.mkdir(parents=True, exist_ok=True)
+
+    target = pdfs_dir / f"{citekey}.md"
+
+    header = "\n".join(_render_frontmatter(citekey, len(pages), metadata))
+    body = _render_body(pages)
+    content = header + body
+
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{citekey}.", suffix=".md.tmp", dir=str(pdfs_dir)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(content)
+        os.replace(tmp_path, target)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+    return target

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -523,6 +523,11 @@ def init_project(
     klemma_dir = project_dir / ".klemma"
     klemma_dir.mkdir(parents=True, exist_ok=True)
     (klemma_dir / "data").mkdir(exist_ok=True)
+    # Default-local note + PDF sidecar locations. Always created so that
+    # `klemma process` can write annotated notes and raw sidecars without
+    # any vault configuration.
+    (klemma_dir / "notes").mkdir(exist_ok=True)
+    (klemma_dir / "pdfs").mkdir(exist_ok=True)
 
     # Project config
     config_target = klemma_dir / "config.yaml"

--- a/src/klemma/skills/agent.py
+++ b/src/klemma/skills/agent.py
@@ -284,6 +284,13 @@ def build_agent_context(
         else Path(__file__).parent.parent.parent.parent / "prompts" / "agent.md"
     )
     raw = prompt_path.read_text(encoding="utf-8")
+    from ..vault import resolve_notes_root as _resolve_notes_root
+
+    notes_root = (
+        _resolve_notes_root(config, project_root)
+        if project_root
+        else Path(config.obsidian.vault_path or "")
+    )
     context = SandboxedEnvironment().from_string(raw).render(
         parent_context=parent_context,
         project_context=project_context,
@@ -304,7 +311,8 @@ def build_agent_context(
         fragment_stats=fragment_stats,
         today_plan=today_plan,
         next_reading=next_reading,
-        vault_path=config.obsidian.vault_path,
+        notes_root=str(notes_root),
+        vault_path=str(notes_root),
         today=date.today().isoformat(),
         language=config.ai.language,
         project_type=project_type,

--- a/src/klemma/vault.py
+++ b/src/klemma/vault.py
@@ -1,4 +1,12 @@
-"""Obsidian vault adapter — CLI with file I/O fallback."""
+"""Notes directory adapter — file I/O primary, Obsidian CLI for reads only.
+
+Since ADR-016 the adapter is re-rooted at the *resolved notes directory*
+(see ``resolve_notes_root``), not the Obsidian vault root. ``create_note``
+writes exclusively via file I/O so re-rooted adapters cannot produce a
+duplicate copy at the Obsidian vault root via the ``obsidian`` CLI —
+Obsidian auto-detects file changes on disk anyway. Read/search helpers
+still try the CLI first and fall back to file I/O.
+"""
 
 import json
 import shutil
@@ -121,19 +129,15 @@ class VaultAdapter:
     def create_note(
         self, name: str, content: str, folder: Optional[str] = None
     ) -> Path:
-        """Create or overwrite a note."""
-        if self.use_cli and not folder:
-            try:
-                subprocess.run(
-                    ["obsidian", "create", f"name={name}", f"content={content}", "silent"],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-            except Exception:
-                pass
+        """Create or overwrite a note.
 
-        # File I/O (always write to ensure file exists)
+        Writes authoritatively via file I/O inside the adapter root. The
+        ``obsidian create`` CLI path was removed in ADR-016: since the
+        adapter is re-rooted at the resolved notes directory, a CLI call
+        (which always targets the Obsidian vault root) would write a
+        second copy at the wrong location. Obsidian auto-detects file
+        changes on disk, so skipping the subprocess costs nothing.
+        """
         target_dir = self._resolve_folder(folder)
         target_dir.mkdir(parents=True, exist_ok=True)
         path = self._ensure_within_vault(target_dir / f"{name}.md")

--- a/src/klemma/vault.py
+++ b/src/klemma/vault.py
@@ -5,7 +5,33 @@ import shutil
 import subprocess
 from datetime import date
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .config import KlemmaConfig
+
+
+def resolve_notes_root(config: "KlemmaConfig", project_root: Path) -> Path:
+    """Resolve the directory that holds `@citekey.md` annotated notes.
+
+    Precedence (ADR for default-local notes):
+
+    1. When ``config.obsidian.vault_path`` is set, return
+       ``vault_path/notes_folder``. ``notes_folder`` may be empty, in
+       which case the resolved path is the vault root itself — this
+       preserves flat Obsidian layouts.
+    2. Otherwise, return ``project_root/.klemma/notes`` — the default
+       local location for fresh projects.
+
+    The returned path is not required to exist; callers that need
+    filesystem presence must ``mkdir`` themselves.
+    """
+    vault_path = (config.obsidian.vault_path or "").strip()
+    if vault_path:
+        notes_folder = (config.obsidian.notes_folder or "").strip()
+        base = Path(vault_path).expanduser()
+        return base / notes_folder if notes_folder else base
+    return Path(project_root) / ".klemma" / "notes"
 
 
 class VaultAdapter:
@@ -206,8 +232,8 @@ class VaultAdapter:
             return {}
         return self._parse_frontmatter(text)
 
-    def list_notes(self, folder: str) -> list[str]:
-        """List note names in a folder."""
+    def list_notes(self, folder: Optional[str] = None) -> list[str]:
+        """List note names in a folder (defaults to the adapter root)."""
         target_dir = self._resolve_folder(folder)
         if not target_dir.exists():
             return []

--- a/tests/test_frontmatter_phase1.py
+++ b/tests/test_frontmatter_phase1.py
@@ -183,13 +183,34 @@ class TestMigrateFrontmatter:
         assert result.exit_code == 0
         assert "skipped 1" in result.output
 
-    def test_no_vault_exits_nonzero(self, mock_ctx):
-        mock_ctx.vault = None
+    def test_migrates_in_local_notes_dir(self, tmp_path, mock_ctx):
+        """migrate-frontmatter works in local mode (.klemma/notes/) with no obsidian: config."""
+        from klemma.vault import VaultAdapter
+
+        notes_root = tmp_path / ".klemma" / "notes"
+        notes_root.mkdir(parents=True)
+        _make_vault_note(notes_root, "@local2024", {
+            "section": "3.1",
+            "chapter": 3,
+            "title": "Local-mode paper",
+        })
+
+        mock_ctx.vault = VaultAdapter(str(notes_root))
+        mock_ctx.config.obsidian.vault_path = ""
+        mock_ctx.config.obsidian.notes_folder = ""
+
         runner = CliRunner()
         with (
             patch("klemma.cli._get_context", return_value=mock_ctx),
             patch("klemma.cli._init_components", return_value=mock_ctx),
         ):
             result = runner.invoke(klemma_cli, ["migrate-frontmatter"])
-        assert result.exit_code != 0
-        assert "No Obsidian vault" in result.output
+
+        assert result.exit_code == 0
+
+        import yaml
+        text = (notes_root / "@local2024.md").read_text()
+        fm = yaml.safe_load(text.split("---")[1])
+        assert fm.get("sections") == ["3.1"]
+        assert fm.get("chapters") == [3]
+

--- a/tests/test_integration_three_tier.py
+++ b/tests/test_integration_three_tier.py
@@ -52,6 +52,11 @@ def _make_cfg(tmp_path: Path) -> MagicMock:
 def _make_pdf_extractor(pdf_path: Path) -> MagicMock:
     mock = MagicMock()
     mock.find_pdf.return_value = pdf_path
+    # `_process_single` calls `extract_pages()` then `format_for_ai()` —
+    # mock both so the AI-bound text path works under the fitz-reuse
+    # refactor (ADR-016).
+    mock.extract_pages.return_value = ["A" * 500]
+    mock.format_for_ai.return_value = "A" * 500
     mock.extract.return_value = "A" * 500
     return mock
 
@@ -391,3 +396,68 @@ class TestCrossProjectSharing:
         frags_b = state_b.get_fragments(source_id="smith2020")
         assert len(frags_b) == 1
         assert frags_b[0]["fragment_text"] == "Key finding"
+
+
+# ---------------------------------------------------------------------------
+# Sidecar integration — regression for DOI case-mismatch bug (ADR-016)
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarIntegration:
+    """`write_pdf_sidecar` is driven by `_process_single` with a real
+    `ZoteroEntry`; verifies the full roundtrip including the DOI field
+    (the Pydantic model stores it as `DOI`, uppercase).
+    """
+
+    def test_sidecar_contains_doi_from_zotero_entry(self, tmp_path):
+        from klemma.literature.models import Author, ZoteroEntry
+
+        pdf = _make_pdf(tmp_path)
+        ps, ul = _make_library_pair(tmp_path / "library.db")
+        state = _make_state(tmp_path / "state.db")
+        cfg = _make_cfg(tmp_path)
+
+        entry = ZoteroEntry(
+            id="smith2020",
+            title="Smith on sea ice",
+            author=[Author(family="Smith", given="A.")],
+            issued={"date-parts": [[2020]]},
+            DOI="10.1000/smith.sea-ice",
+        )
+        library = MagicMock()
+        library.entries = {"smith2020": entry}
+        library.pdf_paths = {}
+
+        fake_frag = MagicMock()
+        fake_frag.text = "Key finding"
+        fake_frag.type = "evidence"
+        fake_frag.page = 1
+        fake_frag.citation_intent = None
+        fake_result = MagicMock()
+        fake_result.fragments = [fake_frag]
+
+        project_root = tmp_path / "project"
+        klemma_home = project_root / ".klemma"
+        klemma_home.mkdir(parents=True)
+
+        with patch("klemma.skills.extractor.extract_fragments", return_value=fake_result):
+            with patch("klemma.skills.extractor.save_fragments_to_vault", return_value=None):
+                with patch("klemma.literature.metadata.lookup_s2", return_value=None):
+                    _process_single(
+                        citekey="smith2020",
+                        cfg=cfg,
+                        state=state,
+                        vault=MagicMock(),
+                        ai=MagicMock(),
+                        pdf_extractor=_make_pdf_extractor(pdf),
+                        library=library,
+                        quiet=True,
+                        paper_store=ps,
+                        user_library=ul,
+                        klemma_home=klemma_home,
+                    )
+
+        sidecar = project_root / ".klemma" / "pdfs" / "smith2020.md"
+        assert sidecar.exists()
+        text = sidecar.read_text(encoding="utf-8")
+        assert "> DOI: 10.1000/smith.sea-ice" in text

--- a/tests/test_interactive_init.py
+++ b/tests/test_interactive_init.py
@@ -164,6 +164,24 @@ class TestInitProjectWithValues:
         assert "zotero" not in cfg
         assert "obsidian" not in cfg
 
+    def test_creates_local_notes_and_pdfs_dirs(self, tmp_path):
+        """Default-local layout: .klemma/notes/ and .klemma/pdfs/ exist after init."""
+        from klemma.setup import InitValues, init_project
+
+        init_project(tmp_path, values=InitValues(title="Local-default"))
+
+        assert (tmp_path / ".klemma" / "notes").is_dir()
+        assert (tmp_path / ".klemma" / "pdfs").is_dir()
+
+    def test_local_default_has_no_obsidian_section(self, tmp_path):
+        """When values carry no vault_path, config.yaml must skip the obsidian block."""
+        from klemma.setup import InitValues, init_project
+
+        init_project(tmp_path, values=InitValues(title="No vault"))
+
+        cfg = yaml.safe_load((tmp_path / ".klemma" / "config.yaml").read_text()) or {}
+        assert "obsidian" not in cfg
+
     def test_no_values_uses_template(self, tmp_path):
         from klemma.setup import init_project
 

--- a/tests/test_literature_sidecar.py
+++ b/tests/test_literature_sidecar.py
@@ -1,0 +1,133 @@
+"""Tests for `klemma.literature.sidecar.write_pdf_sidecar`.
+
+Exercises the three stable format contracts downstream consumers rely on:
+path layout, `<!-- Page N -->` delimiter, frontmatter field set; plus
+atomic-write safety and citekey validation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from klemma.literature.sidecar import write_pdf_sidecar
+
+
+def _metadata() -> dict:
+    return {
+        "title": "Sea ice forecasting with perturbed parameters",
+        "authors": "Goessling H., Jung T.",
+        "year": 2018,
+        "doi": "10.1007/s00382-017-4025-y",
+        "source": "/tmp/goessling2018.pdf",
+    }
+
+
+def test_write_pdf_sidecar_creates_file(tmp_path: Path) -> None:
+    pages = [
+        "First page prose\nsecond line.",
+        "Methods section start.",
+        "Results and discussion.",
+    ]
+
+    target = write_pdf_sidecar(tmp_path, "goessling2018", pages, _metadata())
+
+    assert target == tmp_path / ".klemma" / "pdfs" / "goessling2018.md"
+    assert target.exists()
+    text = target.read_text(encoding="utf-8")
+
+    # Stable frontmatter fields
+    assert "# Sea ice forecasting with perturbed parameters" in text
+    assert "> Citekey: goessling2018" in text
+    assert "> Authors: Goessling H., Jung T." in text
+    assert "> Year: 2018" in text
+    assert "> DOI: 10.1007/s00382-017-4025-y" in text
+    assert "> Pages: 3" in text
+    assert "> Source: /tmp/goessling2018.pdf" in text
+
+    # Page 1 has no marker; pages 2+ delimited by `<!-- Page N -->`
+    assert "<!-- Page 1 -->" not in text
+    markers = re.findall(r"<!-- Page (\d+) -->", text)
+    assert markers == ["2", "3"]
+
+    # Content order preserved
+    assert text.index("First page prose") < text.index("<!-- Page 2 -->")
+    assert text.index("<!-- Page 2 -->") < text.index("Methods section start.")
+    assert text.index("Methods section start.") < text.index("<!-- Page 3 -->")
+    assert text.index("<!-- Page 3 -->") < text.index("Results and discussion.")
+
+
+def test_write_pdf_sidecar_single_page_has_no_marker(tmp_path: Path) -> None:
+    target = write_pdf_sidecar(tmp_path, "single2020", ["only page"], _metadata())
+    text = target.read_text(encoding="utf-8")
+    assert "<!-- Page" not in text
+    assert "> Pages: 1" in text
+    assert "only page" in text
+
+
+def test_write_pdf_sidecar_atomic(tmp_path: Path) -> None:
+    """Simulate a write crash mid-flight: no partial file must remain."""
+    target_dir = tmp_path / ".klemma" / "pdfs"
+
+    def _boom(src: str, dst: str) -> None:  # noqa: ARG001
+        raise OSError("simulated crash")
+
+    with patch("klemma.literature.sidecar.os.replace", side_effect=_boom):
+        with pytest.raises(OSError, match="simulated crash"):
+            write_pdf_sidecar(tmp_path, "crashtest2021", ["page"], _metadata())
+
+    assert not (target_dir / "crashtest2021.md").exists()
+    leftovers = [p for p in target_dir.iterdir() if p.name.endswith(".md.tmp")]
+    assert leftovers == []
+
+
+def test_write_pdf_sidecar_idempotent(tmp_path: Path) -> None:
+    write_pdf_sidecar(tmp_path, "repeat2022", ["v1 page"], _metadata())
+    second = write_pdf_sidecar(tmp_path, "repeat2022", ["v2 page"], _metadata())
+
+    text = second.read_text(encoding="utf-8")
+    assert "v2 page" in text
+    assert "v1 page" not in text
+
+    pdfs_dir = tmp_path / ".klemma" / "pdfs"
+    files = sorted(p.name for p in pdfs_dir.iterdir())
+    assert files == ["repeat2022.md"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "..", "../evil", "a/b", "c\\d", "..\\sneaky"],
+)
+def test_write_pdf_sidecar_rejects_bad_citekey(tmp_path: Path, bad: str) -> None:
+    with pytest.raises(ValueError, match="Invalid citekey"):
+        write_pdf_sidecar(tmp_path, bad, ["page"], _metadata())
+
+
+def test_write_pdf_sidecar_creates_missing_directories(tmp_path: Path) -> None:
+    nested = tmp_path / "fresh_project"
+    assert not (nested / ".klemma").exists()
+    target = write_pdf_sidecar(nested, "fresh2024", ["page"], _metadata())
+    assert target.parent == nested / ".klemma" / "pdfs"
+    assert target.exists()
+
+
+def test_write_pdf_sidecar_handles_missing_metadata(tmp_path: Path) -> None:
+    target = write_pdf_sidecar(tmp_path, "minimal2023", ["page"], {})
+    text = target.read_text(encoding="utf-8")
+    # Falls back to citekey as title; missing fields render as em dash
+    assert "# minimal2023" in text
+    assert "> Authors: —" in text
+    assert "> Year: —" in text
+    assert "> DOI: —" in text
+    assert "> Source: —" in text
+
+
+def test_write_pdf_sidecar_file_permissions_preserved(tmp_path: Path) -> None:
+    """Atomic replace should leave the target readable/writable by the user."""
+    target = write_pdf_sidecar(tmp_path, "perms2020", ["page"], _metadata())
+    mode = os.stat(target).st_mode & 0o600
+    assert mode == 0o600

--- a/tests/test_pdf_extract_pages.py
+++ b/tests/test_pdf_extract_pages.py
@@ -1,0 +1,93 @@
+"""Tests for `PDFExtractor.extract_pages` — the unbounded per-page extractor
+consumed by the raw sidecar writer and, later, the citation-drift checker.
+
+The signature `(pdf_path: Path) -> list[str]` is part of the public API that
+downstream tooling relies on, so breakage here is a contract violation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fitz
+
+from klemma.literature.pdf import PDFExtractor
+
+
+def _write_pdf(path: Path, pages: list[str]) -> None:
+    doc = fitz.open()
+    for text in pages:
+        page = doc.new_page()
+        page.insert_text((72, 72), text, fontsize=11)
+    doc.save(str(path))
+    doc.close()
+
+
+def test_extract_pages_returns_one_per_page(tmp_path: Path) -> None:
+    pdf = tmp_path / "three_pages.pdf"
+    _write_pdf(
+        pdf,
+        [
+            "Introduction page with first paragraph.",
+            "Methods page describing experimental setup.",
+            "Results page with conclusions.",
+        ],
+    )
+
+    extractor = PDFExtractor()
+    pages = extractor.extract_pages(pdf)
+
+    assert len(pages) == 3
+    assert "Introduction" in pages[0]
+    assert "Methods" in pages[1]
+    assert "Results" in pages[2]
+    # No [Page N] inline markers — those belong to `extract()`, not this API.
+    for text in pages:
+        assert "[Page" not in text
+
+
+def test_extract_pages_missing_file_returns_empty() -> None:
+    extractor = PDFExtractor()
+    assert extractor.extract_pages(Path("/nonexistent/doc.pdf")) == []
+
+
+def test_extract_pages_no_truncation(tmp_path: Path) -> None:
+    """extract() truncates to max_chars; extract_pages() must not."""
+    pdf = tmp_path / "long.pdf"
+
+    # Build a single page with substantially more characters than max_chars.
+    long_line = "alpha beta gamma delta epsilon " * 50  # ~1500 chars per line
+    body = "\n".join(long_line for _ in range(30))  # ~45000 chars before wrapping
+    _write_pdf(pdf, [body])
+
+    extractor = PDFExtractor(max_chars=100)  # absurdly small cap
+    pages = extractor.extract_pages(pdf)
+
+    assert len(pages) == 1
+    # The per-page return is the full cleaned text, not the 100-char cap
+    assert len(pages[0]) > 1000
+    assert "content truncated" not in pages[0]
+
+
+def test_extract_pages_empty_pdf(tmp_path: Path) -> None:
+    pdf = tmp_path / "empty.pdf"
+    doc = fitz.open()
+    doc.new_page()  # a single empty page
+    doc.save(str(pdf))
+    doc.close()
+
+    extractor = PDFExtractor()
+    pages = extractor.extract_pages(pdf)
+
+    assert len(pages) == 1
+    assert pages[0] == ""
+
+
+def test_extract_pages_signature_is_list_of_str(tmp_path: Path) -> None:
+    """Lock in the downstream contract: return is always a list[str]."""
+    pdf = tmp_path / "one.pdf"
+    _write_pdf(pdf, ["single"])
+
+    result = PDFExtractor().extract_pages(pdf)
+    assert isinstance(result, list)
+    assert all(isinstance(p, str) for p in result)

--- a/tests/test_vault_folder_validation.py
+++ b/tests/test_vault_folder_validation.py
@@ -24,18 +24,3 @@ def test_check_folder_missing(tmp_path: Path):
     assert adapter.check_folder("References") is False
 
 
-def test_init_warns_missing_notes_folder(tmp_path: Path):
-    """klemma init wizard warns when notes_folder does not exist in vault."""
-    from unittest.mock import MagicMock
-
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    # No "References" subfolder created — should trigger warning
-
-    # Simulate the validation logic from _run_wizard
-    values = MagicMock()
-    values.vault_path = str(vault)
-    values.notes_folder = "References"
-
-    notes_dir = Path(values.vault_path) / values.notes_folder
-    assert not notes_dir.is_dir(), "Precondition: notes_folder should not exist"

--- a/tests/test_vault_resolve.py
+++ b/tests/test_vault_resolve.py
@@ -1,0 +1,62 @@
+"""Tests for `klemma.vault.resolve_notes_root` — the single source of truth
+for where annotated `@citekey.md` notes land. Local default, Obsidian vault
+override, and the flat-vault edge case are the three shapes to lock in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from klemma.config import KlemmaConfig, ObsidianConfig
+from klemma.vault import resolve_notes_root
+
+
+def _cfg(**obsidian_kwargs) -> KlemmaConfig:
+    cfg = KlemmaConfig()
+    cfg.obsidian = ObsidianConfig(**obsidian_kwargs)
+    return cfg
+
+
+def test_resolve_notes_root_default(tmp_path: Path) -> None:
+    project_root = tmp_path / "my_project"
+    project_root.mkdir()
+
+    cfg = _cfg()
+    result = resolve_notes_root(cfg, project_root)
+
+    assert result == project_root / ".klemma" / "notes"
+
+
+def test_resolve_notes_root_obsidian_with_folder(tmp_path: Path) -> None:
+    vault = tmp_path / "obsidian_vault"
+    vault.mkdir()
+
+    cfg = _cfg(vault_path=str(vault), notes_folder="References")
+    result = resolve_notes_root(cfg, tmp_path / "ignored_project")
+
+    assert result == vault / "References"
+
+
+def test_resolve_notes_root_obsidian_flat_vault(tmp_path: Path) -> None:
+    vault = tmp_path / "flat_vault"
+    vault.mkdir()
+
+    cfg = _cfg(vault_path=str(vault), notes_folder="")
+    result = resolve_notes_root(cfg, tmp_path / "ignored_project")
+
+    assert result == vault
+
+
+def test_resolve_notes_root_expands_tilde(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = _cfg(vault_path="~/vault", notes_folder="Refs")
+    result = resolve_notes_root(cfg, tmp_path / "project")
+    assert result == tmp_path / "vault" / "Refs"
+
+
+def test_resolve_notes_root_whitespace_only_vault_path_uses_local(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    cfg = _cfg(vault_path="   ", notes_folder="References")
+    result = resolve_notes_root(cfg, project_root)
+    assert result == project_root / ".klemma" / "notes"


### PR DESCRIPTION
## Summary

Flip the annotated-note default to project-local `.klemma/notes/` and introduce a feynman-style raw PDF sidecar at `.klemma/pdfs/<citekey>.md`. Obsidian integration becomes an opt-in override for power users who read `@<citekey>.md` inside a vault.

Implementation follows the plan at `.claude/plans/stateless-tumbling-diffie.md` and the design is captured in ADR-016.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `python -m pytest tests/ -q` → 1653 passed, 1 skipped
- [x] Unit tests cover `resolve_notes_root()` (5), `PDFExtractor.extract_pages()` (5), `write_pdf_sidecar()` (9)
- [x] `migrate-frontmatter` has explicit local-mode test
- [x] `init_project()` local-default test asserts `.klemma/notes/` + `.klemma/pdfs/` exist and no `obsidian:` section in config.yaml

## Release Note

### Problem

`klemma init` asked every new user for an Obsidian vault path, notes folder, and tags folder — and hard-failed at `klemma process` when those were missing. In practice the vast majority of the researchers klemma serves have no Obsidian vault and no reason to set one up just to try the tool. Worse, once processing ran, the full PDF text was extracted into memory, fed to the AI for fragment extraction, and discarded. There was no on-disk trace of what the AI actually saw — nothing to grep, diff, or debug when a fragment looked wrong, and no cheap primary-source passage store for downstream tools like the planned semantic citation drift checker.

### Academic Foundation

The sidecar format is inspired by feynman's `/lit` dump (see `memory/project_competitor_feynman.md`): flat prose with `<!-- Page N -->` markers + a small frontmatter block. That format has demonstrated itself as effective for grep-level workflows in a horizontal-scope research agent, and pairing it with klemma's project-scoped storage gives the vertical-scope dissertation tool a debugging surface without adding complexity. ADR-013 (KLEMMA.md single source) and ADR-014 (three-tier library split) set the precedent of keeping project-level artifacts inside `.klemma/`; ADR-016 extends that pattern to raw PDF traces.

### Implementation

**Default-local layout.** `klemma init` no longer prompts for `vault_path`/`notes_folder`/`tags_folder`. It pre-creates `.klemma/notes/` and `.klemma/pdfs/`. `ObsidianConfig` defaults are empty strings; the config block is only written to `config.yaml` when `values.vault_path` is explicitly set.

**`resolve_notes_root(config, project_root) -> Path`** is the new single source of truth for where annotated notes land. `VaultAdapter` is re-rooted at the resolved directory instead of the vault root — every call site drops the `folder=` argument. Resolver logic: vault_path set → `Path(vault_path).expanduser() / notes_folder`; otherwise → `project_root / .klemma / notes`.

**Raw PDF sidecars.** New module `src/klemma/literature/sidecar.py` with `write_pdf_sidecar()`: atomic write via `tempfile.mkstemp` + `os.fdopen` + `os.replace`, citekey validation mirrors `LocalFileStore._file_path()` (rejects `..`, `/`, `\\`, empty), idempotent, creates missing directory. `PDFExtractor.extract_pages()` is the unbounded per-page extractor that feeds the writer and (planned) the semantic citation drift checker.

**Three format contracts** are locked in ADR-016 for downstream consumers: the sidecar path is always `<project_root>/.klemma/pdfs/<citekey>.md`; the page delimiter is exactly `\n<!-- Page N -->\n` with N≥2; the frontmatter field set is `Citekey`/`Authors`/`Year`/`DOI`/`Pages`/`Source` (append-only).

**Mode-agnostic commands.** `migrate-frontmatter` and `import --with-queue` no longer hard-fail when `vault is None` — they always have a valid adapter pointing at the resolved notes root.

> **Release note warning for existing Obsidian users:** `vault.get_tags()`, `vault.search()`, and `vault._find_daily_dir()` used to scan the whole vault. They now scan only the notes directory (the adapter root). This matches how klemma actually uses these helpers (citekey-note operations + tag inventory of `@*.md`), but downstream scripts relying on whole-vault scans must move files into the notes folder or use a separate tool. Existing `obsidian.vault_path` / `notes_folder` layouts continue to work unchanged — the resolver feeds them into the adapter just as before.

### Results

- **1653 tests passing, 1 skipped**, ruff clean (+19 new tests: 9 sidecar, 5 resolver, 5 extract_pages, 2 init defaults, 1 migrate-frontmatter local mode, 1 frontmatter test removed as obsolete)
- **22 files changed**, +764 / −146 lines
- **1 new ADR** (ADR-016) documenting the three format contracts so the downstream semantic citation drift checker can hardcode against them
- **2 new modules**: `literature/sidecar.py` (~90 lines), `tests/test_literature_sidecar.py` (~170 lines)
- **Zero-prompt onboarding**: fresh `klemma init` asks only type/title/Zotero/AI backend