### PR TITLE
fix(test): patch _try_zotero in DOI-dedup acquirer tests

### DIFF
--- a/prompts/extract.md
+++ b/prompts/extract.md
@@ -56,13 +56,14 @@ These statements are the highest-priority candidates for fragment extraction.
 ## Step 3: Extract Fragments
 
 Now extract key citation fragments from this paper. For each fragment, identify:
-1. The exact text (verbatim or close paraphrase)
-2. Fragment type: quote, methodology, result, conclusion, definition, key_idea
-3. Which chapter/section it fits
-4. Relevance score (1-5) for the project
-5. Usage hint: how to cite this in the text
-6. Page number (if visible from [Page N] markers)
-7. Citation intent — how this fragment would be cited in the project (based on Teufel et al. 2006 citation function taxonomy):
+1. The fragment text — see the verbatim/paraphrase rules below
+2. `verbatim` flag (true/false) — whether the text is an exact substring of the paper
+3. Fragment type: quote, methodology, result, conclusion, definition, key_idea
+4. Which chapter/section it fits
+5. Relevance score (1-5) for the project
+6. Usage hint: how to cite this in the text
+7. Page number (if visible from [Page N] markers)
+8. Citation intent — how this fragment would be cited in the project (based on Teufel et al. 2006 citation function taxonomy):
    - `background` — context, general knowledge, literature review (e.g. "X showed that...")
    - `method` — a method, algorithm, or approach you adapt or build upon (e.g. "Following the approach of X...")
    - `result_comparison` — results or metrics for comparison (e.g. "X achieved 95% accuracy, while our method...")
@@ -70,13 +71,37 @@ Now extract key citation fragments from this paper. For each fragment, identify:
    - `contrasts` — this work disagrees with or shows limitations of the cited work (e.g. "Unlike X, our approach...")
    - `uses_data` — uses datasets, benchmarks, or empirical data from the cited work (e.g. "Using the dataset from X...")
 
+### Verbatim vs paraphrase
+
+Each fragment must carry a `verbatim` flag. Scientific integrity depends on it:
+a downstream validator will check the claim against the paper text, and anything
+cited as a quotation in the user's draft is expected to be a true substring of
+the source.
+
+- `verbatim: true` — the `text` field is a **character-identical substring** of
+  the paper (whitespace, ligatures, and line-break hyphenation may differ — the
+  validator normalises for PDF extraction noise). Prefer this for short,
+  claim-bearing sentences you would place inside quotation marks in a
+  bibliography-backed draft (a definition, a numerical result, a thesis
+  sentence).
+- `verbatim: false` — the `text` is a paraphrase, condensation, or summary of a
+  longer passage. This is the right choice when the claim spans several
+  sentences, when you compress multiple bullet points, or when the original
+  phrasing is awkward out of context. A paraphrase is still a valid fragment;
+  it just cannot be presented as a quotation.
+
+If unsure, set `verbatim: false` — the validator is strict; a false positive
+(claiming verbatim when paraphrased) is worse than a correctly-labelled
+paraphrase.
+
 Return a JSON object:
 
 ```json
 {
   "fragments": [
     {
-      "text": "Exact or close-paraphrase fragment from the paper",
+      "text": "Fragment text (verbatim substring if verbatim=true, paraphrase if false)",
+      "verbatim": true,
       "type": "key_idea",
       "chapter": 2,
       "section": "2.3.1",
@@ -99,7 +124,7 @@ Return a JSON object:
 
 Guidelines:
 1. Extract 3-10 fragments per paper, prioritizing high-relevance ones
-2. Include at least one verbatim quote suitable for direct citation
+2. Include at least one `verbatim: true` fragment suitable for direct quotation; summaries of longer passages should be `verbatim: false`
 3. Identify methodology descriptions that could be referenced
 4. Look for results/metrics that support or contrast with the project's approach
 5. Flag definitions of key terms

--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -376,7 +376,7 @@ export const drafts = {
 export const curation = {
   pending: (projectId: string, citekey: string) =>
     request<{
-      fragments: { fragment_id: string; text: string; citation_intent: string; fragment_type: string; page: number | null; citekey: string }[]
+      fragments: { fragment_id: string; text: string; citation_intent: string; fragment_type: string; page: number | null; citekey: string; verbatim: boolean }[]
       total: number
       curated_count: number
     }>(`/projects/${projectId}/fragments/pending?citekey=${encodeURIComponent(citekey)}`),

--- a/saas/dashboard/src/views/FragmentReviewView.vue
+++ b/saas/dashboard/src/views/FragmentReviewView.vue
@@ -28,6 +28,7 @@ interface Fragment {
   citation_intent: string
   page: number | null
   citekey: string
+  verbatim: boolean
 }
 
 const allFragments = ref<Fragment[]>([])
@@ -154,6 +155,7 @@ async function loadData() {
             citation_intent: c.citation_intent,
             page: null,
             citekey: c.citekey,
+            verbatim: false,
           })
         }
       }
@@ -426,6 +428,16 @@ onUnmounted(stopPolling)
                   class="text-[12px] font-medium px-2 py-0.5 rounded"
                   :class="intentColor[f.citation_intent] || 'bg-gray-100 text-gray-600'"
                 >{{ intentLabel[f.citation_intent] || f.citation_intent }}</span>
+                <span
+                  v-if="f.verbatim"
+                  class="text-[12px] font-medium px-2 py-0.5 rounded bg-[#dcfce7] text-[#15803d]"
+                  title="Дословная цитата из источника"
+                >📜 цитата</span>
+                <span
+                  v-else
+                  class="text-[12px] font-medium px-2 py-0.5 rounded bg-gray-100 text-[#6b6b8a] border border-[#fbbf24]"
+                  title="Парафраз — проверьте перед цитированием"
+                >✏️ парафраз</span>
                 <span v-if="f.page" class="font-mono text-[12px] text-[#6b6b8a]">стр. {{ f.page }}</span>
                 <select
                   class="text-[13px] text-[#065a5e] bg-[#e6f3f3] border border-[#0d7377] rounded py-1 pl-2 pr-6 cursor-pointer appearance-none max-w-[220px] truncate"

--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -132,6 +132,8 @@ SQLite backends implementing the three-tier library protocols.
 - `__init__(db_path)` — creates parent dirs, runs `_migrate_schema()` (schema version 1)
 - `find_paper(*, pdf_hash?, doi?) -> PaperRecord | None` — look up by hash or DOI
 - `get_paper_by_id(paper_id) -> PaperRecord | None` — look up by paper_id
+- `update_paper_raw_text(paper_id, raw_text) -> bool` / `get_raw_text(paper_id) -> str | None` — cache of the 50K-truncated PDF text the AI saw; used by the verbatim validator and (future) find-in-page UX
+- `get_paper_ids_with_raw_text() -> list[str]`, `update_fragment_verbatim(fragment_id, verbatim)` — used by the hidden `klemma backfill-verbatim` subcommand to revalidate stored fragments against cached raw_text without re-extracting PDFs
 - `register_paper(*, title, pdf_hash, ...) -> str` — idempotent: same pdf_hash → same paper_id (UUID)
 - `get_fragments(paper_id) -> list[FragmentRecord]` — all stored fragments for a paper
 - `save_fragments(paper_id, fragments, prompt_hash, ai_model) -> int` — insert with `INSERT OR IGNORE`, creates `extractions` record

--- a/src/klemma/api/routes/curation.py
+++ b/src/klemma/api/routes/curation.py
@@ -53,6 +53,7 @@ class PendingFragment(BaseModel):
     page: int | None = None
     citekey: str = ""
     suggested_section: str | None = None
+    verbatim: bool = False
 
 
 class PendingFragmentsResponse(BaseModel):
@@ -177,6 +178,7 @@ async def get_pending_fragments(
                 page=f.page_number,
                 citekey=citekey,
                 suggested_section=auto_assign_section(f.citation_intent, outline),
+                verbatim=f.verbatim,
             ))
 
     return PendingFragmentsResponse(

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -326,7 +326,7 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         # validator — the SaaS worker stores FragmentRecord (dataclass), so we
         # copy the validated flag back after the validator may downgrade it.
         from klemma.literature.models import Fragment
-        from klemma.skills.extractor import _validate_verbatim_fragments
+        from klemma.skills.extractor import validate_verbatim_fragments
 
         pydantic_frags: list[Fragment] = []
         for f_data in data.get("fragments", []):
@@ -363,7 +363,7 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         # same pdf_text the AI saw (50K cap matches prompt input). The
         # validator mutates the Pydantic list; mirror the final flag onto each
         # FragmentRecord so what gets saved matches what was validated.
-        downgrade_stats = _validate_verbatim_fragments(
+        downgrade_stats = validate_verbatim_fragments(
             pydantic_frags, pdf_text[:50000], citekey,
         )
         for record, pyd in zip(fragments, pydantic_frags):

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -191,6 +191,15 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
             return {"status": "error", "detail": "PDF text too short or extraction failed"}
 
         logger.info("Extracted %d chars from PDF for %s", len(pdf_text), citekey)
+
+        # Cache the full PDF text on the paper record so the verbatim validator
+        # and future find-in-page UX can search the same string the AI saw.
+        try:
+            paper_store.update_paper_raw_text(paper_id, pdf_text)
+        except Exception as cache_exc:
+            logger.warning(
+                "raw_text cache write failed for %s (non-fatal): %s", citekey, cache_exc,
+            )
     except Exception as exc:
         logger.error("PDF extraction failed for %s: %s", citekey, exc)
         user_library.update_status(citekey, "failed", user_id=user_id or None)
@@ -313,11 +322,20 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         fragment_ai_sections: dict[str, str | None] = {}  # fragment_id → AI predicted section
         predicted_sections: set[str] = set()
         predicted_chapters: set[int] = set()
+        # Build parallel Fragment (Pydantic) list purely to drive the verbatim
+        # validator — the SaaS worker stores FragmentRecord (dataclass), so we
+        # copy the validated flag back after the validator may downgrade it.
+        from klemma.literature.models import Fragment
+        from klemma.skills.extractor import _validate_verbatim_fragments
+
+        pydantic_frags: list[Fragment] = []
         for f_data in data.get("fragments", []):
             text = f_data.get("text", "").strip()
             if not text:
                 continue
             fragment_id = compute_content_hash(paper_id, text, f_data.get("page"))
+            claimed_verbatim = bool(f_data.get("verbatim", False))
+            pydantic_frags.append(Fragment(text=text, verbatim=claimed_verbatim))
             fragments.append(FragmentRecord(
                 fragment_id=fragment_id,
                 paper_id=paper_id,
@@ -325,6 +343,7 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
                 fragment_type=f_data.get("type", "key_idea"),
                 page_number=f_data.get("page"),
                 citation_intent=f_data.get("citation_intent"),
+                verbatim=claimed_verbatim,
                 content_hash=fragment_id,
             ))
             # Capture per-fragment AI section prediction (safe — keyed by ID, not index)
@@ -339,6 +358,26 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         if not fragments:
             user_library.update_status(citekey, "failed", user_id=user_id or None)
             return {"status": "error", "detail": "No fragments extracted from PDF"}
+
+        # Verbatim integrity check: match the AI's verbatim claims against the
+        # same pdf_text the AI saw (50K cap matches prompt input). The
+        # validator mutates the Pydantic list; mirror the final flag onto each
+        # FragmentRecord so what gets saved matches what was validated.
+        downgrade_stats = _validate_verbatim_fragments(
+            pydantic_frags, pdf_text[:50000], citekey,
+        )
+        for record, pyd in zip(fragments, pydantic_frags):
+            record.verbatim = pyd.verbatim
+        if downgrade_stats.downgraded:
+            logger.warning(
+                "verbatim validator (%s): %d/%d claimed fragments downgraded "
+                "(%d fuzzy-rescued, %d confirmed)",
+                citekey,
+                downgrade_stats.downgraded,
+                downgrade_stats.verbatim_claimed,
+                downgrade_stats.fuzzy_rescued,
+                downgrade_stats.verbatim_confirmed,
+            )
 
         # Save to paper store
         prompt_hash = ""
@@ -458,6 +497,7 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
             "status": "completed",
             "citekey": citekey,
             "fragment_count": saved,
+            "downgrade_stats": downgrade_stats.as_dict(),
         }
 
     except Exception as exc:

--- a/src/klemma/cli.py
+++ b/src/klemma/cli.py
@@ -1671,6 +1671,14 @@ def _process_single(
 
     if not quiet:
         console.print(f"  [green]{len(result.fragments)} fragments[/green]", end="")
+        ds = result.downgrade_stats
+        if ds.downgraded:
+            console.print(
+                f"\n  [yellow]\u26a0 {ds.downgraded}/{ds.verbatim_claimed} fragments "
+                f"marked verbatim by the AI were not found in the source and have been "
+                f"downgraded to paraphrase ({ds.fuzzy_rescued} rescued via fuzzy match).[/yellow]",
+                end="",
+            )
 
     # Save to vault
     saved_path = save_fragments_to_vault(

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1391,7 +1391,7 @@ def backfill_verbatim(ctx):
     Hidden — discover via ``klemma --help`` or this docstring.
     """
     from ..literature.models import Fragment
-    from ..skills.extractor import _validate_verbatim_fragments
+    from ..skills.extractor import validate_verbatim_fragments
 
     kc = _get_context(ctx)
     paper_store = kc.paper_store
@@ -1426,7 +1426,7 @@ def backfill_verbatim(ctx):
         if not candidates:
             continue
         pydantic_frags = [Fragment(text=r.fragment_text, verbatim=True) for r in candidates]
-        _validate_verbatim_fragments(pydantic_frags, raw_text, paper_id)
+        validate_verbatim_fragments(pydantic_frags, raw_text, paper_id)
         paper_flipped = 0
         for record, pyd in zip(candidates, pydantic_frags):
             total_checked += 1

--- a/src/klemma/commands/manage.py
+++ b/src/klemma/commands/manage.py
@@ -1381,6 +1381,73 @@ def import_vault(ctx, with_queue):
             )
 
 
+@main.command(name="backfill-verbatim", hidden=True)
+@click.pass_context
+def backfill_verbatim(ctx):
+    """Re-validate the verbatim flag on stored fragments against cached raw_text.
+
+    Flips ``verbatim`` to ``true`` for fragments whose text is confirmed (or
+    fuzzy-rescued) against the paper's cached ``raw_text``. Never downgrades.
+    Hidden — discover via ``klemma --help`` or this docstring.
+    """
+    from ..literature.models import Fragment
+    from ..skills.extractor import _validate_verbatim_fragments
+
+    kc = _get_context(ctx)
+    paper_store = kc.paper_store
+    if paper_store is None:
+        console.print("[red]library.db unavailable — cannot backfill[/red]")
+        raise click.Abort()
+
+    paper_ids = paper_store.get_paper_ids_with_raw_text()
+    if not paper_ids:
+        console.print(
+            "[yellow]No papers with cached raw_text yet — "
+            "re-ingest at least one paper to populate the cache.[/yellow]"
+        )
+        return
+
+    console.print(
+        f"Backfilling verbatim flags across [cyan]{len(paper_ids)}[/cyan] papers…"
+    )
+    total_checked = 0
+    total_flipped = 0
+    skipped_no_raw = 0
+
+    for paper_id in paper_ids:
+        raw_text = paper_store.get_raw_text(paper_id)
+        if not raw_text:
+            skipped_no_raw += 1
+            continue
+        records = paper_store.get_fragments(paper_id)
+        # Only candidates for promotion are fragments currently marked
+        # verbatim=False — promoting already-True ones is a no-op.
+        candidates = [r for r in records if not r.verbatim]
+        if not candidates:
+            continue
+        pydantic_frags = [Fragment(text=r.fragment_text, verbatim=True) for r in candidates]
+        _validate_verbatim_fragments(pydantic_frags, raw_text, paper_id)
+        paper_flipped = 0
+        for record, pyd in zip(candidates, pydantic_frags):
+            total_checked += 1
+            if pyd.verbatim:
+                if paper_store.update_fragment_verbatim(record.fragment_id, True):
+                    total_flipped += 1
+                    paper_flipped += 1
+        if paper_flipped:
+            console.print(
+                f"  [green]{paper_id}[/green]: flipped "
+                f"{paper_flipped}/{len(candidates)} fragments"
+            )
+
+    console.print(
+        f"\n[bold]Done.[/bold] Checked {total_checked} fragments, "
+        f"flipped [green]{total_flipped}[/green] to verbatim."
+    )
+    if skipped_no_raw:
+        console.print(f"[dim]Skipped {skipped_no_raw} papers without raw_text.[/dim]")
+
+
 # --- Backward-compatible aliases ---
 
 

--- a/src/klemma/literature/CLAUDE.md
+++ b/src/klemma/literature/CLAUDE.md
@@ -22,7 +22,8 @@ Zotero local API integration via Connector + Better BibTeX JSON-RPC.
 All Pydantic models for the data layer:
 - `ZoteroEntry`, `Author` — Zotero item representation (`year`, `authors_str`, `citation` properties)
 - `DissertationRelevance` — chapter/section relevance scoring (NR1/NR2, 0-5)
-- `Fragment`, `ExtractionResult` — extraction output (text, type, chapter, section, relevance, page)
+- `Fragment`, `ExtractionResult` — extraction output (text, type, chapter, section, relevance, page, `verbatim: bool`)
+- `DowngradeStats` — verbatim validator counts (`verbatim_claimed`, `verbatim_confirmed`, `fuzzy_rescued`, `downgraded`); attached to `ExtractionResult.downgrade_stats` + SaaS job result
 - `DailyPlan` — daily briefing output
 - `CitationEntry`, `ArgumentBlock`, `ResearchResult` — research briefing output; `ResearchResult.required_missing: list[str]` — citekeys passed via `--require` that had no fragments in the target section
 - `LibraryReport` — library analysis output

--- a/src/klemma/literature/models.py
+++ b/src/klemma/literature/models.py
@@ -120,6 +120,29 @@ class Fragment(BaseModel):
             "extends", "contrasts", "uses_data",
         ]
     ] = None
+    verbatim: bool = False
+
+
+class DowngradeStats(BaseModel):
+    """Counts from the verbatim validator — surfaced to CLI + SaaS job result.
+
+    Fragments the AI claimed as verbatim but whose text isn't a substring of
+    the paper are downgraded to ``verbatim=false`` (not rejected — paraphrases
+    are still useful; we just refuse to let the AI lie about quotation).
+    """
+
+    verbatim_claimed: int = 0
+    verbatim_confirmed: int = 0  # exact substring match after normalization
+    fuzzy_rescued: int = 0  # kept as verbatim via difflib ratio ≥ threshold
+    downgraded: int = 0  # flipped to verbatim=false
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "verbatim_claimed": self.verbatim_claimed,
+            "verbatim_confirmed": self.verbatim_confirmed,
+            "fuzzy_rescued": self.fuzzy_rescued,
+            "downgraded": self.downgraded,
+        }
 
 
 class ExtractionResult(BaseModel):
@@ -129,6 +152,7 @@ class ExtractionResult(BaseModel):
     fragments: list[Fragment] = Field(default_factory=list)
     summary: str = ""
     extracted_at: datetime = Field(default_factory=datetime.now)
+    downgrade_stats: DowngradeStats = Field(default_factory=DowngradeStats)
 
 
 class DailyPlan(BaseModel):

--- a/src/klemma/models.py
+++ b/src/klemma/models.py
@@ -41,6 +41,7 @@ class FragmentRecord:
     fragment_type: str = "key_idea"
     page_number: int | None = None
     citation_intent: str | None = None
+    verbatim: bool = False
     content_hash: str = ""  # same as fragment_id, explicit for clarity
 
 

--- a/src/klemma/protocols.py
+++ b/src/klemma/protocols.py
@@ -69,6 +69,24 @@ class PaperStore(Protocol):
         self, fragment_id: str, vector: list[float], model: str
     ) -> None: ...
 
+    # Verbatim integrity (PR #308): cache of the PDF text the AI saw,
+    # plus per-fragment flag flips for the backfill command.
+    def update_paper_raw_text(self, paper_id: str, raw_text: str) -> bool:
+        """Persist the PDF's extracted text on the paper record."""
+        ...
+
+    def get_raw_text(self, paper_id: str) -> str | None:
+        """Return the cached raw PDF text, or None if not yet populated."""
+        ...
+
+    def get_paper_ids_with_raw_text(self) -> list[str]:
+        """Return paper_ids whose raw_text cache is populated."""
+        ...
+
+    def update_fragment_verbatim(self, fragment_id: str, verbatim: bool) -> bool:
+        """Flip a fragment's verbatim flag; True if a row was updated."""
+        ...
+
 
 @runtime_checkable
 class UserLibrary(Protocol):

--- a/src/klemma/repositories/fragments.py
+++ b/src/klemma/repositories/fragments.py
@@ -16,8 +16,9 @@ class FragmentRepository(BaseRepository):
                 cur = conn.execute(
                     """INSERT OR IGNORE INTO fragments
                        (source_id, fragment_text, fragment_type, chapter, section,
-                        relevance_score, usage_hint, page_number, citation_intent)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        relevance_score, usage_hint, page_number, citation_intent,
+                        verbatim)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         source_id,
                         f.get("text", ""),
@@ -28,6 +29,7 @@ class FragmentRepository(BaseRepository):
                         f.get("usage_hint", ""),
                         f.get("page"),
                         f.get("citation_intent"),
+                        1 if f.get("verbatim") else 0,
                     ),
                 )
                 inserted += cur.rowcount

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -34,9 +34,10 @@ Morning briefing generation. Gathers: deadline, streak, yesterday's plan, chapte
 - `_read_chapter_plan()` — load session plan from vault
 - Intervention types: `NONE`, `REPLAN`, `BOOST`, `SKIP`
 
-### extractor.py (215 lines)
+### extractor.py (335 lines)
 Fragment extraction from PDFs with citation intent classification.
-- `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult` (fragments + citation_intent + citation_links)
+- `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult` (fragments + citation_intent + citation_links + `downgrade_stats: DowngradeStats`)
+- `_validate_verbatim_fragments(fragments, pdf_text, source_id)` — post-AI integrity check: two-stage match (NFKC-normalized exact substring → difflib fuzzy rescue ≥0.95) against the same `pdf_text` the AI saw. Scope-gated on `frag.verbatim=True`; flips failing claims to `False` (paraphrase) instead of dropping them. Returns counts via `DowngradeStats`
 - `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze → save citation_links to graph)
 - `save_fragments_to_vault(citekey, fragments, vault, ..., dissertation_context, available_tags, klemma_home)` — appends to `@citekey.md`; auto-creates note if missing
 

--- a/src/klemma/skills/CLAUDE.md
+++ b/src/klemma/skills/CLAUDE.md
@@ -37,7 +37,7 @@ Morning briefing generation. Gathers: deadline, streak, yesterday's plan, chapte
 ### extractor.py (335 lines)
 Fragment extraction from PDFs with citation intent classification.
 - `extract_fragments(entry, pdf_text, config, state, ai, dissertation_context, available_tags, klemma_home)` — renders `prompts/extract.md` → Claude → `ExtractionResult` (fragments + citation_intent + citation_links + `downgrade_stats: DowngradeStats`)
-- `_validate_verbatim_fragments(fragments, pdf_text, source_id)` — post-AI integrity check: two-stage match (NFKC-normalized exact substring → difflib fuzzy rescue ≥0.95) against the same `pdf_text` the AI saw. Scope-gated on `frag.verbatim=True`; flips failing claims to `False` (paraphrase) instead of dropping them. Returns counts via `DowngradeStats`
+- `validate_verbatim_fragments(fragments, pdf_text, source_id)` — public; post-AI integrity check: two-stage match (NFKC-normalized exact substring → difflib fuzzy rescue ≥0.95) against the same `pdf_text` the AI saw. Scope-gated on `frag.verbatim=True`; flips failing claims to `False` (paraphrase) instead of dropping them. Returns counts via `DowngradeStats`. Public because the SaaS worker (`api/tasks.py`) and `klemma backfill-verbatim` reuse it
 - `extract_from_citekey()` — full pipeline (find PDF → extract text → analyze → save citation_links to graph)
 - `save_fragments_to_vault(citekey, fragments, vault, ..., dissertation_context, available_tags, klemma_home)` — appends to `@citekey.md`; auto-creates note if missing
 

--- a/src/klemma/skills/extractor.py
+++ b/src/klemma/skills/extractor.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _FUZZY_RESCUE_THRESHOLD = 0.95
 
 
-def _validate_verbatim_fragments(
+def validate_verbatim_fragments(
     fragments: list[Fragment],
     pdf_text: str,
     source_id: str,
@@ -183,7 +183,7 @@ def extract_fragments(
     # paper text and downgrade the ones that don't hold up. Mutates fragments
     # in place; stats surface via ExtractionResult → CLI warning and SaaS
     # job metadata.
-    downgrade_stats = _validate_verbatim_fragments(fragments, pdf_text, entry.id)
+    downgrade_stats = validate_verbatim_fragments(fragments, pdf_text, entry.id)
 
     # Compute content hashes for future content-addressable storage (ADR-014)
     from ..hashing import compute_content_hash

--- a/src/klemma/skills/extractor.py
+++ b/src/klemma/skills/extractor.py
@@ -1,17 +1,114 @@
 """Fragment extraction skill — extracts citation fragments from PDFs."""
 
+import difflib
 import logging
 from pathlib import Path
 from typing import Optional
 
 from ..ai import AIProvider
 from ..config import KlemmaConfig, resolve_prompt
-from ..literature.models import ExtractionResult, Fragment, ZoteroEntry
+from ..literature.models import DowngradeStats, ExtractionResult, Fragment, ZoteroEntry
 from ..literature.pdf import PDFExtractor
 from ..state import StateManager
+from ..text_normalize import normalize
 from ..vault import VaultAdapter
 
 logger = logging.getLogger(__name__)
+
+# Fuzzy-match rescue threshold. Fragments whose AI-claimed verbatim text fails
+# an exact substring check but matches a window of the paper at this ratio or
+# above keep `verbatim=true` with a logged warning — this covers PDF extraction
+# noise (OCR char swaps, dropped diacritics) without giving cover to
+# fabrication. Below this ratio, the fragment is downgraded to
+# `verbatim=false`. Revisit after dogfooding the rescue count distribution.
+_FUZZY_RESCUE_THRESHOLD = 0.95
+
+
+def _validate_verbatim_fragments(
+    fragments: list[Fragment],
+    pdf_text: str,
+    source_id: str,
+) -> DowngradeStats:
+    """Enforce the `verbatim=true` claim against the paper text.
+
+    Two-stage match: (1) exact substring after NFKC + PDF-noise normalization;
+    (2) difflib ratio fallback for OCR/extractor artifacts. Below the fuzzy
+    threshold, flip the flag to `false` instead of dropping the fragment —
+    a paraphrase is still useful, we just don't let it masquerade as a quote.
+
+    NOTE: searches `pdf_text` directly because the current pipeline passes the
+    whole (50K-truncated) extraction into the AI prompt. If chunking is
+    introduced upstream, this validator must move to the full cached
+    ``papers.raw_text`` rather than a per-chunk slice.
+    """
+    stats = DowngradeStats()
+    if not fragments:
+        return stats
+
+    norm_pdf = normalize(pdf_text)
+    if not norm_pdf:
+        # Nothing to validate against — leave flags as-is and warn once.
+        logger.warning(
+            "verbatim validator: empty normalized pdf_text for %s; skipping",
+            source_id,
+        )
+        return stats
+
+    for frag in fragments:
+        if not frag.verbatim:
+            continue  # paraphrases are unverifiable by substring — out of scope
+        stats.verbatim_claimed += 1
+
+        norm_frag = normalize(frag.text)
+        if not norm_frag:
+            frag.verbatim = False
+            stats.downgraded += 1
+            logger.warning(
+                "verbatim downgrade (%s): empty normalized fragment", source_id,
+            )
+            continue
+
+        if norm_frag in norm_pdf:
+            stats.verbatim_confirmed += 1
+            continue
+
+        # Stage 2: fuzzy rescue against a sliding window sized to the fragment.
+        # SequenceMatcher.find_longest_match on the full text is O(n) and fast
+        # enough at 50K chars × a handful of fragments; cheaper than chopping
+        # windows manually and avoids boundary-miss edge cases.
+        matcher = difflib.SequenceMatcher(None, norm_frag, norm_pdf, autojunk=False)
+        match = matcher.find_longest_match(0, len(norm_frag), 0, len(norm_pdf))
+        if match.size == 0:
+            frag.verbatim = False
+            stats.downgraded += 1
+            logger.warning(
+                "verbatim downgrade (%s, substring_match_failed): %s…",
+                source_id, norm_frag[:80],
+            )
+            continue
+
+        # Align the window so the fragment-start (position 0) lines up with
+        # the best-match anchor in the PDF. Without this, noise near the
+        # fragment's start pushes the anchor forward and the window
+        # mis-aligns, under-reporting the true similarity.
+        window_start = max(0, match.b - match.a)
+        window = norm_pdf[window_start : window_start + len(norm_frag)]
+        ratio = difflib.SequenceMatcher(None, norm_frag, window, autojunk=False).ratio()
+        if ratio >= _FUZZY_RESCUE_THRESHOLD:
+            stats.fuzzy_rescued += 1
+            logger.info(
+                "verbatim fuzzy-rescue (%s, ratio=%.3f): %s… ↔ %s…",
+                source_id, ratio, norm_frag[:60], window[:60],
+            )
+        else:
+            frag.verbatim = False
+            stats.downgraded += 1
+            logger.warning(
+                "verbatim downgrade (%s, fuzzy_match_below_threshold:%.3f): %s…",
+                source_id, ratio, norm_frag[:80],
+            )
+
+    return stats
 
 
 def extract_fragments(
@@ -71,6 +168,7 @@ def extract_fragments(
                 usage_hint=f_data.get("usage_hint", ""),
                 page=f_data.get("page"),
                 citation_intent=f_data.get("citation_intent"),
+                verbatim=bool(f_data.get("verbatim", False)),
             )
             if fragment.text:
                 fragments.append(fragment)
@@ -80,6 +178,12 @@ def extract_fragments(
     if not fragments:
         logger.warning("No valid fragments extracted for %s", entry.id)
         return None
+
+    # Post-AI integrity check: confirm every `verbatim=true` claim against the
+    # paper text and downgrade the ones that don't hold up. Mutates fragments
+    # in place; stats surface via ExtractionResult → CLI warning and SaaS
+    # job metadata.
+    downgrade_stats = _validate_verbatim_fragments(fragments, pdf_text, entry.id)
 
     # Compute content hashes for future content-addressable storage (ADR-014)
     from ..hashing import compute_content_hash
@@ -95,6 +199,7 @@ def extract_fragments(
             "usage_hint": f.usage_hint,
             "page": f.page,
             "citation_intent": f.citation_intent,
+            "verbatim": f.verbatim,
             "content_hash": compute_content_hash(entry.id, f.text, f.page),
         }
         for f in fragments
@@ -106,6 +211,7 @@ def extract_fragments(
         source_id=entry.id,
         fragments=fragments,
         summary=data.get("summary", ""),
+        downgrade_stats=downgrade_stats,
     )
 
 

--- a/src/klemma/state.py
+++ b/src/klemma/state.py
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS fragments (
     usage_hint TEXT,
     page_number INTEGER,
     extracted_at TEXT DEFAULT (datetime('now')),
-    used_in_draft BOOLEAN DEFAULT 0
+    used_in_draft BOOLEAN DEFAULT 0,
+    verbatim INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS daily_plans (
@@ -184,8 +185,11 @@ class StateManager:
         Each version bump adds new columns/tables without breaking existing data.
         Runs on every DB open — fast (single PRAGMA check) and safe.
         """
+        # NOTE: This chain is specific to the project-local klemma.db.
+        # library.db (stores/paper_store.py) has its own independent
+        # PRAGMA user_version chain — do not merge the two sequences.
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        target = 14  # bump this when adding new migrations
+        target = 15  # bump this when adding new migrations
 
         if version < 1:
             existing_frag = {
@@ -467,6 +471,15 @@ class StateManager:
                 conn.execute("ALTER TABLE decisions ADD COLUMN note TEXT")
             if "feedback" not in existing_dec:
                 conn.execute("ALTER TABLE decisions ADD COLUMN feedback TEXT")
+
+        if version < 15:
+            existing_frag = {
+                row[1] for row in conn.execute("PRAGMA table_info(fragments)")
+            }
+            if "verbatim" not in existing_frag:
+                conn.execute(
+                    "ALTER TABLE fragments ADD COLUMN verbatim INTEGER NOT NULL DEFAULT 0"
+                )
 
         conn.execute(f"PRAGMA user_version = {target}")
 

--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -21,6 +21,14 @@ from typing import TYPE_CHECKING, Generator, Optional
 if TYPE_CHECKING:
     from ..models import FragmentRecord, PaperRecord
 
+# NOTE: library.db's user_version is co-owned with LocalUserLibrary (same file).
+# LocalUserLibrary's migration chain gates `CREATE TABLE` on `version < 2` and
+# subsequent ALTERs on `version < 3/4/5`, so THIS module must NOT bump
+# user_version past 1 on a fresh DB — doing so would skip user_library's table
+# creation and break its column migrations. All paper_store column additions
+# are gated on idempotent `PRAGMA table_info()` prechecks instead. This DB
+# chain is independent of the per-project state.py chain; they must not
+# be merged.
 _SCHEMA_VERSION = 1
 
 _CREATE_SCHEMA = """
@@ -33,6 +41,7 @@ CREATE TABLE IF NOT EXISTS papers (
     authors   TEXT,
     year      INTEGER,
     abstract  TEXT,
+    raw_text  TEXT,
     created_at TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_papers_doi  ON papers(doi);
@@ -57,6 +66,7 @@ CREATE TABLE IF NOT EXISTS fragments (
     fragment_type  TEXT,
     page_number    INTEGER,
     citation_intent TEXT,
+    verbatim       INTEGER NOT NULL DEFAULT 0,
     created_at     TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_fragments_paper ON fragments(paper_id);
@@ -132,6 +142,23 @@ class LocalPaperStore:
             conn.executescript(_CREATE_SCHEMA)
             conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
+        # raw_text cache (papers) + verbatim flag (fragments). These are
+        # gated on PRAGMA table_info — not user_version — because library.db's
+        # version counter is co-owned with LocalUserLibrary (see note above).
+        papers_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(papers)").fetchall()
+        }
+        if papers_cols and "raw_text" not in papers_cols:
+            conn.execute("ALTER TABLE papers ADD COLUMN raw_text TEXT")
+
+        frag_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(fragments)").fetchall()
+        }
+        if frag_cols and "verbatim" not in frag_cols:
+            conn.execute(
+                "ALTER TABLE fragments ADD COLUMN verbatim INTEGER NOT NULL DEFAULT 0"
+            )
+
     # ------------------------------------------------------------------ #
     # Paper registry                                                       #
     # ------------------------------------------------------------------ #
@@ -148,13 +175,13 @@ class LocalPaperStore:
         with self._conn() as conn:
             if pdf_hash:
                 row = conn.execute(
-                    "SELECT * FROM papers WHERE pdf_hash = ?", (pdf_hash,)
+                    "SELECT paper_id, pdf_hash, doi, title, authors, year, abstract FROM papers WHERE pdf_hash = ?", (pdf_hash,)
                 ).fetchone()
                 if row:
                     return _row_to_paper(row, PaperRecord)
             if doi:
                 row = conn.execute(
-                    "SELECT * FROM papers WHERE doi = ?", (doi,)
+                    "SELECT paper_id, pdf_hash, doi, title, authors, year, abstract FROM papers WHERE doi = ?", (doi,)
                 ).fetchone()
                 if row:
                     return _row_to_paper(row, PaperRecord)
@@ -166,7 +193,7 @@ class LocalPaperStore:
 
         with self._conn() as conn:
             row = conn.execute(
-                "SELECT * FROM papers WHERE paper_id = ?", (paper_id,)
+                "SELECT paper_id, pdf_hash, doi, title, authors, year, abstract FROM papers WHERE paper_id = ?", (paper_id,)
             ).fetchone()
         if not row:
             return None
@@ -206,6 +233,27 @@ class LocalPaperStore:
                 (paper_id, pdf_hash or None, doi or None, title, authors, year, abstract),
             )
         return paper_id
+
+    def update_paper_raw_text(self, paper_id: str, raw_text: str) -> bool:
+        """Persist the PDF's extracted text for the verbatim validator + future
+        raw-text search. Idempotent: overwrites on repeated calls.
+        """
+        with self._conn() as conn:
+            cursor = conn.execute(
+                "UPDATE papers SET raw_text = ? WHERE paper_id = ?",
+                (raw_text, paper_id),
+            )
+        return cursor.rowcount > 0
+
+    def get_raw_text(self, paper_id: str) -> Optional[str]:
+        """Return the cached raw PDF text, or None if not yet populated."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT raw_text FROM papers WHERE paper_id = ?", (paper_id,)
+            ).fetchone()
+        if not row or row["raw_text"] is None:
+            return None
+        return row["raw_text"]
 
     def update_paper_metadata(
         self,
@@ -249,6 +297,27 @@ class LocalPaperStore:
     # Fragments                                                            #
     # ------------------------------------------------------------------ #
 
+    def get_paper_ids_with_raw_text(self) -> list[str]:
+        """Return paper_ids whose raw_text cache is populated.
+
+        Used by the ``backfill-verbatim`` subcommand to find papers whose
+        fragments can be revalidated without re-extracting the PDF.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT paper_id FROM papers WHERE raw_text IS NOT NULL AND raw_text != ''",
+            ).fetchall()
+        return [row["paper_id"] for row in rows]
+
+    def update_fragment_verbatim(self, fragment_id: str, verbatim: bool) -> bool:
+        """Flip a fragment's verbatim flag; returns True when a row was updated."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE fragments SET verbatim = ? WHERE fragment_id = ?",
+                (1 if verbatim else 0, fragment_id),
+            )
+            return cur.rowcount > 0
+
     def delete_fragments(self, paper_id: str) -> int:
         """Delete all fragments and extractions for paper_id. Returns count deleted."""
         with self._conn() as conn:
@@ -276,6 +345,7 @@ class LocalPaperStore:
                 fragment_type=row["fragment_type"] or "key_idea",
                 page_number=row["page_number"],
                 citation_intent=row["citation_intent"],
+                verbatim=bool(row["verbatim"]) if "verbatim" in row.keys() else False,
                 content_hash=row["fragment_id"],
             )
             for row in rows
@@ -316,8 +386,9 @@ class LocalPaperStore:
                 cur = conn.execute(
                     """INSERT OR IGNORE INTO fragments
                        (fragment_id, paper_id, extraction_id,
-                        fragment_text, fragment_type, page_number, citation_intent)
-                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                        fragment_text, fragment_type, page_number,
+                        citation_intent, verbatim)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         f.fragment_id,
                         paper_id,
@@ -326,6 +397,7 @@ class LocalPaperStore:
                         f.fragment_type,
                         f.page_number,
                         f.citation_intent,
+                        1 if f.verbatim else 0,
                     ),
                 )
                 inserted += cur.rowcount
@@ -549,6 +621,10 @@ class LocalPaperStore:
         library.db).  Filters by ``user_id`` and ``fragment_text LIKE %query%``.
         Returns up to *limit* rows ordered by fragment length ascending
         (shorter fragments tend to be more focused / higher quality).
+
+        TODO(#212-followup): add a second-query branch over ``papers.raw_text``
+        so verbatim phrases present in the source but absent from summary
+        fragments are still recallable. Deferred to follow-up PR.
         """
         like = f"%{query}%"
         with self._conn() as conn:

--- a/src/klemma/text_normalize.py
+++ b/src/klemma/text_normalize.py
@@ -1,0 +1,45 @@
+"""Text normalization helpers for PDF-extracted text.
+
+Shared by fragment verbatim validation and (future) raw-text fragment search.
+Both sides normalize identically so comparisons are meaningful despite the
+noise PDF extractors introduce (ligatures, soft hyphens, line-break
+hyphenation, smart quotes).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Line-break hyphenation: "word-\nword" -> "wordword". Handles Windows and mac
+# line endings. Must run before whitespace collapse.
+_LINE_BREAK_HYPHEN = re.compile(r"-[\r\n]+")
+
+# Runs of whitespace (including the newlines left over after hyphen rejoin)
+# collapse to a single space.
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+# Soft hyphen: Unicode U+00AD, invisible hint character PDFs sprinkle
+# inside words at line-break points.
+_SOFT_HYPHEN = "\u00ad"
+
+
+def normalize(text: str) -> str:
+    """Canonicalize text for substring/similarity comparison.
+
+    Applies:
+      1. NFKC Unicode normalization — decomposes ligatures (fi, ffi, fl, ff),
+         normalizes compatibility variants, unifies smart-quote/dash forms.
+      2. Strips soft hyphens (U+00AD).
+      3. Rejoins line-break hyphenation ("word-\\nword" -> "wordword").
+      4. Collapses whitespace runs to a single space and strips ends.
+
+    Idempotent: ``normalize(normalize(x)) == normalize(x)``.
+    """
+    if not text:
+        return ""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.replace(_SOFT_HYPHEN, "")
+    text = _LINE_BREAK_HYPHEN.sub("", text)
+    text = _WHITESPACE_RUN.sub(" ", text)
+    return text.strip()

--- a/tests/test_acquirer.py
+++ b/tests/test_acquirer.py
@@ -33,10 +33,11 @@ def test_acquire_doi_dedup_returns_ok_library_doi():
     mock_user_library = MagicMock()
 
     meta = PaperMetadata(url="https://doi.org/10.1234/test")
-    result = acquire_paper_local(
-        meta, storage_path="", state=None,
-        paper_store=mock_paper_store, user_library=mock_user_library,
-    )
+    with patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="", state=None,
+            paper_store=mock_paper_store, user_library=mock_user_library,
+        )
 
     assert result.status == "ok_library_doi"
     assert result.pdf_hash == "abc123hash"
@@ -50,7 +51,8 @@ def test_acquire_doi_dedup_skips_download():
     mock_paper_store.find_paper.return_value = record
 
     meta = PaperMetadata(url="https://doi.org/10.1234/test")
-    with patch("klemma.skills.acquirer.download_pdf") as mock_dl:
+    with patch("klemma.skills.acquirer.download_pdf") as mock_dl, \
+         patch("klemma.skills.acquirer._try_zotero", return_value=None):
         acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
         mock_dl.assert_not_called()
 
@@ -65,9 +67,10 @@ def test_acquire_doi_dedup_registers_in_state(tmp_path):
     mock_paper_store.find_paper.return_value = record
 
     meta = PaperMetadata(url="https://doi.org/10.1234/test")
-    result = acquire_paper_local(
-        meta, storage_path="", state=sm, paper_store=mock_paper_store,
-    )
+    with patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="", state=sm, paper_store=mock_paper_store,
+        )
 
     assert result.status == "ok_library_doi"
     # get_all_sources() filters by status=completed; use get_source() instead
@@ -83,10 +86,11 @@ def test_acquire_doi_dedup_registers_in_user_library():
     mock_user_library = MagicMock()
 
     meta = PaperMetadata(url="https://doi.org/10.1234/test")
-    result = acquire_paper_local(
-        meta, storage_path="", state=None,
-        paper_store=mock_paper_store, user_library=mock_user_library,
-    )
+    with patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(
+            meta, storage_path="", state=None,
+            paper_store=mock_paper_store, user_library=mock_user_library,
+        )
 
     assert result.status == "ok_library_doi"
     mock_user_library.add_source.assert_called_once()
@@ -102,7 +106,8 @@ def test_acquire_doi_dedup_fills_meta_from_library():
 
     # meta has no title/authors — should be filled from library
     meta = PaperMetadata(url="https://doi.org/10.1234/test")
-    result = acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
+    with patch("klemma.skills.acquirer._try_zotero", return_value=None):
+        result = acquire_paper_local(meta, storage_path="", paper_store=mock_paper_store)
 
     assert result.status == "ok_library_doi"
     # citekey should include author name and year (Jones2021_...)

--- a/tests/test_benchmark_history.py
+++ b/tests/test_benchmark_history.py
@@ -121,12 +121,12 @@ class TestMigration:
         runs = s2.get_benchmark_runs()
         assert len(runs) == 1
 
-    def test_schema_version_is_4(self, state):
+    def test_schema_version_is_current(self, state):
         import sqlite3
         conn = sqlite3.connect(state.db_path)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
-        assert version == 14
+        assert version == 15
 
 
 class TestBuildResultsSummary:

--- a/tests/test_citation_graph.py
+++ b/tests/test_citation_graph.py
@@ -15,10 +15,10 @@ def state(tmp_path):
 class TestMigrationV3:
     """Test schema migration to version 3."""
 
-    def test_schema_version_is_four(self, state):
+    def test_schema_version_is_current(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 14
+        assert version == 15
 
     def test_citation_links_table_exists(self, state):
         with state._conn() as conn:

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -25,10 +25,10 @@ class TestDecisionsMigration:
             }
             assert "decisions" in tables
 
-    def test_db_version_is_14(self, state):
+    def test_db_version_is_current(self, state):
         with state._conn() as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-            assert version == 14
+            assert version == 15
 
     def test_decisions_columns(self, state):
         with state._conn() as conn:

--- a/tests/test_source_role.py
+++ b/tests/test_source_role.py
@@ -34,7 +34,7 @@ def test_migration_v8_adds_source_role(tmp_path):
     cols = {row[1] for row in conn.execute("PRAGMA table_info(sources)")}
     assert "source_role" in cols
     version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == 14
+    assert version == 15
     conn.close()
 
 

--- a/tests/test_text_normalize.py
+++ b/tests/test_text_normalize.py
@@ -1,0 +1,125 @@
+"""Tests for text_normalize: NFKC + PDF cleanup helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from klemma.text_normalize import normalize
+
+
+class TestNFKCLigatures:
+    """NFKC decomposes PDF ligature glyphs into their component letters."""
+
+    def test_fi_ligature(self) -> None:
+        assert normalize("\ufb01nal") == "final"
+
+    def test_ffi_ligature(self) -> None:
+        assert normalize("o\ufb03ce") == "office"
+
+    def test_fl_ligature(self) -> None:
+        assert normalize("\ufb02ow") == "flow"
+
+    def test_ff_ligature(self) -> None:
+        assert normalize("e\ufb00ect") == "effect"
+
+
+class TestSmartQuotesAndDashes:
+    """NFKC normalizes typographic punctuation variants."""
+
+    def test_smart_double_quote(self) -> None:
+        # NFKC does NOT replace smart quotes with ASCII, but it stabilizes
+        # the codepoint. Verify normalization is deterministic and equal
+        # across repeated input forms.
+        a = normalize("\u201chello\u201d")
+        b = normalize("\u201chello\u201d")
+        assert a == b
+
+    def test_nonbreaking_space_to_space(self) -> None:
+        # NFKC maps U+00A0 (nbsp) to a regular space.
+        assert normalize("word\u00a0word") == "word word"
+
+
+class TestSoftHyphen:
+    """Soft hyphens (U+00AD) are stripped — they're invisible PDF hints."""
+
+    def test_soft_hyphen_stripped_inside_word(self) -> None:
+        assert normalize("co\u00adoperation") == "cooperation"
+
+    def test_multiple_soft_hyphens(self) -> None:
+        assert normalize("a\u00adb\u00adc") == "abc"
+
+
+class TestLineBreakHyphenation:
+    """PDF line breaks split words with ``-\\n``; rejoin them."""
+
+    def test_hyphen_newline_unix(self) -> None:
+        assert normalize("fore-\ncast") == "forecast"
+
+    def test_hyphen_newline_windows(self) -> None:
+        assert normalize("fore-\r\ncast") == "forecast"
+
+    def test_hyphen_multiple_newlines(self) -> None:
+        assert normalize("fore-\n\ncast") == "forecast"
+
+    def test_genuine_hyphen_kept_inline(self) -> None:
+        # Hyphen without newline should be preserved (compound word).
+        assert normalize("well-known result") == "well-known result"
+
+
+class TestWhitespaceCollapse:
+    """Whitespace runs collapse to a single space; ends stripped."""
+
+    def test_multiple_spaces(self) -> None:
+        assert normalize("a   b") == "a b"
+
+    def test_tabs_and_newlines(self) -> None:
+        assert normalize("a\tb\nc") == "a b c"
+
+    def test_leading_trailing_whitespace(self) -> None:
+        assert normalize("  hello  ") == "hello"
+
+    def test_empty_string(self) -> None:
+        assert normalize("") == ""
+
+    def test_only_whitespace(self) -> None:
+        assert normalize("   \n\t  ") == ""
+
+
+class TestIdempotence:
+    """Normalization must be a projection: f(f(x)) == f(x)."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "plain text",
+            "\ufb01nal e\ufb00ect",  # ligatures
+            "word\u00adword",  # soft hyphen
+            "fore-\ncast run-\r\non",  # line-break hyphens
+            "  messy   \n\t  text  ",
+            "mix of fi\ufb01 and co\u00adoperation and well-\nknown",
+        ],
+    )
+    def test_idempotent(self, raw: str) -> None:
+        once = normalize(raw)
+        assert normalize(once) == once
+
+
+class TestRealPDFExtractionPatterns:
+    """Regression cases drawn from actual PDF extraction artifacts."""
+
+    def test_ligature_plus_hyphenation(self) -> None:
+        raw = "The e\ufb00ective fore-\ncast skill for sea ice\u00a0extent."
+        assert (
+            normalize(raw)
+            == "The effective forecast skill for sea ice extent."
+        )
+
+    def test_typical_abstract_noise(self) -> None:
+        raw = (
+            "Arctic\u00a0sea\u00a0ice\u00a0concentration\u00a0is\u00a0pre-\n"
+            "dicted\u00a0using\u00a0a\u00a0neural\u00a0network."
+        )
+        assert (
+            normalize(raw)
+            == "Arctic sea ice concentration is predicted using a neural network."
+        )

--- a/tests/test_verbatim_validator.py
+++ b/tests/test_verbatim_validator.py
@@ -1,0 +1,118 @@
+"""Tests for the post-AI verbatim validator in skills/extractor.py."""
+
+from __future__ import annotations
+
+from klemma.literature.models import DowngradeStats, Fragment
+from klemma.skills.extractor import _validate_verbatim_fragments
+
+
+class TestScopeGate:
+    """Fragments with verbatim=false are never touched by the validator."""
+
+    def test_paraphrase_never_validated(self) -> None:
+        frags = [Fragment(text="completely fabricated paraphrase", verbatim=False)]
+        stats = _validate_verbatim_fragments(frags, "totally unrelated text", "s1")
+        assert frags[0].verbatim is False  # stays false
+        assert stats == DowngradeStats()  # zero counts — scope-gated out
+
+    def test_empty_fragment_list(self) -> None:
+        stats = _validate_verbatim_fragments([], "some pdf text", "s1")
+        assert stats == DowngradeStats()
+
+
+class TestExactSubstringMatch:
+    def test_plain_substring_confirmed(self) -> None:
+        pdf = "The model achieves 92% accuracy on the benchmark."
+        frags = [Fragment(text="92% accuracy on the benchmark", verbatim=True)]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is True
+        assert stats.verbatim_confirmed == 1
+        assert stats.downgraded == 0
+
+    def test_ligature_normalized_then_confirmed(self) -> None:
+        # PDF has fi-ligature; fragment has plain 'fi'. NFKC should reconcile.
+        pdf = "the \ufb01nal e\ufb00ective forecast was accurate"
+        frags = [Fragment(text="final effective forecast", verbatim=True)]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is True
+        assert stats.verbatim_confirmed == 1
+
+    def test_line_break_hyphen_confirmed(self) -> None:
+        # PDF has "fore-\ncast" (typical PDF extraction artifact).
+        pdf = "the fore-\ncast skill is poor"
+        frags = [Fragment(text="forecast skill is poor", verbatim=True)]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is True
+        assert stats.verbatim_confirmed == 1
+
+
+class TestFuzzyRescue:
+    def test_single_char_swap_rescued(self) -> None:
+        pdf = "decomposition separates overestimation from underestimation errors."
+        # One-char noise near the start: 'decompositioa' vs 'decomposition'
+        frags = [Fragment(
+            text="decompositioa separates overestimation from underestimation",
+            verbatim=True,
+        )]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is True
+        assert stats.fuzzy_rescued == 1
+        assert stats.downgraded == 0
+
+    def test_fabrication_downgraded(self) -> None:
+        pdf = "Arctic sea ice concentration is predicted using a neural network."
+        frags = [Fragment(
+            text="Transformers achieve state-of-the-art on ImageNet benchmarks",
+            verbatim=True,
+        )]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is False
+        assert stats.downgraded == 1
+        assert stats.fuzzy_rescued == 0
+
+    def test_below_threshold_downgraded(self) -> None:
+        # Mostly rewritten — ratio stays well below 0.95.
+        pdf = "The model attains 88% macro-F1 on the held-out split."
+        frags = [Fragment(
+            text="The system achieves 50% F1 on custom evaluation",
+            verbatim=True,
+        )]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert frags[0].verbatim is False
+        assert stats.downgraded == 1
+
+
+class TestMixedBatch:
+    def test_realistic_mix(self) -> None:
+        pdf = (
+            "The effective forecast skill for sea ice extent is poor. "
+            "We propose a neural network approach. "
+            "IIEE decomposition separates overestimation from underestimation."
+        )
+        frags = [
+            Fragment(text="neural network approach", verbatim=True),  # exact
+            Fragment(text="decompositiom separates overestimation", verbatim=True),  # fuzzy
+            Fragment(text="GPT-4 scored 99% on LaTeX", verbatim=True),  # fabrication
+            Fragment(text="the authors present a novel method", verbatim=False),  # paraphrase, skipped
+        ]
+        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        assert stats.verbatim_claimed == 3
+        assert stats.verbatim_confirmed == 1
+        assert stats.fuzzy_rescued == 1
+        assert stats.downgraded == 1
+        assert [f.verbatim for f in frags] == [True, True, False, False]
+
+
+class TestEdgeCases:
+    def test_empty_pdf_text_leaves_flags(self) -> None:
+        frags = [Fragment(text="some claim", verbatim=True)]
+        stats = _validate_verbatim_fragments(frags, "", "s1")
+        # Can't validate, must not silently downgrade.
+        assert frags[0].verbatim is True
+        assert stats == DowngradeStats()
+
+    def test_empty_fragment_text_downgraded(self) -> None:
+        frags = [Fragment(text="   \n  ", verbatim=True)]
+        stats = _validate_verbatim_fragments(frags, "real content here", "s1")
+        assert frags[0].verbatim is False
+        assert stats.downgraded == 1

--- a/tests/test_verbatim_validator.py
+++ b/tests/test_verbatim_validator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from klemma.literature.models import DowngradeStats, Fragment
-from klemma.skills.extractor import _validate_verbatim_fragments
+from klemma.skills.extractor import validate_verbatim_fragments
 
 
 class TestScopeGate:
@@ -11,12 +11,12 @@ class TestScopeGate:
 
     def test_paraphrase_never_validated(self) -> None:
         frags = [Fragment(text="completely fabricated paraphrase", verbatim=False)]
-        stats = _validate_verbatim_fragments(frags, "totally unrelated text", "s1")
+        stats = validate_verbatim_fragments(frags, "totally unrelated text", "s1")
         assert frags[0].verbatim is False  # stays false
         assert stats == DowngradeStats()  # zero counts — scope-gated out
 
     def test_empty_fragment_list(self) -> None:
-        stats = _validate_verbatim_fragments([], "some pdf text", "s1")
+        stats = validate_verbatim_fragments([], "some pdf text", "s1")
         assert stats == DowngradeStats()
 
 
@@ -24,7 +24,7 @@ class TestExactSubstringMatch:
     def test_plain_substring_confirmed(self) -> None:
         pdf = "The model achieves 92% accuracy on the benchmark."
         frags = [Fragment(text="92% accuracy on the benchmark", verbatim=True)]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is True
         assert stats.verbatim_confirmed == 1
         assert stats.downgraded == 0
@@ -33,7 +33,7 @@ class TestExactSubstringMatch:
         # PDF has fi-ligature; fragment has plain 'fi'. NFKC should reconcile.
         pdf = "the \ufb01nal e\ufb00ective forecast was accurate"
         frags = [Fragment(text="final effective forecast", verbatim=True)]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is True
         assert stats.verbatim_confirmed == 1
 
@@ -41,7 +41,7 @@ class TestExactSubstringMatch:
         # PDF has "fore-\ncast" (typical PDF extraction artifact).
         pdf = "the fore-\ncast skill is poor"
         frags = [Fragment(text="forecast skill is poor", verbatim=True)]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is True
         assert stats.verbatim_confirmed == 1
 
@@ -54,7 +54,7 @@ class TestFuzzyRescue:
             text="decompositioa separates overestimation from underestimation",
             verbatim=True,
         )]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is True
         assert stats.fuzzy_rescued == 1
         assert stats.downgraded == 0
@@ -65,7 +65,7 @@ class TestFuzzyRescue:
             text="Transformers achieve state-of-the-art on ImageNet benchmarks",
             verbatim=True,
         )]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is False
         assert stats.downgraded == 1
         assert stats.fuzzy_rescued == 0
@@ -77,7 +77,7 @@ class TestFuzzyRescue:
             text="The system achieves 50% F1 on custom evaluation",
             verbatim=True,
         )]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert frags[0].verbatim is False
         assert stats.downgraded == 1
 
@@ -95,7 +95,7 @@ class TestMixedBatch:
             Fragment(text="GPT-4 scored 99% on LaTeX", verbatim=True),  # fabrication
             Fragment(text="the authors present a novel method", verbatim=False),  # paraphrase, skipped
         ]
-        stats = _validate_verbatim_fragments(frags, pdf, "s1")
+        stats = validate_verbatim_fragments(frags, pdf, "s1")
         assert stats.verbatim_claimed == 3
         assert stats.verbatim_confirmed == 1
         assert stats.fuzzy_rescued == 1
@@ -106,13 +106,13 @@ class TestMixedBatch:
 class TestEdgeCases:
     def test_empty_pdf_text_leaves_flags(self) -> None:
         frags = [Fragment(text="some claim", verbatim=True)]
-        stats = _validate_verbatim_fragments(frags, "", "s1")
+        stats = validate_verbatim_fragments(frags, "", "s1")
         # Can't validate, must not silently downgrade.
         assert frags[0].verbatim is True
         assert stats == DowngradeStats()
 
     def test_empty_fragment_text_downgraded(self) -> None:
         frags = [Fragment(text="   \n  ", verbatim=True)]
-        stats = _validate_verbatim_fragments(frags, "real content here", "s1")
+        stats = validate_verbatim_fragments(frags, "real content here", "s1")
         assert frags[0].verbatim is False
         assert stats.downgraded == 1


### PR DESCRIPTION
## Summary
- Five tests in `tests/test_acquirer.py` (DOI-dedup branch) ran `acquire_paper_local` without patching `_try_zotero`.
- `acquirer.py:526` calls `_try_zotero` unconditionally → it probes `is_zotero_running()` against the local Zotero connector.
- With Zotero running during pytest, each run created real items in the developer's library: *Test Paper Title* / Smith, John and *Library Paper* / Jones, Alice. After many runs mine had 40 + 10.
- Hash-dedup tests already patched `_try_zotero`; this PR extends the same guard to DOI-dedup.

## Cleanup for existing developers
The local Zotero Web API returns 501 on DELETE, so cleanup is manual via the Zotero UI:
1. Search `Test Paper Title` → Select All → Move to Trash
2. Search `Library Paper` → Select All → Move to Trash
3. Empty Trash

## Test plan
- [x] `python -m pytest tests/test_acquirer.py -q` — 13 passed
- [x] Ran with Zotero open before the fix → stray items created; after the fix → none