### PR TITLE
fix(ci): install [litellm] extra in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - run: pip install -e ".[dev,api]"
+      - run: pip install -e ".[dev,api,litellm]"
       - run: pytest -v
 
   frontend:


### PR DESCRIPTION
## Summary
- LiteLLM embedding tests from #301 fail on CI with `ImportError: litellm not installed`
- CI test job installs `.[dev,api]` which omits the `litellm` extra → 15+ failing tests on both Python 3.11 and 3.12
- This blocks PRs #305, #306, #307 from going green; master CI also affected

## Fix
Switch `pip install -e ".[dev,api]"` → `pip install -e ".[dev,api,litellm]"` in the test matrix step.

## Test plan
- [x] Lint clean locally
- [ ] CI goes green on this PR
- [ ] After merge, PRs #305/#306/#307 are unblocked