### PR TITLE
fix(saas): FragmentReviewView undo leak + empty-paraphrase clear

### DIFF
--- a/saas/dashboard/src/views/FragmentReviewView.vue
+++ b/saas/dashboard/src/views/FragmentReviewView.vue
@@ -408,6 +408,18 @@ function stopPolling() {
   }
 }
 
+function composeNoteForSend(fragmentId: string, verdict: 'accepted' | 'rejected'): string | undefined {
+  // notes[] always holds the user's clean note (never the [причина: …] marker).
+  // The marker is only appended at send time when verdict === 'rejected' and
+  // hideReasons has an entry — so an in-session undo doesn't leak the marker.
+  const userNote = (notes.value[fragmentId] || '').replace(HIDE_REASON_RE, '').trim()
+  const hr = hideReasons.value[fragmentId]
+  if (verdict === 'rejected' && hr) {
+    return userNote ? `${userNote}\n[причина: ${hr}]` : `[причина: ${hr}]`
+  }
+  return userNote || undefined
+}
+
 async function setVerdict(fragmentId: string, verdict: 'accepted' | 'rejected') {
   verdicts.value[fragmentId] = verdict
   const frag = allFragments.value.find(f => f.fragment_id === fragmentId)
@@ -419,7 +431,7 @@ async function setVerdict(fragmentId: string, verdict: 'accepted' | 'rejected') 
     citekey: frag.citekey,
     verdict,
     assigned_section: assignedSections.value[fragmentId] || undefined,
-    note: notes.value[fragmentId] || undefined,
+    note: composeNoteForSend(fragmentId, verdict),
     suggested_text: sentence || undefined,
     sentence_model: sentence && model ? model : undefined,
   }])
@@ -433,12 +445,6 @@ async function pickFragment(fragmentId: string) {
 async function hideFragment(fragmentId: string, reason: string) {
   hideReasons.value[fragmentId] = reason
   openCardMenu.value = null
-  // Pipe the reason into the `note` field so it survives reload via existing
-  // curation plumbing. Preserve any user-written note that was already there.
-  const existing = (notes.value[fragmentId] || '').replace(HIDE_REASON_RE, '').trim()
-  notes.value[fragmentId] = existing
-    ? `${existing}\n[причина: ${reason}]`
-    : `[причина: ${reason}]`
   await setVerdict(fragmentId, 'rejected')
 }
 
@@ -448,18 +454,20 @@ function onSuggestedInput(fragmentId: string, value: string) {
 
 async function saveSuggested(fragmentId: string) {
   const sentence = (suggestedTexts.value[fragmentId] || '').trim()
-  if (!sentence) return
   const model = sentenceModels.value[fragmentId]
   const hasRow = !!verdicts.value[fragmentId] || suggestedIds.value.has(fragmentId)
   if (hasRow) {
+    // Persist even an empty string — lets the user clear an existing paraphrase.
+    // Backend PATCH uses `is not None` so "" overwrites the stored text.
     await curation.update(projectId.value, fragmentId, {
       suggested_text: sentence,
       sentence_model: sentence && model ? model : undefined,
     })
     return
   }
-  // No curation row yet — create one with verdict='suggested' so the edited
-  // paraphrase survives reload without forcing the user to pick the fragment.
+  // No curation row yet. Empty input: nothing to persist.
+  if (!sentence) return
+  // Otherwise create a suggested row so the edit survives reload.
   const frag = allFragments.value.find(f => f.fragment_id === fragmentId)
   if (!frag) return
   await curation.curate(projectId.value, [{


### PR DESCRIPTION
## Summary
Follow-up to #337 addressing two adversarial-review findings.

1. **Hide-reason marker leaked into live note state.** `hideFragment()` mutated `notes[fragmentId]` with the `[причина: …]` suffix, but `undo()` only cleared `hideReasons` — not `notes` — so the raw marker survived in component state and shipped back on the next accept/reject. Fix: keep `notes[]` clean at all times; compose the combined note only at send time in `composeNoteForSend()` when `verdict === 'rejected'` and a reason is set.
2. **Empty paraphrase could not be persisted.** `saveSuggested()` short-circuited on empty input, so a user who deleted all text from an existing paraphrase found the old text on reload. Backend PATCH uses `is not None` on `suggested_text`, so `""` correctly clobbers the stored value — send it through when a row exists; keep the short-circuit only when no row exists yet.

Finding #3 (section-assignment regression) remains tracked in #338 — intentional UX simplification, manual override deferred.

## Release Note

### Problem
After #337 shipped, two medium-severity bugs surfaced: (a) in-session undo of a hidden fragment left a raw `[причина: …]` marker in the note buffer, which would then be sent back to the backend on the next pick/reject, polluting the note field; (b) users could no longer clear an existing paraphrase by deleting all text — the backend kept the old value forever.

### Academic Foundation
Both bugs violate the "clean round-trip" principle for human-in-the-loop annotation (Amershi et al., 2019, Guidelines for Human-AI Interaction): what the user sees in the UI must be exactly what is persisted, and vice versa, with no hidden state that surfaces on edge-case actions like undo.

### Implementation
Added `composeNoteForSend(fragmentId, verdict)` that builds the persisted note string at send time rather than mutating `notes[]`. Extended `saveSuggested()` to persist empty strings via PATCH when a curation row already exists, while still short-circuiting empty input when no row exists yet.

### Results
FragmentReviewView.vue: +18 / −10. Build passes. No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)