### PR TITLE
fix(api): promote business-logic job errors to top-level 'failed'

### DIFF
--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -67,6 +67,18 @@ class JobStatusResponse(BaseModel):
     result: dict | None = None
 
 
+def _resolve_status(raw_status: str, result: Any) -> str:
+    """Promote business-logic errors in the result payload to top-level 'failed'.
+
+    Tasks return ``{"status": "error", "detail": ...}`` for recoverable failures
+    (token exhaustion, missing PDF, AI timeout). Without this, callers see the
+    outer status as 'finished' and must defensively unwrap result.status.
+    """
+    if raw_status == "finished" and isinstance(result, dict) and result.get("status") == "error":
+        return "failed"
+    return raw_status
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -146,7 +158,11 @@ async def get_job_status(
     # Check local job store first (populated when Redis is unavailable)
     if job_id in _local_jobs:
         j = _local_jobs[job_id]
-        return JobStatusResponse(job_id=job_id, status=j["status"], result=j["result"])
+        return JobStatusResponse(
+            job_id=job_id,
+            status=_resolve_status(j["status"], j["result"]),
+            result=j["result"],
+        )
 
     # Check Redis
     if not _RQ_AVAILABLE:
@@ -162,10 +178,11 @@ async def get_job_status(
         redis_conn = Redis.from_url(redis_url)
         job = Job.fetch(job_id, connection=redis_conn)
 
+        result = job.result if job.is_finished else None
         return JobStatusResponse(
             job_id=job_id,
-            status=job.get_status(),
-            result=job.result if job.is_finished else None,
+            status=_resolve_status(job.get_status(), result),
+            result=result,
         )
     except RedisConnectionError:
         raise HTTPException(

--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -124,6 +124,56 @@ def test_job_status_finished(client, monkeypatch):
     assert data["result"]["fragment_count"] == 5
 
 
+def test_job_status_business_error_promoted_to_failed(client, monkeypatch):
+    """Tasks that return {status: error, ...} surface as outer status='failed'.
+
+    Without this promotion, callers see status='finished' for token-limit
+    exhaustion and other recoverable errors, then must defensively unwrap
+    result.status. Regression guard for the golden E2E find.
+    """
+    token = _auth_token(client)
+
+    mock_job = MagicMock()
+    mock_job.get_status.return_value = "finished"
+    mock_job.is_finished = True
+    mock_job.result = {"status": "error", "detail": "Token limit exhausted"}
+
+    import klemma.api.routes.process as proc_mod
+
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", True)
+    monkeypatch.setattr(proc_mod, "Redis", MagicMock())
+    mock_job_cls = MagicMock()
+    mock_job_cls.fetch.return_value = mock_job
+    monkeypatch.setattr(proc_mod, "Job", mock_job_cls)
+
+    resp = client.get("/process/jobs/test-456", headers=_headers(token))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["result"]["detail"] == "Token limit exhausted"
+
+
+def test_job_status_local_business_error_promoted_to_failed(client):
+    """Same promotion applies to the in-memory local job store."""
+    import klemma.api.routes.process as proc_mod
+
+    proc_mod._local_jobs["local-err-1"] = {
+        "status": "finished",
+        "result": {"status": "error", "detail": "PDF text too short"},
+    }
+    token = _auth_token(client)
+    try:
+        resp = client.get("/process/jobs/local-err-1", headers=_headers(token))
+    finally:
+        proc_mod._local_jobs.pop("local-err-1", None)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "failed"
+    assert data["result"]["detail"] == "PDF text too short"
+
+
 def test_job_status_not_found(client, monkeypatch):
     token = _auth_token(client)
 


### PR DESCRIPTION
## Summary
- `/process/jobs/{job_id}` now returns `status='failed'` whenever the inner result payload reports `status='error'` (token exhaustion, missing PDF, AI timeout).
- Removes the need for every caller to defensively unwrap `result.status` to detect business-logic failures.
- Applies to both Redis-backed and local job stores.

## Test plan
- [x] `ruff check src/klemma/api/routes/process.py`
- [x] `pytest -k "process or job_status"` — 23 passed
- [ ] Manual: trigger a process_source job that exhausts tokens; confirm UI shows failed state without unwrapping result

## Release Note

### Problem
Tasks like `process_source` and `generate_draft` return `{"status": "error", "detail": ...}` inside their result payload for recoverable failures (token exhaustion, missing PDF, AI provider timeout). The `/process/jobs/{job_id}` endpoint surfaced these as outer `status='finished'`, so every frontend and CLI client had to inspect `result.status` to detect failures. Asymmetric error reporting made retries and UI state machines unnecessarily complex.

### Academic Foundation
Operational fix — no academic foundation needed. Aligns with general distributed-systems principle that job orchestration should expose terminal state at the highest level (RFC 7807 problem details, K8s job conditions).

### Implementation
Added `_resolve_status()` helper in `src/klemma/api/routes/process.py` that promotes inner `result.status == "error"` to outer `status = "failed"`. Applied uniformly to both code paths (local in-memory job store and Redis/rq backend).

### Results
- 1 file changed, 20 insertions, 3 deletions
- `ruff check` clean
- 23 process/job-related tests pass
- Frontends/CLI can now trust the top-level `status` field for terminal state classification