### PR TITLE
feat(prompt): verbatim-only fragment extraction

### DIFF
--- a/prompts/extract.md
+++ b/prompts/extract.md
@@ -71,28 +71,26 @@ Now extract key citation fragments from this paper. For each fragment, identify:
    - `contrasts` — this work disagrees with or shows limitations of the cited work (e.g. "Unlike X, our approach...")
    - `uses_data` — uses datasets, benchmarks, or empirical data from the cited work (e.g. "Using the dataset from X...")
 
-### Verbatim vs paraphrase
+### Verbatim only — no paraphrasing
 
-Each fragment must carry a `verbatim` flag. Scientific integrity depends on it:
-a downstream validator will check the claim against the paper text, and anything
-cited as a quotation in the user's draft is expected to be a true substring of
-the source.
+**Every fragment's `text` field MUST be a character-identical substring of the
+paper.** Whitespace, ligatures, and line-break hyphenation may differ — the
+downstream validator normalises for PDF extraction noise. Anything else is a
+scientific integrity failure: the user cites fragments as quotations in their
+draft, and a paraphrase presented as a quotation is a fabrication.
 
-- `verbatim: true` — the `text` field is a **character-identical substring** of
-  the paper (whitespace, ligatures, and line-break hyphenation may differ — the
-  validator normalises for PDF extraction noise). Prefer this for short,
-  claim-bearing sentences you would place inside quotation marks in a
-  bibliography-backed draft (a definition, a numerical result, a thesis
-  sentence).
-- `verbatim: false` — the `text` is a paraphrase, condensation, or summary of a
-  longer passage. This is the right choice when the claim spans several
-  sentences, when you compress multiple bullet points, or when the original
-  phrasing is awkward out of context. A paraphrase is still a valid fragment;
-  it just cannot be presented as a quotation.
+- `verbatim: true` — required for every fragment you emit. Copy the sentence
+  (or a contiguous clause) exactly from the paper. Short, claim-bearing
+  sentences are ideal: a definition, a numerical result, a thesis sentence.
+- `verbatim: false` — **do not use.** If a useful claim spans multiple
+  sentences or cannot be expressed as a contiguous substring, either pick the
+  single most quotable sentence from that passage (and set `verbatim: true`)
+  or **omit the fragment entirely**. Fewer correct fragments beats more
+  fragments that cannot be quoted.
 
-If unsure, set `verbatim: false` — the validator is strict; a false positive
-(claiming verbatim when paraphrased) is worse than a correctly-labelled
-paraphrase.
+If you cannot find a verbatim substring that captures the claim, drop the
+fragment. The validator is strict; the system prefers silence over
+fabrication.
 
 Return a JSON object:
 
@@ -100,7 +98,7 @@ Return a JSON object:
 {
   "fragments": [
     {
-      "text": "Fragment text (verbatim substring if verbatim=true, paraphrase if false)",
+      "text": "Verbatim substring from the paper (character-identical)",
       "verbatim": true,
       "type": "key_idea",
       "chapter": 2,
@@ -124,7 +122,7 @@ Return a JSON object:
 
 Guidelines:
 1. Extract 3-10 fragments per paper, prioritizing high-relevance ones
-2. Include at least one `verbatim: true` fragment suitable for direct quotation; summaries of longer passages should be `verbatim: false`
+2. Every fragment must be `verbatim: true` with a character-identical substring of the paper; drop any claim you cannot express as a direct quotation
 3. Identify methodology descriptions that could be referenced
 4. Look for results/metrics that support or contrast with the project's approach
 5. Flag definitions of key terms


### PR DESCRIPTION
## Summary
- Tighten `prompts/extract.md` so every emitted fragment MUST be a character-identical substring of the paper (`verbatim: true`).
- Drop the paraphrase affordance: `verbatim: false` is now explicitly disallowed — prefer fewer fragments over unquotable claims.
- Validator from #308 unchanged: remains the integrity backstop for any AI-mislabelled output.

## Test plan
- [x] `python -m pytest tests/test_prompts.py -q` → 30 passed
- [ ] Smoke: re-ingest a paper via SaaS, confirm FragmentReviewView shows 📜 on all extracted fragments (no ✏️)
- [ ] Downgrade log: any 📜→✏️ downgrade now indicates the AI lied, not a legitimate paraphrase — monitor `DowngradeStats` from worker logs

## Release Note

### Problem
The extraction prompt from #308 left `verbatim=false` as a legitimate fallback for claims the AI couldn't phrase as a contiguous substring. In practice this meant the curation UI mixed quotable (📜) and unquotable (✏️) fragments in a single review flow. Users had to re-read every fragment before citing to check whether they were looking at a real quote or a paraphrase the AI had smoothed into citation shape. The paraphrase affordance quietly re-introduced the integrity failure mode #308 set out to close: a `[@citekey]` next to AI-generated text that never appeared in the source.

### Academic Foundation
Teufel et al. (2006) — the citation-function taxonomy Klemma uses — treats citations as pointers to source claims, not to derived summaries. A paraphrase presented as a quotation in a draft is an unverifiable citation. Feynman design steals (project memory) flagged the same pattern: integrity commandments in adjacent tools forbid emitting non-substring text as a "quote". The validator in #308 already enforces this at write-time; this PR pulls the rule upstream into the prompt so the AI stops proposing paraphrases the user then has to curate.

### Implementation
Three surgical edits in `prompts/extract.md`:
1. The "Verbatim vs paraphrase" section is rewritten as "Verbatim only — no paraphrasing" with explicit guidance: `verbatim: true` required, `verbatim: false` forbidden, drop the claim if it can't be expressed as a contiguous substring.
2. JSON schema comment updated from "Exact or paraphrased fragment" to "Verbatim substring from the paper (character-identical)".
3. Guideline #2 updated to match: every fragment must be `verbatim: true`.
No code changes — the post-AI validator from #308, the `DowngradeStats` return model, and the UI badges all stay as-is. Anything the AI still mislabels gets caught downstream and logged as a warning.

### Results
30/30 prompt tests still passing. Zero LOC delta outside `prompts/extract.md`. Expected impact: fragment counts per paper may drop modestly (AI will skip claims it can't quote verbatim), but every accepted fragment becomes safe to cite without re-reading the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)