### PR TITLE
fix(saas): scope gap NOT EXISTS filter to current user's library

### DIFF
--- a/src/klemma/stores/paper_store.py
+++ b/src/klemma/stores/paper_store.py
@@ -522,12 +522,14 @@ class LocalPaperStore:
                    WHERE cg.citing_paper_id IN ({placeholders})
                      AND NOT EXISTS (
                        SELECT 1 FROM papers p
+                       INNER JOIN user_sources us_own
+                         ON us_own.paper_id = p.paper_id AND us_own.user_id = ?
                        WHERE LOWER(TRIM(p.title)) = LOWER(TRIM(cg.cited_title))
                      )
                    GROUP BY cg.cited_title_hash
                    ORDER BY count DESC
                    LIMIT ?""",
-                (user_id, *paper_ids, limit),
+                (user_id, *paper_ids, user_id, limit),
             ).fetchall()
 
             gaps = [dict(r) for r in rows]

--- a/tests/test_paper_store.py
+++ b/tests/test_paper_store.py
@@ -1,11 +1,13 @@
 """Tests for LocalPaperStore (ADR-014 Phase 1B)."""
 
+import hashlib
 import sqlite3
 
 import pytest
 
 from klemma.models import FragmentRecord
 from klemma.stores import LocalPaperStore
+from klemma.stores.user_library import LocalUserLibrary
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -285,3 +287,55 @@ def test_dual_write_cache_hit(tmp_path):
     cached = store.get_fragments(pid)
     assert len(cached) == 2
     assert {f.fragment_text for f in cached} == {"Finding A", "Finding B"}
+
+
+# ---------------------------------------------------------------------------
+# get_reference_gaps — user-scoped NOT EXISTS filter
+# ---------------------------------------------------------------------------
+
+
+def _title_hash(title: str) -> str:
+    return hashlib.md5(title.lower().encode()).hexdigest()
+
+
+def test_reference_gaps_excludes_only_current_user_papers(tmp_path):
+    """NOT EXISTS filter must be scoped to the current user's library.
+
+    If user B has uploaded a paper whose title matches a gap for user A,
+    that gap must still appear in user A's recommendations.
+    Before the fix, the global papers table was queried without user_id
+    filtering — any user's upload would suppress gaps for all other users.
+    """
+    db_path = tmp_path / "library.db"
+    store = LocalPaperStore(db_path)
+    library = LocalUserLibrary(db_path)  # initializes user_sources table in same DB
+
+    user_a = "user-a"
+    user_b = "user-b"
+
+    # User A has one paper that cites "Gap Paper"
+    pid_a = store.register_paper(title="User A Paper", pdf_hash="hasha")
+    store.save_citation_links(pid_a, [
+        {"title": "Gap Paper", "authors": "X", "year": 2020}
+    ])
+    library.add_source(pid_a, "user_a_paper", status="completed", user_id=user_a)
+
+    # User B has ALSO uploaded "Gap Paper" — it's in the global papers table
+    pid_gap = store.register_paper(title="Gap Paper", pdf_hash="hashgap")
+    library.add_source(pid_gap, "gap_paper", status="completed", user_id=user_b)
+
+    # User A's gaps should still include "Gap Paper" — user B's ownership is irrelevant
+    gaps, _ = store.get_reference_gaps(paper_ids=[pid_a], user_id=user_a, limit=50)
+    gap_titles = [g["title"] for g in gaps]
+    assert "Gap Paper" in gap_titles, (
+        "Gap Paper should appear for user A even though user B uploaded it"
+    )
+
+    # If user A also uploads "Gap Paper", it should disappear from gaps
+    library.add_source(pid_gap, "gap_paper_a", status="completed", user_id=user_a)
+
+    gaps2, _ = store.get_reference_gaps(paper_ids=[pid_a], user_id=user_a, limit=50)
+    gap_titles2 = [g["title"] for g in gaps2]
+    assert "Gap Paper" not in gap_titles2, (
+        "Gap Paper should NOT appear once user A has it in their own library"
+    )


### PR DESCRIPTION
## Summary

Cherry-pick of `cdb0944` from `feat/gap-scoring-intent-formula` (the now-abandoned branch that was rebased into master via #319 without this follow-up fix). Multi-tenant security fix in `LocalPaperStore.get_reference_gaps`.

## Problem

The `NOT EXISTS` deduplication in `get_reference_gaps` was querying the **global** `papers` table without `user_id` filtering. Consequence: any paper uploaded by any other user with a matching title silently suppressed the gap from all other users' recommendations.

Concrete example: if user A uploads "Seasonal Arctic sea-ice forecasting" and it's cited by user B's library, B's `/library/recommendations` and `/library/gaps` would NOT list it as a gap — because the title exists in the global `papers` table, even though B has no access to it.

## Fix

Add `INNER JOIN user_sources us_own ON us_own.paper_id = p.paper_id AND us_own.user_id = ?` inside the `NOT EXISTS` sub-query. The dedup now only consults papers that the **requesting user** actually owns.

Diff is 2 lines in SQL + one extra binding in the parameter tuple.

## Tests

New regression test `test_reference_gaps_excludes_only_current_user_papers` that:
1. Creates user A with paper P_A citing "Gap Paper"
2. Creates user B who owns "Gap Paper"
3. Asserts user A's gaps still include "Gap Paper" (would fail on the pre-fix code)
4. Asserts that once user A also uploads "Gap Paper", it disappears from A's gaps

Full suite: **1878 passed, 1 skipped, 0 failed**. Ruff clean.

## Why separately from `feat/gap-scoring-intent-formula`

That branch has 6 "unique" commits vs master, but 5 of them are already on master via squash-merges (PRs #319, #317, #318). Only `cdb0944` is genuinely new. Merging the whole branch would regress master on 20+ files (remove #334 LLM-curated recommendations, 8 dependabot bumps). Cherry-picking the single useful commit keeps the history clean.

## Test plan

- [ ] `PYTHONPATH=src python -m pytest tests/test_paper_store.py -v`
- [ ] `ruff check src/ tests/`
- [ ] Full suite `python -m pytest tests/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)