### PR TITLE
feat(embeddings): LiteLLM backend + BGE-M3/Ollama default + --remodel migration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,6 +79,25 @@ ai:
   # model: "ollama/llama3"
   # base_url: "http://localhost:11434"
 
+embeddings:
+  # --- LiteLLM + Ollama (recommended, single-billing) ------------------------
+  # Free, offline, strong on Russian. Keeps Anthropic as the only paid vendor.
+  # Setup (one-time): `ollama pull bge-m3`  (~1.2 GB, 1024-dim, 8k context)
+  backend: "litellm"
+  model: "ollama/bge-m3"
+  base_url: "http://localhost:11434"
+  # dim: 1024                          # optional; auto-detected on first call
+
+  # --- Alternatives (uncomment one) ------------------------------------------
+  # backend: "openai"
+  # model: "text-embedding-3-small"
+  # api_key_env: "OPENAI_API_KEY"
+  #
+  # backend: "s2"                      # Semantic Scholar free API (768d, English-centric)
+  #
+  # backend: "local"                   # sentence-transformers, no Ollama needed
+  # model: "allenai/specter2"
+
 state:
   db_path: "./data/klemma.db"          # relative to ~/.klemma/ or absolute
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -97,20 +97,43 @@ my-thesis/
 
 ### 2.6 Настройка embeddings (рекомендуется)
 
-Добавьте в `.klemma/config.yaml`:
+**Рекомендуемый вариант — LiteLLM + Ollama (бесплатно, офлайн, один биллинг):**
+
+```bash
+# Однократная установка
+brew install ollama   # или https://ollama.com/download
+ollama pull bge-m3    # ~1.2 GB, 1024-dim, 8k контекста, мультиязычный
+```
 
 ```yaml
+# .klemma/config.yaml
 embeddings:
-  backend: "s2"       # бесплатный Semantic Scholar API
+  backend: "litellm"
+  model: "ollama/bge-m3"
+  base_url: "http://localhost:11434"
 ```
+
+BGE-M3 силён на русском и других неанглийских языках, работает офлайн, и оставляет Anthropic единственным платным вендором — удобно для биллинга. LiteLLM-бэкенд поддерживает любую `provider/model` пару (Voyage, Cohere, Mistral, Ollama), так что перейти на другую модель — это правка конфига без кода.
 
 Это включает семантический поиск (`similar`), гибридное обнаружение источников и semantic gap scoring. Бэкенды:
 
 | Бэкенд | Стоимость | Требования | Качество |
 |--------|-----------|------------|----------|
-| `s2` | Бесплатно | Интернет | Хорошее (SPECTER 768-dim) |
+| `litellm` + `ollama/bge-m3` | Бесплатно | Ollama | Отличное (1024-dim, мультиязычный) |
+| `litellm` + `voyage/voyage-3` | Платно | API key | Отличное (1024-dim) |
+| `s2` | Бесплатно | Интернет | Хорошее (SPECTER 768-dim, English-centric) |
 | `local` | Бесплатно | GPU, `[local-embeddings]` | Хорошее (SPECTER2) |
 | `openai` | Платно | API key, `[openai]` | Отличное (1536-dim) |
+
+**Миграция с OpenAI/S2 на BGE-M3.** Если у вас уже есть источники с embeddings от другого бэкенда, переключите `embeddings:` и запустите `--remodel` — Klemma пересчитает векторы для всех строк, где `embedding_model` не совпадает с текущей моделью:
+
+```bash
+klemma embed sources --remodel
+klemma embed fragments --remodel
+klemma embed sections           # секционные центроиды пересчитываются автоматически
+```
+
+Старые векторы перезаписываются атомарно; источников без embedding миграция не касается.
 
 ### 2.7 Дополнительные AI-настройки
 

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -239,14 +239,18 @@ Provider-agnostic paper search — resolve reference gaps to acquisition targets
 - `ChainSearchProvider` — try providers in sequence, first hit wins. Default chain: CrossRef → S2
 - `create_search(config)` — factory: `"s2"`, `"crossref"`, `"auto"` (chain), `""` (disabled)
 
-### embeddings.py (268 lines)
-`EmbeddingProvider` runtime-checkable protocol + 3 backends + utilities.
+### embeddings.py (393 lines)
+`EmbeddingProvider` runtime-checkable protocol + 4 backends + utilities.
 - `EmbeddingProvider` protocol — `dim`, `model_name`, `embed(title, abstract) → list[float] | None`
 - `SemanticScholarEmbeddings` — free S2 API (768-dim SPECTER), rate-limited (throttle param)
 - `LocalSPECTEREmbeddings` — offline sentence-transformers SPECTER2 model
 - `OpenAIEmbeddings` — text-embedding-3-small (1536-dim)
-- `create_embeddings(config)` — factory, returns provider or None if disabled
+- `LiteLLMEmbeddings` — any `provider/model` supported by LiteLLM (Ollama/BGE-M3 recommended default, also Voyage, Cohere, Mistral, OpenAI). Auto-detects `dim` on first call; `model_name` stored as `"model-provider"` for uniqueness across providers. `api_base` passed through to `litellm.embedding()` for Ollama endpoints
+- `create_embeddings(config)` — factory, returns provider or None if disabled; supports `backend: "litellm"` with `model`, `base_url`, `api_key_env`, `timeout`, `dim`
+- `_derive_embedding_provider(model)` — local helper mirroring `config._derive_provider` to avoid circular import
 - `cosine_similarity(a, b)` — dot-product cosine similarity for float vectors
+
+The `embed sources|fragments|all` commands accept `--remodel` to re-embed rows whose `embedding_model` no longer matches the active provider (migration path for changing backends).
 
 ### discovery.py (260 lines)
 Auto-discovery for `klemma init` interactive wizard.

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1177,6 +1177,9 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
     # Step 2: LLM backend
     backend = ""
     ai_model = ""
+    # Default: LiteLLM + Ollama/BGE-M3 (free, local, single Anthropic billing).
+    # Users can downgrade to OpenAI embeddings only when they explicitly say so.
+    embeddings_backend = "litellm"
     if has_openai:
         click.echo("\n  LLM backend")
         click.echo("    1. Claude Code Max (free — uses claude CLI)")
@@ -1193,17 +1196,32 @@ def _interactive_init(project_type: str, prefill: dict | None = None):
         if llm_choice == "1":
             backend = "claude"
             ai_model = "sonnet"
-            click.echo("    LLM: Claude Code Max  |  Embeddings: OpenAI")
         else:
             backend = "litellm"
             ai_model = "openai/gpt-4.1"
-            click.echo("    LLM: OpenAI gpt-4.1  |  Embeddings: OpenAI")
+
+        click.echo("\n  Embeddings backend")
+        click.echo("    1. LiteLLM + Ollama (bge-m3) — free, offline, strong on Russian")
+        click.echo("    2. OpenAI text-embedding-3-small (uses the key above)")
+        emb_choice = click.prompt(
+            "  Choose",
+            type=click.Choice(["1", "2"]),
+            default="1",
+        )
+        if emb_choice == "1":
+            embeddings_backend = "litellm"
+            click.echo(f"    LLM: {ai_model}  |  Embeddings: LiteLLM + Ollama (bge-m3)")
+            click.echo("    (one-time setup: ollama pull bge-m3)")
+        else:
+            embeddings_backend = "openai"
+            click.echo(f"    LLM: {ai_model}  |  Embeddings: OpenAI text-embedding-3-small")
     else:
         backend = "claude"
         ai_model = "sonnet"
-        click.echo("    LLM: Claude Code Max  |  Embeddings: not configured (add later)")
-
-    embeddings_backend = "openai" if has_openai else ""
+        click.echo(
+            "    LLM: Claude Code Max  |  Embeddings: LiteLLM + Ollama (bge-m3)"
+        )
+        click.echo("    (one-time setup: ollama pull bge-m3)")
 
     # --- Auto-discovery (prefill overrides discovery) ---
     click.echo("\n  Detecting paths...")
@@ -1762,7 +1780,7 @@ def _resolve_emb(kctx, backend, dry_run):
     if not emb and not dry_run:
         console.print(
             "[red]No embedding backend configured.[/red]\n"
-            "Set embeddings.backend in config.yaml (s2, local, openai) "
+            "Set embeddings.backend in config.yaml (s2, local, openai, litellm) "
             "or use --backend flag."
         )
         return None

--- a/src/klemma/commands/process.py
+++ b/src/klemma/commands/process.py
@@ -215,18 +215,25 @@ main.add_command(embed)
 )
 @click.option(
     "--backend",
-    type=click.Choice(["s2", "local", "openai"]),
+    type=click.Choice(["s2", "local", "openai", "litellm"]),
     help="Override embedding backend",
 )
 @click.option(
     "--backfill", is_flag=True, help="Fetch missing abstracts from S2 before embedding"
 )
+@click.option(
+    "--remodel",
+    is_flag=True,
+    help="Also re-embed rows whose embedding_model differs from the current backend",
+)
 @click.pass_context
-def embed_sources(ctx, citekeys, dry_run, backend, backfill):
+def embed_sources(ctx, citekeys, dry_run, backend, backfill, remodel):
     """Embed source title+abstract vectors.
 
     Without CITEKEYS: embed all sources missing embeddings.
     With CITEKEYS: embed specific sources by citekey.
+    With --remodel: also re-embed sources whose stored embedding came
+    from a different model (used when switching providers).
     """
     kctx = _get_context(ctx)
     state = kctx.state
@@ -253,6 +260,15 @@ def embed_sources(ctx, citekeys, dry_run, backend, backfill):
             return
     else:
         candidates = state.get_sources_without_embeddings()
+        if remodel:
+            stale = state.get_sources_with_stale_model(emb.model_name)
+            if stale:
+                console.print(
+                    f"[dim]--remodel: {len(stale)} source(s) with stale "
+                    f"embedding_model will be re-embedded[/dim]"
+                )
+                seen = set(candidates)
+                candidates = list(candidates) + [ck for ck in stale if ck not in seen]
 
     if not candidates:
         console.print("[green]All sources already have embeddings.[/green]")
@@ -368,12 +384,21 @@ def embed_sources(ctx, citekeys, dry_run, backend, backfill):
 @click.option("--dry-run", is_flag=True, help="Preview without API calls")
 @click.option(
     "--backend",
-    type=click.Choice(["s2", "local", "openai"]),
+    type=click.Choice(["s2", "local", "openai", "litellm"]),
     help="Override embedding backend",
 )
+@click.option(
+    "--remodel",
+    is_flag=True,
+    help="Also re-embed fragments whose embedding_model differs from the current backend",
+)
 @click.pass_context
-def embed_fragments(ctx, dry_run, backend):
-    """Embed extracted fragment text vectors."""
+def embed_fragments(ctx, dry_run, backend, remodel):
+    """Embed extracted fragment text vectors.
+
+    With --remodel: also re-embed fragments whose stored embedding came
+    from a different model (used when switching providers).
+    """
     kctx = _get_context(ctx)
     state = kctx.state
     paper_store = kctx.paper_store
@@ -383,6 +408,15 @@ def embed_fragments(ctx, dry_run, backend):
         return
 
     candidates = state.get_unembedded_fragments()
+    if remodel:
+        stale = state.get_fragments_with_stale_model(emb.model_name)
+        if stale:
+            console.print(
+                f"[dim]--remodel: {len(stale)} fragment(s) with stale "
+                f"embedding_model will be re-embedded[/dim]"
+            )
+            seen_ids = {f["id"] for f in candidates}
+            candidates = list(candidates) + [f for f in stale if f["id"] not in seen_ids]
     if not candidates:
         console.print("[green]All fragments already have embeddings.[/green]")
         return
@@ -475,12 +509,17 @@ def embed_fragments(ctx, dry_run, backend):
 @click.option("--dry-run", is_flag=True, help="Preview without writing to DB")
 @click.option(
     "--backend",
-    type=click.Choice(["s2", "local", "openai"]),
+    type=click.Choice(["s2", "local", "openai", "litellm"]),
     help="Override embedding backend",
 )
 @click.pass_context
 def embed_sections(ctx, dry_run, backend):
-    """Compute section centroid embeddings from source vectors."""
+    """Compute section centroid embeddings from source vectors.
+
+    Centroids are re-computed from the source vectors already stored, so
+    ``--remodel`` at this layer would be a no-op — re-run ``embed sources
+    --remodel`` first and then invoke ``embed sections``.
+    """
     kctx = _get_context(ctx)
     state = kctx.state
     emb = _resolve_emb(kctx, backend, dry_run)
@@ -533,16 +572,21 @@ def embed_sections(ctx, dry_run, backend):
 @click.option("--dry-run", is_flag=True, help="Preview without API calls")
 @click.option(
     "--backend",
-    type=click.Choice(["s2", "local", "openai"]),
+    type=click.Choice(["s2", "local", "openai", "litellm"]),
     help="Override embedding backend",
 )
+@click.option(
+    "--remodel",
+    is_flag=True,
+    help="Forward --remodel to the sources and fragments sub-steps",
+)
 @click.pass_context
-def embed_all(ctx, dry_run, backend):
+def embed_all(ctx, dry_run, backend, remodel):
     """Run sources \u2192 fragments \u2192 sections in sequence."""
     console.print("[dim]Step 1/3: sources[/dim]")
-    ctx.invoke(embed_sources, dry_run=dry_run, backend=backend)
+    ctx.invoke(embed_sources, dry_run=dry_run, backend=backend, remodel=remodel)
     console.print("\n[dim]Step 2/3: fragments[/dim]")
-    ctx.invoke(embed_fragments, dry_run=dry_run, backend=backend)
+    ctx.invoke(embed_fragments, dry_run=dry_run, backend=backend, remodel=remodel)
     console.print("\n[dim]Step 3/3: sections[/dim]")
     ctx.invoke(embed_sections, dry_run=dry_run, backend=backend)
 

--- a/src/klemma/config.py
+++ b/src/klemma/config.py
@@ -343,11 +343,13 @@ class AIConfig(BaseModel):
 
 
 class EmbeddingsConfig(BaseModel):
-    backend: str = ""  # "s2" | "local" | "openai" | "" (disabled)
-    model: str = ""  # model id (backend-specific)
+    backend: str = ""  # "s2" | "local" | "openai" | "litellm" | "" (disabled)
+    model: str = ""  # model id (backend-specific; litellm: "provider/model")
     api_key_env: str = ""  # env var for API key
-    base_url: Optional[str] = None  # custom endpoint (OpenAI only)
+    base_url: Optional[str] = None  # custom endpoint (OpenAI or LiteLLM/Ollama)
     throttle: float = 3.1  # seconds between S2 API requests
+    timeout: int = 60  # request timeout (litellm backend)
+    dim: Optional[int] = None  # explicit dim override (litellm; auto-detected otherwise)
 
 
 class SearchConfig(BaseModel):

--- a/src/klemma/embeddings.py
+++ b/src/klemma/embeddings.py
@@ -4,6 +4,7 @@ Protocol-based abstraction supporting multiple backends:
 - SemanticScholar: Free S2 API (768-dim SPECTER)
 - Local SPECTER: sentence-transformers allenai/specter2
 - OpenAI: text-embedding-3-small (1536-dim)
+- LiteLLM: any LiteLLM-compatible model (Ollama/BGE-M3, Voyage, Cohere, …)
 
 Install optional deps: pip install klemma[embeddings]
 """
@@ -223,6 +224,103 @@ class OpenAIEmbeddings:
 
 
 # ---------------------------------------------------------------------------
+# LiteLLM Embeddings (any provider/model via litellm.embedding())
+# ---------------------------------------------------------------------------
+
+
+def _derive_embedding_provider(model: str) -> str:
+    """Extract provider name from a LiteLLM embedding model string.
+
+    Mirrors `config._derive_provider` but lives here to avoid a circular
+    import (`embeddings.py` is loaded before `config.py` fully initialises).
+
+    Examples:
+        "ollama/bge-m3" → "ollama"
+        "voyage/voyage-3-large" → "voyage"
+        "cohere/embed-multilingual-v3.0" → "cohere"
+        "openai/text-embedding-3-small" → "openai"
+        "text-embedding-3-small" (bare) → "openai"
+    """
+    if "/" in model:
+        return model.split("/", 1)[0]
+    return "openai"
+
+
+class LiteLLMEmbeddings:
+    """Embedding provider that delegates to ``litellm.embedding()``.
+
+    Single adapter for every LiteLLM-compatible embedding endpoint:
+    Ollama (local), Voyage, Cohere, OpenAI, … Model format is
+    ``provider/model`` (e.g. ``ollama/bge-m3``); bare strings are treated
+    as OpenAI models by ``_derive_embedding_provider``.
+
+    Dimension is auto-detected on the first successful call (or taken from
+    the optional ``dim`` kwarg before then).
+    """
+
+    dim: int = 0  # populated on first successful embed() or from kwarg
+    model_name: str = ""
+
+    def __init__(
+        self,
+        model: str,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: int = 60,
+        dim: Optional[int] = None,
+    ):
+        try:
+            import litellm as _litellm
+        except ImportError:
+            raise ImportError(
+                "LiteLLM embedding backend requires the 'litellm' package. "
+                "Install with: pip install klemma[litellm]"
+            )
+        self._litellm = _litellm
+        self.model = model
+        self.api_base = api_base
+        self.api_key = api_key
+        self.timeout = timeout
+        if dim is not None:
+            self.dim = dim
+        # model_name: "provider/model" → "model-provider" for uniqueness
+        # across providers offering the same model id.
+        if "/" in model:
+            provider, name = model.split("/", 1)
+            self.model_name = f"{name}-{provider}"
+        else:
+            self.model_name = model
+
+    def embed(self, title: str, abstract: str = "") -> Optional[list[float]]:
+        """Embed a paper via ``litellm.embedding()``.
+
+        Text format is ``f"{title}\\n{abstract}".strip()`` — no ``[SEP]``
+        token, since BGE-M3 and most modern embedding models work on
+        natural-language strings directly.
+        """
+        text = f"{title}\n{abstract}".strip()
+        if not text:
+            return None
+        try:
+            response = self._litellm.embedding(
+                model=self.model,
+                input=[text],
+                api_base=self.api_base,
+                api_key=self.api_key,
+                timeout=self.timeout,
+            )
+            vec = response.data[0]["embedding"]
+            if not vec:
+                logger.warning("LiteLLM embed returned empty vector for '%s'", title[:60])
+                return None
+            self.dim = len(vec)
+            return list(vec)
+        except Exception as e:
+            logger.warning("LiteLLM embed error for '%s': %s", title[:60], e)
+            return None
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -234,11 +332,13 @@ def create_embeddings(
     """Create an EmbeddingProvider from config dict.
 
     Config keys:
-        backend: "s2" | "local" | "openai" (default: "s2")
-        model: model name/id (optional, backend-specific)
+        backend: "s2" | "local" | "openai" | "litellm" (default: "s2")
+        model: model name/id (backend-specific; litellm: "provider/model")
         api_key_env: env var for API key (optional)
-        base_url: custom endpoint (OpenAI only)
+        base_url: custom endpoint (OpenAI or LiteLLM/Ollama)
         throttle: seconds between S2 requests (default: 3.1)
+        timeout: request timeout in seconds (litellm only, default: 60)
+        dim: explicit dimension override (litellm only; otherwise auto-detected)
 
     api_keys: optional dict from klemmarc (e.g. {"openai": "sk-..."}).
     Direct keys take priority over env vars.
@@ -270,6 +370,23 @@ def create_embeddings(
             api_key_env=config.get("api_key_env", "OPENAI_API_KEY"),
             base_url=config.get("base_url"),
             api_key=api_keys.get("openai"),
+        )
+
+    if backend == "litellm":
+        model = config.get("model", "ollama/bge-m3")
+        provider = _derive_embedding_provider(model)
+        api_key = api_keys.get(provider)
+        if not api_key:
+            env_var = config.get("api_key_env")
+            if env_var:
+                api_key = os.environ.get(env_var)
+        # Pure-local providers (ollama) accept api_key=None; LiteLLM handles it.
+        return LiteLLMEmbeddings(
+            model=model,
+            api_base=config.get("base_url"),
+            api_key=api_key,
+            timeout=int(config.get("timeout", 60)),
+            dim=config.get("dim"),
         )
 
     logger.warning("Unknown embedding backend: %s", backend)

--- a/src/klemma/repositories/fragments.py
+++ b/src/klemma/repositories/fragments.py
@@ -246,6 +246,26 @@ class FragmentRepository(BaseRepository):
             )
             return [dict(row) for row in cur.fetchall()]
 
+    def get_fragments_with_stale_model(
+        self, current_model: str, limit: int = 100000,
+    ) -> list[dict]:
+        """Get fragments whose embedding came from a different model.
+
+        Used by ``klemma embed fragments --remodel``. Row shape matches
+        ``get_unembedded_fragments`` so the embedding loop is unchanged.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT f.id, f.source_id, f.fragment_text, f.page_number, s.id as citekey
+                   FROM fragments f
+                   JOIN sources s ON f.source_id = s.id
+                   WHERE f.embedding IS NOT NULL
+                     AND (f.embedding_model IS NULL OR f.embedding_model != ?)
+                   LIMIT ?""",
+                (current_model, limit),
+            )
+            return [dict(row) for row in cur.fetchall()]
+
     # ── Reassign skips ─────────────────────────────────────────────────
 
     def save_reassign_skip(

--- a/src/klemma/repositories/sources.py
+++ b/src/klemma/repositories/sources.py
@@ -252,6 +252,23 @@ class SourceRepository(BaseRepository):
             )
             return [row["id"] for row in cur]
 
+    def get_sources_with_stale_model(self, current_model: str) -> list[str]:
+        """Return citekeys whose embedding came from a different model.
+
+        Used by ``klemma embed sources --remodel`` when switching embedding
+        providers (e.g. OpenAI → BGE-M3): existing rows must be re-embedded
+        so every vector lives in the same space.
+        """
+        with self._conn() as conn:
+            cur = conn.execute(
+                """SELECT id FROM sources
+                   WHERE status='completed'
+                     AND embedding IS NOT NULL
+                     AND (embedding_model IS NULL OR embedding_model != ?)""",
+                (current_model,),
+            )
+            return [row["id"] for row in cur]
+
     def get_stats(self) -> dict[str, int]:
         with self._conn() as conn:
             stats = {}

--- a/src/klemma/setup.py
+++ b/src/klemma/setup.py
@@ -34,7 +34,7 @@ class InitValues:
     backend: str = ""          # "claude" | "litellm" | "" (use klemmarc default)
     ai_model: str = ""         # model name for project config (e.g. "sonnet", "openai/gpt-4.1")
     openai_api_key: str = ""   # OpenAI key to save in ~/.klemmarc.yaml
-    embeddings_backend: str = ""  # "openai" | "s2" | "" (derive from openai_api_key)
+    embeddings_backend: str = ""  # "openai" | "s2" | "local" | "litellm" | "" (derive)
     plan_data: Any = None         # PlanData from plan_parser (transient, not serialized)
 
     def __post_init__(self):
@@ -102,7 +102,13 @@ def _build_project_config(values: InitValues, *, has_parent: bool = False) -> di
     emb_backend = values.embeddings_backend
     if not emb_backend and values.openai_api_key:
         emb_backend = "openai"
-    if emb_backend == "openai":
+    if emb_backend == "litellm":
+        cfg["embeddings"] = {
+            "backend": "litellm",
+            "model": "ollama/bge-m3",
+            "base_url": "http://localhost:11434",
+        }
+    elif emb_backend == "openai":
         cfg["embeddings"] = {"backend": "openai", "model": "text-embedding-3-small"}
     elif emb_backend == "s2":
         cfg["embeddings"] = {"backend": "s2"}

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -551,6 +551,9 @@ class StateManager:
     def get_sources_without_embeddings(self) -> list[str]:
         return self.sources.get_sources_without_embeddings()
 
+    def get_sources_with_stale_model(self, current_model: str) -> list[str]:
+        return self.sources.get_sources_with_stale_model(current_model)
+
     def get_stats(self) -> dict[str, int]:
         return self.sources.get_stats()
 
@@ -621,6 +624,11 @@ class StateManager:
 
     def get_unembedded_fragments(self, limit: int = 100000) -> list[dict]:
         return self.fragments.get_unembedded_fragments(limit)
+
+    def get_fragments_with_stale_model(
+        self, current_model: str, limit: int = 100000,
+    ) -> list[dict]:
+        return self.fragments.get_fragments_with_stale_model(current_model, limit)
 
     def save_reassign_skip(self, source_id: str, from_section: str, to_section: str):
         return self.fragments.save_reassign_skip(source_id, from_section, to_section)

--- a/tests/test_cli_embed.py
+++ b/tests/test_cli_embed.py
@@ -331,3 +331,111 @@ def test_embed_sources_dedup_from_library(tmp_path):
 
     all_emb = sm.get_all_embeddings()
     assert "paper1" in all_emb
+
+
+def test_embed_sources_remodel_includes_stale(tmp_path):
+    """--remodel adds sources with different embedding_model to the candidate list."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["stale1", "fresh1"])
+    sm.mark_completed("stale1", "")
+    sm.mark_completed("fresh1", "")
+    # Stale row: stored under old model name; fresh row: already under new name.
+    sm.save_embedding("stale1", [0.1, 0.2], "text-embedding-3-small")
+    sm.save_embedding("fresh1", [0.3, 0.4], "bge-m3-ollama")
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "bge-m3-ollama"
+    mock_emb.embed.return_value = [0.9, 0.8]
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.embeddings = mock_emb
+    mock_ctx.paper_store = None
+    mock_ctx.user_library = None
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = MagicMock()
+    mock_ctx.library.entries = {}
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["embed", "sources", "--remodel"])
+
+    assert result.exit_code == 0, result.output
+    assert "stale embedding_model" in result.output
+    # stale1 is re-embedded; fresh1 already has current model and is skipped
+    assert mock_emb.embed.call_count == 1
+    _, model = sm.get_embedding("stale1")
+    assert model == "bge-m3-ollama"
+
+
+def test_embed_sources_no_remodel_leaves_stale(tmp_path):
+    """Without --remodel, sources with stale embedding_model are NOT re-embedded."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["stale1"])
+    sm.mark_completed("stale1", "")
+    sm.save_embedding("stale1", [0.1, 0.2], "text-embedding-3-small")
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "bge-m3-ollama"
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.embeddings = mock_emb
+    mock_ctx.paper_store = None
+    mock_ctx.user_library = None
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = MagicMock()
+    mock_ctx.library.entries = {}
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["embed", "sources"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_emb.embed.call_count == 0
+    _, model = sm.get_embedding("stale1")
+    assert model == "text-embedding-3-small"
+
+
+def test_embed_fragments_remodel_includes_stale(tmp_path):
+    """--remodel adds fragments whose embedding_model differs from current backend."""
+    db = tmp_path / ".klemma" / "state.db"
+    db.parent.mkdir(parents=True)
+    sm = StateManager(db)
+    sm.register_sources(["paper1"])
+    sm.mark_completed("paper1", "")
+    sm.save_fragments("paper1", [{"text": "Stale fragment", "type": "result"}])
+
+    # Seed a stale embedding on the only fragment
+    frag = sm.get_unembedded_fragments()[0]
+    sm.save_fragment_embedding(frag["id"], [0.1, 0.2], "text-embedding-3-small")
+
+    mock_emb = MagicMock()
+    mock_emb.model_name = "bge-m3-ollama"
+    mock_emb.embed.return_value = [0.9, 0.8]
+
+    mock_ctx = MagicMock()
+    mock_ctx.state = sm
+    mock_ctx.embeddings = mock_emb
+    mock_ctx.paper_store = None
+    mock_ctx.user_library = None
+    mock_ctx.config = MagicMock()
+    mock_ctx.library = None
+
+    runner = CliRunner()
+    with patch("klemma.cli.discover_project_root", return_value=tmp_path), \
+         patch("klemma.cli._init_components", return_value=mock_ctx), \
+         patch("klemma.cli._get_context", return_value=mock_ctx):
+        result = runner.invoke(klemma_cli, ["embed", "fragments", "--remodel"])
+
+    assert result.exit_code == 0, result.output
+    assert "stale embedding_model" in result.output
+    assert mock_emb.embed.call_count == 1

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,12 +1,16 @@
 """Tests for embedding providers and utilities."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from klemma.embeddings import (
     EmbeddingProvider,
+    LiteLLMEmbeddings,
     LocalSPECTEREmbeddings,
     OpenAIEmbeddings,
     SemanticScholarEmbeddings,
+    _derive_embedding_provider,
     cosine_similarity,
     create_embeddings,
 )
@@ -80,6 +84,136 @@ class TestCreateEmbeddings:
             "model": "text-embedding-ada-002",
         })
         assert provider.model_name == "text-embedding-ada-002"
+
+    def test_litellm_backend(self):
+        provider = create_embeddings({
+            "backend": "litellm",
+            "model": "ollama/bge-m3",
+            "base_url": "http://localhost:11434",
+        })
+        assert provider is not None
+        assert isinstance(provider, LiteLLMEmbeddings)
+        assert provider.model == "ollama/bge-m3"
+        assert provider.api_base == "http://localhost:11434"
+        assert provider.model_name == "bge-m3-ollama"
+
+    def test_litellm_backend_default_model(self):
+        provider = create_embeddings({"backend": "litellm"})
+        assert isinstance(provider, LiteLLMEmbeddings)
+        assert provider.model == "ollama/bge-m3"
+
+    def test_litellm_backend_api_key_from_dict(self):
+        provider = create_embeddings(
+            {"backend": "litellm", "model": "voyage/voyage-3-large"},
+            api_keys={"voyage": "pa-test-key"},
+        )
+        assert isinstance(provider, LiteLLMEmbeddings)
+        assert provider.api_key == "pa-test-key"
+
+    def test_litellm_backend_custom_timeout(self):
+        provider = create_embeddings({
+            "backend": "litellm",
+            "model": "ollama/bge-m3",
+            "timeout": 120,
+        })
+        assert provider.timeout == 120
+
+    def test_litellm_backend_explicit_dim(self):
+        provider = create_embeddings({
+            "backend": "litellm",
+            "model": "ollama/bge-m3",
+            "dim": 1024,
+        })
+        assert provider.dim == 1024
+
+
+class TestDeriveEmbeddingProvider:
+    """Tests for _derive_embedding_provider."""
+
+    def test_ollama(self):
+        assert _derive_embedding_provider("ollama/bge-m3") == "ollama"
+
+    def test_voyage(self):
+        assert _derive_embedding_provider("voyage/voyage-3-large") == "voyage"
+
+    def test_cohere(self):
+        assert _derive_embedding_provider("cohere/embed-multilingual-v3.0") == "cohere"
+
+    def test_openai_slash(self):
+        assert _derive_embedding_provider("openai/text-embedding-3-small") == "openai"
+
+    def test_openai_bare(self):
+        assert _derive_embedding_provider("text-embedding-3-small") == "openai"
+
+
+class TestLiteLLMEmbeddings:
+    """Tests for LiteLLMEmbeddings class (mocked litellm.embedding)."""
+
+    def _make_response(self, vec):
+        response = MagicMock()
+        response.data = [{"embedding": vec}]
+        return response
+
+    def test_model_name_ollama(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        assert p.model_name == "bge-m3-ollama"
+
+    def test_model_name_voyage(self):
+        p = LiteLLMEmbeddings("voyage/voyage-3-large")
+        assert p.model_name == "voyage-3-large-voyage"
+
+    def test_model_name_bare(self):
+        p = LiteLLMEmbeddings("text-embedding-3-small")
+        assert p.model_name == "text-embedding-3-small"
+
+    def test_embed_success(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3", api_base="http://localhost:11434")
+        p._litellm = MagicMock()
+        p._litellm.embedding.return_value = self._make_response([0.1, 0.2, 0.3])
+        vec = p.embed("Test title", "Test abstract")
+        assert vec == [0.1, 0.2, 0.3]
+        assert p.dim == 3
+        call_kwargs = p._litellm.embedding.call_args.kwargs
+        assert call_kwargs["model"] == "ollama/bge-m3"
+        assert call_kwargs["api_base"] == "http://localhost:11434"
+        assert call_kwargs["input"] == ["Test title\nTest abstract"]
+
+    def test_embed_title_only(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        p._litellm.embedding.return_value = self._make_response([0.5, 0.5])
+        p.embed("Only title")
+        call_kwargs = p._litellm.embedding.call_args.kwargs
+        assert call_kwargs["input"] == ["Only title"]
+
+    def test_embed_empty_input_returns_none(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        assert p.embed("", "") is None
+        p._litellm.embedding.assert_not_called()
+
+    def test_embed_error_returns_none(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        p._litellm.embedding.side_effect = ConnectionError("ollama down")
+        assert p.embed("title") is None
+
+    def test_embed_empty_vector_returns_none(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        p._litellm.embedding.return_value = self._make_response([])
+        assert p.embed("title") is None
+
+    def test_dim_updates_on_success(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3", dim=999)
+        p._litellm = MagicMock()
+        p._litellm.embedding.return_value = self._make_response([0.0] * 1024)
+        p.embed("title")
+        assert p.dim == 1024
+
+    def test_is_embedding_provider(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        assert isinstance(p, EmbeddingProvider)
 
 
 class TestProtocolCompliance:


### PR DESCRIPTION
## Summary

- New `LiteLLMEmbeddings` backend — any `provider/model` supported by LiteLLM (Ollama/BGE-M3 recommended, also Voyage, Cohere, Mistral, OpenAI)
- Interactive init wizard now defaults to `litellm` + `ollama/bge-m3` — keeps Anthropic as the only paid vendor
- `klemma embed sources|fragments|all --remodel` re-embeds rows whose `embedding_model` no longer matches the current backend, giving a clean migration path when switching providers

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/ -q` — 1652 passed, 1 skipped
- [x] New tests: 27 covering factory branch, LiteLLMEmbeddings protocol compliance, --remodel for sources and fragments
- [ ] Manual smoke: `ollama pull bge-m3`, switch config to `litellm`/`ollama/bge-m3`, run `klemma embed sources --remodel` on a project with OpenAI embeddings

## Release Note

### Problem

Klemma had a split billing problem: Anthropic for generation, OpenAI for embeddings. For Russian-language dissertations, the OpenAI embedding models are also weaker — English-centric SPECTER (via Semantic Scholar) and `text-embedding-3-small` both underperform on non-English titles and abstracts, which is exactly the core Klemma workload. Users who wanted to avoid a second API key were stuck with the S2 free tier (rate-limited, English-biased, 768-dim) or sentence-transformers on a GPU they may not have.

### Academic Foundation

BGE-M3 (Chen et al., 2024, BAAI) is a multilingual embedding model with 8192-token context and 1024-dim vectors, demonstrated to outperform OpenAI `text-embedding-3-small` on Russian, Chinese, and other non-English benchmarks. The M3 architecture (Multi-Functionality, Multi-Linguality, Multi-Granularity) was specifically designed to handle cross-lingual retrieval at a paragraph level, which matches Klemma's fragment retrieval workload. Ollama packages it for local inference with a one-line install. LiteLLM (BerriAI) provides a unified `embedding()` API across all major providers, letting Klemma treat any of them as a drop-in backend.

### Implementation

Added `LiteLLMEmbeddings` class in `src/klemma/embeddings.py` with lazy `litellm` import, `api_base` pass-through for Ollama endpoints, auto-detected dimensionality on first call, and `"model-provider"` naming convention to guarantee uniqueness when the same model ID is served by multiple providers. Wired a `"litellm"` branch into `create_embeddings()` factory alongside the existing s2/local/openai backends. Extended `EmbeddingsConfig` with `timeout` and optional `dim` fields. Added `--remodel` flag on `klemma embed sources|fragments|all`: new `get_sources_with_stale_model()` / `get_fragments_with_stale_model()` queries on the repositories + facade delegates identify rows whose stored `embedding_model` no longer matches the active provider, and the embed commands merge them with the un-embedded candidates in a single pass. Interactive init wizard now prompts for embeddings backend separately and defaults to `litellm` + `ollama/bge-m3`. Rewrote `config.example.yaml` to put the Ollama+BGE-M3 setup as the recommended default with alternatives commented below. Added a new "Embeddings: LiteLLM + Ollama (recommended)" section to `docs/USER_GUIDE.md` with migration instructions.

### Results

All 1652 tests pass (+27 new). Lint clean. Files touched: 13 (551 insertions, 31 deletions). Users with a running Ollama can now switch to BGE-M3 by editing three lines in `config.yaml` and running `klemma embed sources --remodel && klemma embed fragments --remodel` — no API key, no rate limits, no billing surface beyond Anthropic. Source and fragment embedding tables gain a migration-safe `embedding_model` check without requiring any schema changes.

Part of the single-billing / offline-friendly tooling track.