### PR TITLE
perf(process_source): drop S2, batch fragment embeds, adaptive max_tokens

### DIFF
--- a/saas/deploy/.env.example
+++ b/saas/deploy/.env.example
@@ -9,6 +9,10 @@ KLEMMA_JWT_SECRET=change-me-to-a-random-64-char-hex-string
 # OPENAI_API_KEY=sk-...
 # KLEMMA_AI_MODEL=anthropic/claude-sonnet-4-20250514
 
+# CrossRef polite pool — include your email for higher rate limits
+# (https://www.crossref.org/documentation/retrieve-metadata/rest-api/access-and-authentication)
+# KLEMMA_CROSSREF_MAILTO=you@example.org
+
 # Embeddings (default: Ollama/BGE-M3 via LiteLLM — runs locally in Docker, no API key)
 # KLEMMA_EMBEDDINGS_BACKEND=litellm
 # KLEMMA_EMBEDDINGS_MODEL=ollama/bge-m3

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -242,6 +242,7 @@ Provider-agnostic paper search — resolve reference gaps to acquisition targets
 ### embeddings.py (393 lines)
 `EmbeddingProvider` runtime-checkable protocol + 4 backends + utilities.
 - `EmbeddingProvider` protocol — `dim`, `model_name`, `embed(title, abstract) → list[float] | None`
+- `embed_batch(texts) → list[list[float] | None]` — optional method on backends (LiteLLM implements it as a single batched HTTP call); fallback helper `_default_embed_batch(provider, texts)` loops `embed()` for backends without native batching
 - `SemanticScholarEmbeddings` — free S2 API (768-dim SPECTER), rate-limited (throttle param)
 - `LocalSPECTEREmbeddings` — offline sentence-transformers SPECTER2 model
 - `OpenAIEmbeddings` — text-embedding-3-small (1536-dim)

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -285,7 +285,14 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
             "Output only valid JSON with fragments array and key_references array."
         )
 
-        result = ai.call_with_meta(system, user_prompt, max_tokens=8192)
+        # Adaptive max_tokens: short PDFs produce few fragments, so a high
+        # cap is wasted latency + cost. ~4 chars per token, fragments are
+        # typically 200-400 tokens each; we scale with pdf size but floor
+        # at 1024 (to cover at least the dissertation_context + few frags)
+        # and cap at 8192 (the previous hardcoded ceiling).
+        pdf_chars = len(pdf_text)
+        adaptive_max_tokens = max(1024, min(8192, pdf_chars // 4))
+        result = ai.call_with_meta(system, user_prompt, max_tokens=adaptive_max_tokens)
         if not result or not result.text:
             user_library.update_status(citekey, "failed", user_id=user_id or None)
             return {"status": "error", "detail": "AI extraction returned no data"}
@@ -345,18 +352,30 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         model_name = ai_config.model
         saved = paper_store.save_fragments(paper_id, fragments, prompt_hash, model_name)
 
-        # Auto-embed paper and fragments (non-fatal — fragments are saved regardless)
+        # Auto-embed paper and fragments (non-fatal — fragments are saved regardless).
+        # Fragments go through a single batched call when the backend supports
+        # it (LiteLLM/Ollama does); others fall back to per-item embed().
         emb = _create_embeddings_provider()
         if emb:
             try:
                 paper_vec = emb.embed(paper.title or citekey, paper.abstract or "")
                 if paper_vec:
                     paper_store.save_paper_embedding(paper_id, paper_vec, emb.model_name)
+
+                texts = [frag.fragment_text for frag in fragments]
+                batch_fn = getattr(emb, "embed_batch", None)
+                if callable(batch_fn):
+                    vectors = batch_fn(texts)
+                else:
+                    from klemma.embeddings import _default_embed_batch
+                    vectors = _default_embed_batch(emb, texts)
+
                 frag_count = 0
-                for frag in fragments:
-                    frag_vec = emb.embed(frag.fragment_text)
-                    if frag_vec:
-                        paper_store.save_fragment_embedding(frag.fragment_id, frag_vec, emb.model_name)
+                for frag, vec in zip(fragments, vectors):
+                    if vec:
+                        paper_store.save_fragment_embedding(
+                            frag.fragment_id, vec, emb.model_name
+                        )
                         frag_count += 1
                 logger.info("Embedded paper + %d fragments for %s", frag_count, citekey)
             except Exception as exc:

--- a/src/klemma/embeddings.py
+++ b/src/klemma/embeddings.py
@@ -35,6 +35,16 @@ class EmbeddingProvider(Protocol):
         ...
 
 
+def _default_embed_batch(provider, texts: list[str]) -> list[Optional[list[float]]]:
+    """Fallback batch embed: call ``embed()`` sequentially.
+
+    Backends that cannot send multiple inputs in one request (S2, local
+    SentenceTransformer, OpenAI without explicit batch wiring) fall back to
+    this. LiteLLM backends override with a true batched HTTP call.
+    """
+    return [provider.embed(t) if t else None for t in texts]
+
+
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
@@ -318,6 +328,47 @@ class LiteLLMEmbeddings:
         except Exception as e:
             logger.warning("LiteLLM embed error for '%s': %s", title[:60], e)
             return None
+
+    def embed_batch(
+        self, texts: list[str]
+    ) -> list[Optional[list[float]]]:
+        """Batched embed via a single ``litellm.embedding()`` call.
+
+        Empty strings are preserved as ``None`` in the output without being
+        sent to the backend. On API failure returns all-None (same semantics
+        as ``embed()`` on error — non-fatal).
+        """
+        if not texts:
+            return []
+
+        # Filter to non-empty inputs; keep index mapping so we can reassemble
+        indexed = [(i, t) for i, t in enumerate(texts) if t and t.strip()]
+        if not indexed:
+            return [None] * len(texts)
+
+        payload = [t for _, t in indexed]
+        try:
+            response = self._litellm.embedding(
+                model=self.model,
+                input=payload,
+                api_base=self.api_base,
+                api_key=self.api_key,
+                timeout=self.timeout,
+            )
+        except Exception as e:
+            logger.warning(
+                "LiteLLM batch embed error (%d items): %s", len(payload), e
+            )
+            return [None] * len(texts)
+
+        out: list[Optional[list[float]]] = [None] * len(texts)
+        for (orig_idx, _text), entry in zip(indexed, response.data):
+            vec = entry.get("embedding") if isinstance(entry, dict) else getattr(entry, "embedding", None)
+            if not vec:
+                continue
+            self.dim = len(vec)
+            out[orig_idx] = list(vec)
+        return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -4,11 +4,12 @@ PDF text extraction, Pydantic data models, vault note generation, and metadata a
 
 ## Modules
 
-### metadata.py (~150 lines)
-Auto-extract paper metadata from PDF properties + Semantic Scholar API lookup.
+### metadata.py (~220 lines)
+Auto-extract paper metadata from PDF properties + CrossRef lookup.
 - `extract_pdf_metadata(pdf_path)` — PyMuPDF `doc.metadata` for title/author; first-page heuristic fallback for generic titles
-- `lookup_s2(title)` — S2 `paper/search` API with rate limiting, fuzzy title match, returns title/authors/year/abstract/doi
-- `resolve_metadata(pdf_path, cli_title?, cli_authors?, cli_year?, cli_doi?)` — orchestrator: CLI flags → PDF metadata → S2 enrichment → empty fallback
+- `lookup_crossref(title, mailto?)` — CrossRef `/works` API with polite-pool `mailto` (env `KLEMMA_CROSSREF_MAILTO` or default); fuzzy title match; returns title/authors/year/abstract/doi. JATS tags stripped from abstract.
+- `lookup_s2(title)` — S2 `paper/search` API (kept for CLI acquirer; **not** called from `resolve_metadata` — S2 is rate-limited and unreliable under load)
+- `resolve_metadata(pdf_path, cli_title?, cli_authors?, cli_year?, cli_doi?)` — orchestrator: CLI flags → PDF metadata → CrossRef enrichment → empty fallback. Only one network lookup (CrossRef).
 - `_titles_match(query, candidate)` — fuzzy word-overlap comparison (>0.6 threshold)
 
 ### zotero_api.py (~80 lines)

--- a/src/klemma/literature/metadata.py
+++ b/src/klemma/literature/metadata.py
@@ -1,4 +1,4 @@
-"""Auto-extract paper metadata from PDF properties + Semantic Scholar API."""
+"""Auto-extract paper metadata from PDF properties + CrossRef/S2 lookup."""
 
 import logging
 import os
@@ -6,6 +6,7 @@ import re
 import time
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote_plus
 
 import fitz  # PyMuPDF
 import requests
@@ -19,6 +20,10 @@ _GENERIC_TITLES = {
 
 _s2_last_request = 0.0
 _S2_THROTTLE = 3.1  # seconds between S2 API calls
+
+# CrossRef recommends including a mailto address to enter the polite pool
+# (higher, predictable rate limits). Read from env, fall back to a neutral one.
+_DEFAULT_CROSSREF_MAILTO = "klemma@litresearch.ru"
 
 
 def extract_pdf_metadata(pdf_path: Path) -> dict:
@@ -134,6 +139,80 @@ def lookup_s2(title: str) -> Optional[dict]:
     return None
 
 
+def _crossref_mailto() -> str:
+    return os.environ.get("KLEMMA_CROSSREF_MAILTO", _DEFAULT_CROSSREF_MAILTO)
+
+
+def lookup_crossref(title: str, mailto: Optional[str] = None) -> Optional[dict]:
+    """Look up paper metadata on CrossRef by title.
+
+    Returns ``{"title", "authors", "year", "abstract", "doi"}`` or ``None``.
+
+    CrossRef's polite pool (https://api.crossref.org) gives higher, more
+    predictable rate limits when the request carries a ``mailto=`` parameter
+    and a ``User-Agent`` header with the same address. We set both.
+
+    Abstract field is usually empty on CrossRef — it's returned as JATS XML
+    in ``message.abstract`` only for publishers that deposit it. We strip
+    the tags when present; otherwise an empty string.
+    """
+    if not title:
+        return None
+
+    mailto = mailto or _crossref_mailto()
+    url = (
+        "https://api.crossref.org/works"
+        f"?query.bibliographic={quote_plus(title)}&rows=3&mailto={quote_plus(mailto)}"
+    )
+    try:
+        resp = requests.get(
+            url,
+            timeout=10,
+            headers={"User-Agent": f"klemma/1.0 (mailto:{mailto})"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.warning("CrossRef lookup failed for '%s': %s", title[:60], e)
+        return None
+
+    for item in data.get("message", {}).get("items", []):
+        item_title = " ".join(item.get("title", []) or [])
+        if not _titles_match(title, item_title):
+            continue
+
+        # Authors: CrossRef returns structured {family, given} pairs
+        authors = ", ".join(
+            f"{a.get('family', '')} {a.get('given', '')}".strip()
+            for a in item.get("author", [])
+            if a.get("family") or a.get("given")
+        )
+
+        # Year: prefer published-print, then issued, then published-online
+        year: Optional[int] = None
+        for date_field in ("published-print", "issued", "published-online"):
+            parts = (item.get(date_field) or {}).get("date-parts") or [[]]
+            if parts and parts[0] and parts[0][0]:
+                try:
+                    year = int(parts[0][0])
+                    break
+                except (TypeError, ValueError):
+                    pass
+
+        raw_abstract = item.get("abstract") or ""
+        abstract = re.sub(r"<[^>]+>", "", raw_abstract).strip()
+
+        return {
+            "title": item_title,
+            "authors": authors,
+            "year": year,
+            "abstract": abstract,
+            "doi": item.get("DOI", ""),
+        }
+
+    return None
+
+
 def _titles_match(query: str, candidate: str) -> bool:
     """Fuzzy title comparison: normalize and check word overlap (>0.6)."""
     def normalize(s: str) -> set[str]:
@@ -178,37 +257,20 @@ def resolve_metadata(
     if cli_doi:
         result["doi"] = cli_doi
 
-    # Layer 3: S2 enrichment (if we have a title to search with)
+    # Layer 3: CrossRef enrichment — primary (and only) network lookup.
+    # S2 is intentionally disabled on this path: it's rate-limited, flaky
+    # under load, and CrossRef covers both CS and non-CS literature with
+    # generous rate limits when using the polite pool (mailto param).
     if result["title"]:
-        s2 = lookup_s2(result["title"])
-        if s2:
-            # S2 fills in blanks but doesn't override existing values
+        cr = lookup_crossref(result["title"])
+        if cr:
             if not result["authors"]:
-                result["authors"] = s2.get("authors", "")
+                result["authors"] = cr.get("authors", "")
             if result["year"] is None:
-                result["year"] = s2.get("year")
+                result["year"] = cr.get("year")
             if not result["abstract"]:
-                result["abstract"] = s2.get("abstract", "")
+                result["abstract"] = cr.get("abstract", "")
             if not result["doi"]:
-                result["doi"] = s2.get("doi", "")
-
-    # Layer 4: CrossRef fallback (if S2 didn't fill year or DOI)
-    if result["title"] and (result["year"] is None or not result["doi"]):
-        try:
-            from klemma.search import CrossRefSearchProvider
-
-            cr = CrossRefSearchProvider()
-            hit = cr.resolve(result["title"])
-            if hit:
-                if result["year"] is None and hit.year:
-                    result["year"] = hit.year
-                if not result["doi"] and hit.doi:
-                    result["doi"] = hit.doi
-                if not result["authors"] and hit.authors:
-                    result["authors"] = hit.authors
-                if not result["abstract"] and hit.abstract:
-                    result["abstract"] = hit.abstract
-        except Exception:
-            pass  # non-fatal
+                result["doi"] = cr.get("doi", "")
 
     return result

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -215,6 +215,84 @@ class TestLiteLLMEmbeddings:
         p = LiteLLMEmbeddings("ollama/bge-m3")
         assert isinstance(p, EmbeddingProvider)
 
+    def test_embed_batch_single_call(self):
+        """embed_batch sends all non-empty texts in a single HTTP call."""
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        response = MagicMock()
+        response.data = [
+            {"embedding": [0.1, 0.2]},
+            {"embedding": [0.3, 0.4]},
+            {"embedding": [0.5, 0.6]},
+        ]
+        p._litellm.embedding.return_value = response
+
+        vectors = p.embed_batch(["one", "two", "three"])
+
+        assert p._litellm.embedding.call_count == 1
+        assert vectors == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+        assert p._litellm.embedding.call_args.kwargs["input"] == ["one", "two", "three"]
+
+    def test_embed_batch_preserves_none_for_empty(self):
+        """Empty strings become None without being sent to the backend."""
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        response = MagicMock()
+        response.data = [
+            {"embedding": [0.1]},
+            {"embedding": [0.2]},
+        ]
+        p._litellm.embedding.return_value = response
+
+        vectors = p.embed_batch(["one", "", "two", "   "])
+
+        assert vectors == [[0.1], None, [0.2], None]
+        assert p._litellm.embedding.call_args.kwargs["input"] == ["one", "two"]
+
+    def test_embed_batch_all_empty_skips_call(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        assert p.embed_batch(["", "  "]) == [None, None]
+        p._litellm.embedding.assert_not_called()
+
+    def test_embed_batch_empty_list(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        assert p.embed_batch([]) == []
+        p._litellm.embedding.assert_not_called()
+
+    def test_embed_batch_error_returns_all_none(self):
+        p = LiteLLMEmbeddings("ollama/bge-m3")
+        p._litellm = MagicMock()
+        p._litellm.embedding.side_effect = ConnectionError("ollama down")
+        assert p.embed_batch(["one", "two"]) == [None, None]
+
+
+class TestDefaultEmbedBatchFallback:
+    """The _default_embed_batch helper used by backends without batch support."""
+
+    def test_falls_back_to_sequential_embed(self):
+        from klemma.embeddings import _default_embed_batch
+
+        provider = MagicMock()
+        provider.embed.side_effect = [[1.0], [2.0], None]
+
+        result = _default_embed_batch(provider, ["a", "b", "c"])
+
+        assert result == [[1.0], [2.0], None]
+        assert provider.embed.call_count == 3
+
+    def test_skips_empty_without_calling(self):
+        from klemma.embeddings import _default_embed_batch
+
+        provider = MagicMock()
+        provider.embed.return_value = [0.5]
+
+        result = _default_embed_batch(provider, ["text", ""])
+
+        assert result == [[0.5], None]
+        assert provider.embed.call_count == 1
+
 
 class TestProtocolCompliance:
     """Verify all providers satisfy EmbeddingProvider protocol."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -176,14 +176,14 @@ class TestLookupS2:
 
 class TestResolveMetadata:
     def test_cli_wins(self):
-        """CLI title/authors override PDF+S2."""
+        """CLI title/authors override PDF+CrossRef."""
         from klemma.literature.metadata import resolve_metadata
 
         with patch("klemma.literature.metadata.extract_pdf_metadata") as mock_pdf, \
-             patch("klemma.literature.metadata.lookup_s2") as mock_s2:
+             patch("klemma.literature.metadata.lookup_crossref") as mock_cr:
             mock_pdf.return_value = {"title": "PDF Title", "authors": "PDF Author"}
-            mock_s2.return_value = {
-                "title": "S2 Title", "authors": "S2 Author",
+            mock_cr.return_value = {
+                "title": "CR Title", "authors": "CR Author",
                 "year": 2024, "abstract": "Abstract", "doi": "10.1/x",
             }
 
@@ -197,17 +197,17 @@ class TestResolveMetadata:
         assert result["title"] == "My Title"
         assert result["authors"] == "My Authors"
         assert result["year"] == 2023
-        # S2 enriches abstract and doi even when CLI provides title
+        # CrossRef enriches abstract and doi even when CLI provides title
         assert result["doi"] == "10.1/x"
 
-    def test_pdf_then_s2(self):
-        """PDF title → S2 enriches year+doi."""
+    def test_pdf_then_crossref(self):
+        """PDF title → CrossRef enriches authors/year/doi."""
         from klemma.literature.metadata import resolve_metadata
 
         with patch("klemma.literature.metadata.extract_pdf_metadata") as mock_pdf, \
-             patch("klemma.literature.metadata.lookup_s2") as mock_s2:
+             patch("klemma.literature.metadata.lookup_crossref") as mock_cr:
             mock_pdf.return_value = {"title": "Deep Learning", "authors": ""}
-            mock_s2.return_value = {
+            mock_cr.return_value = {
                 "title": "Deep Learning", "authors": "Smith J., Jones K.",
                 "year": 2024, "abstract": "We study...", "doi": "10.5555/dl",
             }
@@ -220,13 +220,13 @@ class TestResolveMetadata:
         assert result["doi"] == "10.5555/dl"
 
     def test_no_sources(self):
-        """No PDF metadata, S2 fails → empty fallback."""
+        """No PDF metadata, CrossRef fails → empty fallback."""
         from klemma.literature.metadata import resolve_metadata
 
         with patch("klemma.literature.metadata.extract_pdf_metadata") as mock_pdf, \
-             patch("klemma.literature.metadata.lookup_s2") as mock_s2:
+             patch("klemma.literature.metadata.lookup_crossref") as mock_cr:
             mock_pdf.return_value = {"title": "", "authors": ""}
-            mock_s2.return_value = None
+            mock_cr.return_value = None
 
             result = resolve_metadata(Path("/tmp/paper.pdf"))
 
@@ -234,6 +234,118 @@ class TestResolveMetadata:
         assert result["authors"] == ""
         assert result["year"] is None
         assert result["doi"] == ""
+
+    def test_s2_not_called(self):
+        """S2 must not be called from resolve_metadata — CrossRef is the only lookup."""
+        from klemma.literature.metadata import resolve_metadata
+
+        with patch("klemma.literature.metadata.extract_pdf_metadata") as mock_pdf, \
+             patch("klemma.literature.metadata.lookup_crossref") as mock_cr, \
+             patch("klemma.literature.metadata.lookup_s2") as mock_s2:
+            mock_pdf.return_value = {"title": "Some Title", "authors": ""}
+            mock_cr.return_value = None
+
+            resolve_metadata(Path("/tmp/paper.pdf"))
+
+        assert mock_s2.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# lookup_crossref
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCrossRef:
+    def test_success_with_mailto(self):
+        """CrossRef returns matching paper + polite pool mailto is used."""
+        from klemma.literature.metadata import lookup_crossref
+
+        cr_response = {
+            "message": {
+                "items": [
+                    {
+                        "title": ["Deep Learning for NLP"],
+                        "author": [
+                            {"family": "Smith", "given": "John"},
+                            {"family": "Jones", "given": "Kate"},
+                        ],
+                        "issued": {"date-parts": [[2024]]},
+                        "DOI": "10.1234/test",
+                        "abstract": "<jats:p>We survey NLP...</jats:p>",
+                    }
+                ]
+            }
+        }
+
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = cr_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            result = lookup_crossref("Deep Learning for NLP", mailto="me@test")
+
+        assert result is not None
+        assert result["year"] == 2024
+        assert "Smith" in result["authors"]
+        assert result["doi"] == "10.1234/test"
+        # JATS tags stripped
+        assert "<" not in result["abstract"]
+        assert "We survey" in result["abstract"]
+        # mailto appears in URL
+        call_url = mock_req.get.call_args.args[0]
+        assert "mailto=me%40test" in call_url
+
+    def test_mailto_from_env(self, monkeypatch):
+        """mailto falls back to KLEMMA_CROSSREF_MAILTO env var."""
+        from klemma.literature.metadata import lookup_crossref
+
+        monkeypatch.setenv("KLEMMA_CROSSREF_MAILTO", "env@example.org")
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {"message": {"items": []}}
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            lookup_crossref("anything")
+
+        call_url = mock_req.get.call_args.args[0]
+        assert "mailto=env%40example.org" in call_url
+        ua = mock_req.get.call_args.kwargs["headers"]["User-Agent"]
+        assert "env@example.org" in ua
+
+    def test_no_match(self):
+        from klemma.literature.metadata import lookup_crossref
+
+        cr_response = {
+            "message": {
+                "items": [
+                    {
+                        "title": ["Completely Unrelated Paper on Chemistry"],
+                        "author": [{"family": "Alice", "given": "A"}],
+                        "issued": {"date-parts": [[2020]]},
+                        "DOI": "10.0/x",
+                    }
+                ]
+            }
+        }
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = cr_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            result = lookup_crossref("Deep Learning for NLP")
+
+        assert result is None
+
+    def test_api_error(self):
+        from klemma.literature.metadata import lookup_crossref
+
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_req.get.side_effect = Exception("timeout")
+            assert lookup_crossref("Deep Learning for NLP") is None
+
+    def test_empty_title(self):
+        from klemma.literature.metadata import lookup_crossref
+        assert lookup_crossref("") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three independent wins on the SaaS PDF-ingestion path. The E2E golden test took 4+ minutes on a ~1.2 KB synthetic PDF; three bottlenecks contributed roughly equally, so we hit all three at once.

### 1. Ditch S2 from metadata enrichment
`resolve_metadata()` no longer calls `lookup_s2()`. S2 is rate-limited to ~1 req/3s, times out at 15s, and retries with 15/30/60/120s backoff on 429 — a single 429 storm can burn >4 minutes on its own. Replaced with a direct CrossRef call (`lookup_crossref`) using the polite pool: `mailto` param in the query + matching `User-Agent` for higher predictable limits. Email comes from `KLEMMA_CROSSREF_MAILTO` (env) or a safe default.

`lookup_s2` stays — it's still referenced by the CLI acquirer and `S2SearchProvider` — but it's off the hot path.

### 2. Batch fragment embeddings
`LiteLLMEmbeddings.embed_batch(texts)` sends N fragments in one `litellm.embedding()` call. Before: a sequential for-loop over fragments (one HTTP round-trip each to the Ollama sidecar). Empty strings are preserved as `None` in the output without being sent. Fallback helper `_default_embed_batch()` handles providers that don't implement `embed_batch` (S2, local SPECTER, OpenAI) so the caller doesn't need to branch.

### 3. Adaptive `max_tokens`
Short PDFs don't need 8K tokens of output capacity. The main extraction call now uses `max(1024, min(8192, pdf_chars // 4))`. Short synthetic PDFs drop to the 1024 floor; real papers still hit the 8K ceiling.

## Release Note

### Problem
Short PDFs (~1.2 KB synthetic test documents) were taking over 4 minutes through `process_source()`. Profiling showed three independent contributors, each worth ~60–90 seconds: S2 rate-limiting on `resolve_metadata`, sequential per-fragment embedding, and a hardcoded 8192-token ceiling regardless of input size.

### Academic Foundation
CrossRef polite-pool guidance: CrossRef's public API explicitly documents that clients providing a `mailto` parameter (and matching User-Agent) get higher predictable rate limits (https://www.crossref.org/documentation/retrieve-metadata/rest-api/access-and-authentication). For ingestion-time metadata enrichment — a non-interactive, batch-style workload — predictable throughput beats the Semantic Scholar API's richer content when S2's free tier throttles aggressively under contention.

### Implementation
- `literature/metadata.py`: new `lookup_crossref(title, mailto=...)`; `resolve_metadata` now does one network lookup (CrossRef), not two (S2 → CrossRef). `lookup_s2` preserved for the CLI acquirer only.
- `embeddings.py`: new `embed_batch()` on `LiteLLMEmbeddings` (single batched HTTP call, preserves order, empty-string inputs mapped to `None`); public fallback `_default_embed_batch()` for backends without native batching.
- `api/tasks.py`: fragment-embed loop replaced with batched call via `getattr(emb, "embed_batch", None)`; `max_tokens` computed adaptively from PDF length.
- `saas/deploy/.env.example`: `KLEMMA_CROSSREF_MAILTO` documented.

### Results
- 13 new tests: 4 `lookup_crossref` happy-path + mailto + error cases, 1 guard that `resolve_metadata` never calls `lookup_s2`, 5 `embed_batch` cases (single call, empty preservation, all-empty skip, empty list, error), 2 fallback cases.
- 1666 pass (was 1653), 1 skipped, 0 failed, `ruff check` clean.
- Expected latency cut on the golden E2E path: substantial on small PDFs (the S2 timeout path dominates there); for full-size papers the embed batching + adaptive tokens are the main wins.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q --ignore=tests/test_golden_e2e.py` — 1666 pass
- [ ] Re-run golden E2E against `litresearch.ru` once deployed — compare phase timings with baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)