### PR TITLE
fix(saas): raise adaptive_max_tokens floor 1024→2048

### DIFF
--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -344,10 +344,11 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         # Adaptive max_tokens: short PDFs produce few fragments, so a high
         # cap is wasted latency + cost. ~4 chars per token, fragments are
         # typically 200-400 tokens each; we scale with pdf size but floor
-        # at 1024 (to cover at least the dissertation_context + few frags)
+        # at 2048 (floor was 1024, but PDFs shorter than 8K chars would get
+        # truncated JSON responses — raised after e2e test confirmed the bug)
         # and cap at 8192 (the previous hardcoded ceiling).
         pdf_chars = len(pdf_text)
-        adaptive_max_tokens = max(1024, min(8192, pdf_chars // 4))
+        adaptive_max_tokens = max(2048, min(8192, pdf_chars // 4))
         result = ai.call_with_meta(system, user_prompt, max_tokens=adaptive_max_tokens)
         if not result or not result.text:
             user_library.update_status(citekey, "failed", user_id=user_id or None)


### PR DESCRIPTION
## Summary

- Root cause: `adaptive_max_tokens = max(1024, min(8192, pdf_chars // 4))` — PDFs shorter than ~8K chars yielded `max_tokens=1024`, which is insufficient for a complete JSON response when the AI extracts 5+ fragments (~1500 tokens needed)
- Effect: JSON response truncated mid-fragment → `extract_json()` finds unmatched braces → `json.loads` fails → `"Failed to parse AI response as JSON"` → processing job fails
- Confirmed via golden e2e test: synthetic PDFs (~1200 chars) reproducibly hit this floor; real academic papers (≥5K chars) are unaffected
- Fix: raise the floor from 1024 to 2048 tokens

## Test plan

- [ ] Re-run `tests/test_golden_e2e.py` after deploy — synthetic PDF processing should succeed
- [ ] Real PDFs unaffected (they get `pdf_chars // 4` tokens, well above 2048)

Fixes e2e regression surfaced by running `test_golden_e2e.py` post-PR-315 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)