### PR TITLE
feat(saas): add Ollama/BGE-M3 auto-embedding to SaaS worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,9 @@ jobs:
             sudo docker compose up -d --force-recreate api worker </dev/null
             sudo docker compose up -d </dev/null
 
+            # Pull BGE-M3 model into Ollama (idempotent, skips if already present)
+            sudo docker compose exec -T ollama ollama pull bge-m3 </dev/null 2>&1 | tail -1 || true
+
             # Health check with retries (5 attempts, 3s apart)
             for i in 1 2 3 4 5; do
               sleep 3

--- a/saas/deploy/.env.example
+++ b/saas/deploy/.env.example
@@ -8,3 +8,8 @@ KLEMMA_JWT_SECRET=change-me-to-a-random-64-char-hex-string
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # KLEMMA_AI_MODEL=anthropic/claude-sonnet-4-20250514
+
+# Embeddings (default: Ollama/BGE-M3 via LiteLLM — runs locally in Docker, no API key)
+# KLEMMA_EMBEDDINGS_BACKEND=litellm
+# KLEMMA_EMBEDDINGS_MODEL=ollama/bge-m3
+# KLEMMA_EMBEDDINGS_BASE_URL=http://ollama:11434

--- a/saas/deploy/docker-compose.yml
+++ b/saas/deploy/docker-compose.yml
@@ -38,10 +38,16 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - KLEMMA_AI_MODEL=${KLEMMA_AI_MODEL:-anthropic/claude-sonnet-4-20250514}
+      # Embeddings (Ollama/BGE-M3 via LiteLLM — runs inside Docker network)
+      - KLEMMA_EMBEDDINGS_BACKEND=${KLEMMA_EMBEDDINGS_BACKEND:-litellm}
+      - KLEMMA_EMBEDDINGS_MODEL=${KLEMMA_EMBEDDINGS_MODEL:-ollama/bge-m3}
+      - KLEMMA_EMBEDDINGS_BASE_URL=${KLEMMA_EMBEDDINGS_BASE_URL:-http://ollama:11434}
     volumes:
       - klemma-data:/data/klemma
     depends_on:
       redis:
+        condition: service_healthy
+      ollama:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
@@ -61,6 +67,22 @@ services:
       timeout: 3s
       retries: 3
 
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 3g
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
   caddy:
     image: caddy:2-alpine
     ports:
@@ -79,5 +101,6 @@ services:
 volumes:
   klemma-data:
   redis-data:
+  ollama-data:
   caddy-data:
   caddy-config:

--- a/src/klemma/api/CLAUDE.md
+++ b/src/klemma/api/CLAUDE.md
@@ -21,9 +21,14 @@ Shared FastAPI dependencies for data store access.
 - `set/get_file_store()` — `FileStore` singleton
 - All set in `app.py` lifespan, used by route handlers via `Depends()`
 
-### tasks.py (~60 lines)
+### tasks.py (~790 lines)
 Async task definitions for rq worker. Tasks receive primitive args (worker runs in separate process).
-- `process_source(paper_id, citekey, data_dir)` — extraction task stub (initializes own stores)
+- `_create_ai_provider()` — AI provider from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, KLEMMA_AI_MODEL)
+- `_create_embeddings_provider()` — embedding provider from env vars (KLEMMA_EMBEDDINGS_BACKEND/MODEL/BASE_URL); returns None when disabled
+- `process_source(paper_id, citekey, data_dir)` — full pipeline: PDF extract → AI fragments → auto-embed → section assign → citation links → auto-suggest
+- `generate_outline_saas(project_id, context_text, ...)` — outline generation from plan-prospekt
+- `generate_research(section, project_id, ...)` — research briefing via researcher.py in headless mode
+- `generate_draft(section, data_dir, ...)` — section draft via drafter.py in headless mode
 
 ### worker.py (~25 lines)
 RQ worker entry point: `python -m klemma.api.worker`
@@ -41,9 +46,9 @@ Route modules. See [routes/CLAUDE.md](routes/CLAUDE.md).
 
 Docker Compose stack in `saas/deploy/`:
 - `Dockerfile` — Python 3.12, installs `[api,recommended]`, uvicorn 2 workers
-- `docker-compose.yml` — 5 services: api, worker, redis, nginx, certbot
-- `nginx/default.conf` — reverse proxy, security headers, XFF override
-- `.env.example` — required secrets (JWT secret)
+- `docker-compose.yml` — 6 services: api, worker, redis, ollama, caddy, (certbot removed)
+- `Caddyfile` — reverse proxy with auto-TLS
+- `.env.example` — required secrets (JWT secret) + optional embeddings config
 
 ```bash
 cp saas/deploy/.env.example saas/deploy/.env  # edit with real secret

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -35,6 +35,29 @@ def _create_ai_provider():
     return create_ai(config), config
 
 
+def _create_embeddings_provider():
+    """Create an embedding provider from environment variables.
+
+    Mirrors ``_create_ai_provider()`` pattern.  Returns ``None`` when
+    ``KLEMMA_EMBEDDINGS_BACKEND`` is unset (embedding disabled).
+    """
+    backend = os.getenv("KLEMMA_EMBEDDINGS_BACKEND", "")
+    if not backend:
+        return None
+    from klemma.embeddings import create_embeddings
+
+    config = {
+        "backend": backend,
+        "model": os.getenv("KLEMMA_EMBEDDINGS_MODEL", "ollama/bge-m3"),
+        "base_url": os.getenv("KLEMMA_EMBEDDINGS_BASE_URL"),
+        "timeout": int(os.getenv("KLEMMA_EMBEDDINGS_TIMEOUT", "60")),
+    }
+    dim = os.getenv("KLEMMA_EMBEDDINGS_DIM")
+    if dim:
+        config["dim"] = int(dim)
+    return create_embeddings(config)
+
+
 def _mirror_research_report(data_path: Path, project_id: str, section: str, text: str, model: str) -> None:
     """Write research report to MD file for klemma-cli sync pull.
 
@@ -321,6 +344,23 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         prompt_hash = ""
         model_name = ai_config.model
         saved = paper_store.save_fragments(paper_id, fragments, prompt_hash, model_name)
+
+        # Auto-embed paper and fragments (non-fatal — fragments are saved regardless)
+        emb = _create_embeddings_provider()
+        if emb:
+            try:
+                paper_vec = emb.embed(paper.title or citekey, paper.abstract or "")
+                if paper_vec:
+                    paper_store.save_paper_embedding(paper_id, paper_vec, emb.model_name)
+                frag_count = 0
+                for frag in fragments:
+                    frag_vec = emb.embed(frag.fragment_text)
+                    if frag_vec:
+                        paper_store.save_fragment_embedding(frag.fragment_id, frag_vec, emb.model_name)
+                        frag_count += 1
+                logger.info("Embedded paper + %d fragments for %s", frag_count, citekey)
+            except Exception as exc:
+                logger.warning("Embedding failed for %s (non-fatal): %s", citekey, exc)
 
         # Auto-assign sections based on AI predictions (SaaS only — when project context given)
         if project_id and predicted_sections:


### PR DESCRIPTION
## Summary

- Adds Ollama service to Docker Compose stack (6th service) with 3GB memory limit and `ollama list` healthcheck
- Worker auto-embeds paper + fragments after AI extraction via `_create_embeddings_provider()` (mirrors `_create_ai_provider()` pattern)
- BGE-M3 model pulled idempotently on each deploy via `deploy.yml`
- Eliminates need for CLI `klemma push --embeddings` for SaaS-uploaded papers

## Test plan

- [ ] `ruff check src/klemma/api/tasks.py` — lint clean
- [ ] `python -m pytest tests/ -q` — 1629 passed
- [ ] Deploy to VPS: Ollama service starts healthy
- [ ] `docker compose exec ollama ollama list` — `bge-m3` present
- [ ] Upload a paper via SaaS UI → verify `paper_embeddings` and `fragment_embeddings` tables have vectors
- [ ] Existing `/sync/push/embeddings` still works for CLI users

## Release Note

### Problem
Papers uploaded via the SaaS dashboard received no embeddings — vectors were only available when pushed from the CLI via `klemma push --embeddings`. This blocked server-side semantic search (similar papers, section similarity) for SaaS-only users.

### Academic Foundation
BGE-M3 (Xiao et al., 2024) provides 1024-dim multilingual embeddings with 8K context, outperforming SPECTER2 on cross-lingual retrieval benchmarks. LiteLLM abstraction layer enables transparent backend switching per ADR-003.

### Implementation
- `saas/deploy/docker-compose.yml`: Ollama service with `ollama-data` volume, 3GB memory limit, `ollama list` healthcheck (curl not available in image)
- `src/klemma/api/tasks.py`: `_create_embeddings_provider()` factory from env vars + auto-embed block in `process_source()` after fragment save
- `.github/workflows/deploy.yml`: idempotent `ollama pull bge-m3` after compose up
- Non-fatal: embedding failure doesn't block fragment extraction

### Results
- 5 files changed, 81 insertions
- 1629 tests passing, lint clean
- Zero additional API keys needed (Ollama runs locally in Docker network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)