### PR TITLE
Refactor FragmentReviewView layout & styling to use CSS classes

### DIFF
--- a/saas/dashboard/CLAUDE.md
+++ b/saas/dashboard/CLAUDE.md
@@ -23,10 +23,13 @@ saas/dashboard/
 │   │   ├── LibraryView    — source table + PDF upload + reference gaps
 │   │   ├── SourceView     — source detail: fragments, section assignment, processing + "Отобрать цитаты" CTA
 │   │   ├── FragmentReviewView — /:projectId/library/:citekey/review — citation curation cards
-│   │   │     standalone layout, accept/reject per fragment, intent color badges, section dropdown,
-│   │   │     notes, progress bar, batch accept, undo support, suggested-sentence textarea per card (ADR-017,
-│   │   │     teal primary + italic grey provenance), sentence-generation job polling, partial-failure retry,
-│   │   │     "Accept all as-is" bulk button when every fragment has a sentence
+│   │   │     design-system layout (Literata 34px title, JetBrains Mono metadata, max-width 960px),
+│   │   │     decision-state tally (в работе / в пуле / скрыто) instead of progress bar,
+│   │   │     ochre "picked" cards with 3px left bar + tint and no footer ("убрать" moves to
+│   │   │     overflow menu), pool cards place "+ В работу" in meta row, intent chips on one oklch
+│   │   │     family, Source Serif 4 italic provenance with "✓ совпадает с источником" trust badge,
+│   │   │     accept/reject per fragment, notes, undo support, suggested-sentence textarea per card
+│   │   │     (ADR-017), sentence-generation job polling, partial-failure retry
 │   │   ├── MapView        — /:projectId/map — curated citation bank grouped by outline sections
 │   │   │     AppLayout, accepted fragments per section, suggest popup, move/exclude actions
 │   │   ├── SectionEditorView — /:projectId/write — section-card write paradigm (Phase 5A, #273)

--- a/saas/dashboard/index.html
+++ b/saas/dashboard/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:image" content="https://litresearch.ru/og-image.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=Source+Sans+3:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=Source+Sans+3:wght@300;400;500;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;1,8..60,400;1,8..60,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <title>LitResearch — извлечение фрагментов и покрытие литературы для научной работы</title>
     <!-- Yandex.Metrika counter -->
     <script type="text/javascript">

--- a/saas/dashboard/src/App.vue
+++ b/saas/dashboard/src/App.vue
@@ -208,167 +208,145 @@ const routeKey = computed(() => (route.params.projectId as string) ?? route.path
   <!-- Public / standalone routes: no chrome -->
   <RouterView v-if="isPublicRoute || isStandaloneRoute" :key="routeKey" />
 
-  <!-- App shell -->
-  <div v-else class="flex flex-col h-screen" style="background: var(--color-paper-bg, #faf9f7)">
+  <!-- App shell — sidebar hosts brand / project / nav; main area is unwrapped content -->
+  <div v-else class="app-shell">
 
-    <!-- ── Topbar ─────────────────────────────────────────────────────── -->
-    <header class="h-12 flex-shrink-0 bg-white flex items-center gap-3 px-5 z-20" style="border-bottom: 1px solid var(--color-rule, #e8e5df)">
-      <RouterLink
-        :to="projectId ? `/${projectId}/library` : '/library'"
-        class="font-display font-bold tracking-[-0.4px] text-base no-underline"
-        style="color: var(--color-ink, #1a1a2e)"
-      >k<span style="color: var(--color-accent, #0d7377)">lemma</span></RouterLink>
+    <!-- ── Sidebar ──────────────────────────────────────────────────── -->
+    <aside class="app-sidebar">
 
-      <!-- Project switcher -->
-      <div class="relative" @click.stop>
+      <!-- Brand -->
+      <div class="sidebar-logo-row">
+        <RouterLink
+          :to="projectId ? `/${projectId}/library` : '/library'"
+          class="sidebar-logo"
+        >LitResearch</RouterLink>
+      </div>
+
+      <!-- Project switcher: labeled pill with mono uppercase label + current name + chevron -->
+      <div class="project-switch-wrap" @click.stop>
         <button
+          class="project-switch"
+          :class="{ open: showProjectDropdown }"
           @click="showProjectDropdown = !showProjectDropdown"
-          class="inline-flex items-center gap-1.5 text-sm font-medium rounded-md px-2.5 py-1 border-none bg-transparent cursor-pointer transition-colors"
-          style="color: var(--color-ink-2, #3d3d5c)"
         >
-          <span v-if="projectStore.loading && !projectName" class="inline-block h-3 w-16 rounded animate-pulse" style="background: var(--color-rule, #e8e5df)" />
-          <template v-else>{{ projectName || 'Проект' }}</template>
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 4.5l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <span class="project-switch-inner">
+            <span class="project-switch-label">Проект</span>
+            <span class="project-switch-name">
+              <span v-if="projectStore.loading && !projectName" class="inline-block h-3 w-20 rounded animate-pulse" style="background: var(--color-rule)" />
+              <template v-else>{{ projectName || '—' }}</template>
+            </span>
+          </span>
+          <span class="project-switch-caret">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5l3 3 3-3"/></svg>
+          </span>
         </button>
-        <div
-          v-if="showProjectDropdown"
-          class="absolute top-full left-0 mt-1.5 rounded-[9px] p-[5px] z-50"
-          style="background: white; border: 1px solid var(--color-rule, #e8e5df); min-width: 200px; box-shadow: 0 8px 24px rgba(0,0,0,0.11)"
-        >
-          <div
-            v-for="project in projectStore.projects" :key="project.project_id"
+        <div v-if="showProjectDropdown" class="project-menu">
+          <div class="project-menu-head">Проекты</div>
+          <button
+            v-for="project in projectStore.projects"
+            :key="project.project_id"
+            class="project-menu-item"
+            :class="{ active: project.project_id === projectId }"
             @click="switchProject(project.project_id); showProjectDropdown = false"
-            class="flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-sm cursor-pointer transition-colors hover:bg-[var(--color-rule-light,#f0ede8)]"
-            :class="project.project_id === projectId ? 'font-medium' : ''"
-            :style="project.project_id === projectId ? 'color: var(--color-accent-deep, #065a5e)' : 'color: var(--color-ink-muted, #6b6b8a)'"
           >
-            <span class="w-[7px] h-[7px] rounded-full flex-shrink-0" :style="project.project_id === projectId ? 'background: var(--color-ok, #2d6a4f)' : 'background: var(--color-rule, #e8e5df)'" />
-            {{ project.name }}
-          </div>
-          <div style="border-top: 1px solid var(--color-rule-light, #f0ede8); margin-top: 4px; padding-top: 4px">
-            <div
-              @click="openWizard(); showProjectDropdown = false"
-              class="flex items-center gap-2 px-2.5 py-[7px] rounded-md text-sm cursor-pointer transition-colors hover:bg-[var(--color-rule-light,#f0ede8)]"
-              style="color: var(--color-ink-muted, #6b6b8a)"
-            >
-              <svg viewBox="0 0 16 16" fill="currentColor" class="w-3 h-3 flex-shrink-0"><path d="M8.75 3.75a.75.75 0 0 0-1.5 0v3.5h-3.5a.75.75 0 0 0 0 1.5h3.5v3.5a.75.75 0 0 0 1.5 0v-3.5h3.5a.75.75 0 0 0 0-1.5h-3.5v-3.5Z"/></svg>
-              Новый проект
-            </div>
-          </div>
+            <span class="project-menu-name">{{ project.name }}</span>
+          </button>
+          <div class="project-menu-divider"></div>
+          <button
+            class="project-menu-item new"
+            @click="openWizard(); showProjectDropdown = false"
+          >
+            <span class="project-menu-name">+ Новый проект</span>
+          </button>
         </div>
       </div>
 
-      <div class="flex-1" />
-
-      <!-- Bell -->
+      <!-- Nav -->
+      <div class="nav-label">Навигация</div>
+      <RouterLink
+        v-if="effectiveProjectId"
+        :to="`/${effectiveProjectId}/library`"
+        class="nav-item"
+        :class="{ active: route.name === 'library' || route.name === 'source' || route.name === 'fragment-review' }"
+      >
+        <span class="nav-icon">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3"><path d="M2 2h6l3 3v7a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z"/><path d="M8 2v3h3" stroke-linejoin="round"/></svg>
+        </span>
+        <span>Библиотека</span>
+      </RouterLink>
+      <RouterLink
+        v-if="effectiveProjectId"
+        :to="`/${effectiveProjectId}/map`"
+        class="nav-item"
+        :class="{ active: route.name === 'map' }"
+      >
+        <span class="nav-icon">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"><path d="M1 3l4-1.5 4 1.5 4-1.5v9l-4 1.5-4-1.5-4 1.5z"/><path d="M5 1.5v9M9 3.5v9"/></svg>
+        </span>
+        <span>Карта</span>
+      </RouterLink>
       <RouterLink
         v-if="projectId"
         :to="`/${projectId}/feed`"
-        class="relative w-8 h-8 rounded-[7px] flex items-center justify-center border transition-colors no-underline"
-        style="border-color: var(--color-rule, #e8e5df); color: var(--color-ink-muted, #6b6b8a)"
-        title="Лента событий"
+        class="nav-item"
+        :class="{ active: route.name === 'feed' }"
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path d="M8 1.5a5 5 0 0 1 5 5v2.5l1 2H2l1-2V6.5a5 5 0 0 1 5-5z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
-          <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
-        </svg>
+        <span class="nav-icon">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"><path d="M7 1a4.5 4.5 0 0 1 4.5 4.5v2.25l1 1.75H1.5l1-1.75V5.5A4.5 4.5 0 0 1 7 1z"/><path d="M5.75 11.5a1.3 1.3 0 0 0 2.5 0" stroke-linecap="round"/></svg>
+        </span>
+        <span>Лента</span>
       </RouterLink>
-    </header>
 
-    <!-- ── Workspace ──────────────────────────────────────────────────── -->
-    <div class="flex flex-1 overflow-hidden">
-
-      <!-- ── Sidebar ──────────────────────────────────────────────────── -->
-      <nav class="flex-shrink-0 flex flex-col overflow-y-auto" style="width: 176px; background: white; border-right: 1px solid var(--color-rule, #e8e5df)">
-
-        <!-- Nav links -->
-        <div class="py-2">
-          <div class="px-3.5 py-1 text-[13px] font-semibold uppercase tracking-wide" style="color: var(--color-ink-muted, #6b6b8a)">Навигация</div>
-          <RouterLink
-            v-if="effectiveProjectId"
-            :to="`/${effectiveProjectId}/library`"
-            class="flex items-center gap-2 px-3.5 py-2 text-[14px] no-underline transition-colors rounded-md mx-1.5"
-            :class="route.name === 'library' || route.name === 'source' || route.name === 'fragment-review' ? 'font-semibold' : ''"
-            :style="route.name === 'library' || route.name === 'source' || route.name === 'fragment-review' ? 'color: var(--color-accent-deep, #065a5e); background: var(--color-accent-pale, #e6f3f3)' : 'color: var(--color-ink-2, #3d3d5c)'"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style="flex-shrink:0" :style="route.name === 'library' || route.name === 'source' || route.name === 'fragment-review' ? 'color: var(--color-accent, #0d7377)' : 'color: var(--color-ink-muted, #9898b0)'">
-              <path d="M2 2h6l3 3v7a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z" stroke="currentColor" stroke-width="1.3"/>
-              <path d="M8 2v3h3" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
-            </svg>
-            Библиотека
-          </RouterLink>
-          <RouterLink
-            v-if="effectiveProjectId"
-            :to="`/${effectiveProjectId}/map`"
-            class="flex items-center gap-2 px-3.5 py-2 text-[14px] no-underline transition-colors rounded-md mx-1.5"
-            :class="route.name === 'map' ? 'font-semibold' : ''"
-            :style="route.name === 'map' ? 'color: var(--color-accent-deep, #065a5e); background: var(--color-accent-pale, #e6f3f3)' : 'color: var(--color-ink-2, #3d3d5c)'"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style="flex-shrink:0" :style="route.name === 'map' ? 'color: var(--color-accent, #0d7377)' : 'color: var(--color-ink-muted, #9898b0)'">
-              <path d="M1 3l4-1.5 4 1.5 4-1.5v9l-4 1.5-4-1.5-4 1.5z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
-              <path d="M5 1.5v9M9 3.5v9" stroke="currentColor" stroke-width="1.3"/>
-            </svg>
-            Карта
-          </RouterLink>
-          <div v-if="!effectiveProjectId" class="px-3.5 py-3 text-[13px] italic" style="color: var(--color-ink-muted, #6b6b8a)">
-            <div v-if="projectStore.loading">Загрузка…</div>
-            <div v-else>Выберите проект</div>
-          </div>
-        </div>
-
-        <div class="flex-1" />
-
-        <!-- User profile -->
-        <div style="border-top: 1px solid var(--color-rule, #e8e5df); padding: 10px 12px">
-          <!-- Skeleton while loading -->
-          <template v-if="!profileLoaded">
-            <div class="flex items-center gap-2 mb-2 px-[2px] py-1">
-              <div class="w-[30px] h-[30px] rounded-full flex-shrink-0 animate-pulse" style="background: var(--color-rule, #e8e5df)" />
-              <div class="flex-1 space-y-1.5">
-                <div class="h-3 w-20 rounded animate-pulse" style="background: var(--color-rule, #e8e5df)" />
-                <div class="h-3 w-10 rounded animate-pulse" style="background: var(--color-rule, #e8e5df)" />
-              </div>
-            </div>
-            <div class="h-1 rounded-full animate-pulse mb-1" style="background: var(--color-rule, #e8e5df)" />
-            <div class="h-2.5 w-16 rounded animate-pulse ml-auto" style="background: var(--color-rule, #e8e5df)" />
-          </template>
-          <!-- Loaded -->
-          <template v-else>
-            <div class="flex items-center gap-2 mb-2 rounded-lg px-[2px] py-1">
-              <div class="w-[30px] h-[30px] rounded-full flex-shrink-0 flex items-center justify-center text-[14px] font-bold text-white" style="background: linear-gradient(135deg, #6366f1 0%, #2563eb 100%)">{{ userInitials }}</div>
-              <div class="flex-1 min-w-0">
-                <div class="text-[14px] font-semibold truncate" style="color: var(--color-ink, #1a1a2e)">{{ userName || '…' }}</div>
-                <div class="inline-flex items-center gap-0.5 text-[12px] font-semibold rounded px-[5px] py-[1px] mt-0.5" style="color: #7c3aed; background: #f3e8ff; border: 1px solid #e9d5ff">
-                  <svg width="9" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/></svg>
-                  Pro
-                </div>
-              </div>
-              <button @click="logout" title="Выйти" class="w-6 h-6 flex items-center justify-center rounded-md transition-colors hover:bg-[var(--color-err-bg,#fff0f0)] flex-shrink-0" style="color: var(--color-ink-muted, #6b6b8a)">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-              </button>
-            </div>
-            <template v-if="tokenBalance && tokenBalance.total_granted > 0">
-              <div class="flex justify-between items-center mb-1" style="font-size: 12px; color: var(--color-ink-muted, #6b6b8a)">
-                <span>Кредиты</span>
-                <strong style="font-family: var(--font-mono, monospace); color: var(--color-ink-2, #3d3d5c)">{{ tokenBalance.remaining.toLocaleString() }}</strong>
-              </div>
-              <div
-                class="rounded-full overflow-hidden cursor-help"
-                style="height: 4px; background: var(--color-rule, #e8e5df); margin-bottom: 3px"
-                :title="`${tokenBalance.remaining.toLocaleString()} из ${tokenBalance.total_granted.toLocaleString()} кредитов · ~${Math.floor(tokenBalance.remaining / 12000)} статей осталось · обновляются 1-го числа`"
-              >
-                <div class="h-full rounded-full transition-all" :style="{ width: `${100 - tokenPercent}%`, background: tokenBarLow ? 'linear-gradient(90deg, #f59e0b, #ef4444)' : 'linear-gradient(90deg, #6366f1, #2563eb)' }" />
-              </div>
-              <div class="text-right" style="font-size: 12px; color: var(--color-ink-muted, #6b6b8a)">из {{ tokenBalance.total_granted.toLocaleString() }} в месяц</div>
-            </template>
-          </template>
-        </div>
-      </nav>
-
-      <!-- ── Main content ─────────────────────────────────────────────── -->
-      <div class="flex-1 flex overflow-hidden">
-        <RouterView :key="routeKey" />
+      <div v-if="!effectiveProjectId" class="nav-empty">
+        <span v-if="projectStore.loading">Загрузка…</span>
+        <span v-else>Выберите проект</span>
       </div>
+
+      <div class="sidebar-spacer"></div>
+
+      <!-- Credits + user (pinned to bottom) -->
+      <div class="sidebar-bottom">
+        <template v-if="!profileLoaded">
+          <div class="flex items-center gap-2 mb-2 px-[2px] py-1">
+            <div class="w-[28px] h-[28px] rounded-full flex-shrink-0 animate-pulse" style="background: var(--color-rule)" />
+            <div class="flex-1 space-y-1.5">
+              <div class="h-3 w-20 rounded animate-pulse" style="background: var(--color-rule)" />
+              <div class="h-3 w-10 rounded animate-pulse" style="background: var(--color-rule)" />
+            </div>
+          </div>
+        </template>
+        <template v-else>
+          <div v-if="tokenBalance && tokenBalance.total_granted > 0" class="credits">
+            <div class="credits-row">
+              <span>Кредиты</span>
+              <span><span class="credits-num">{{ tokenBalance.remaining.toLocaleString() }}</span>
+                <span class="credits-total"> / {{ tokenBalance.total_granted.toLocaleString() }}</span></span>
+            </div>
+            <div
+              class="credits-bar"
+              :title="`${tokenBalance.remaining.toLocaleString()} из ${tokenBalance.total_granted.toLocaleString()} кредитов · обновляются 1-го числа`"
+            >
+              <div class="credits-bar-fill" :class="{ low: tokenBarLow }" :style="{ width: `${100 - tokenPercent}%` }" />
+            </div>
+            <div class="credits-sub">в месяц · обновится 1-го</div>
+          </div>
+          <div class="user-row">
+            <div class="user-avatar">{{ userInitials }}</div>
+            <div class="user-meta">
+              <span class="user-name">{{ userName || '…' }}</span>
+              <span class="pro-chip">Pro</span>
+            </div>
+            <button class="icon-btn" @click="logout" title="Выйти" aria-label="Выйти">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+            </button>
+          </div>
+        </template>
+      </div>
+    </aside>
+
+    <!-- ── Main area ─────────────────────────────────────────────────── -->
+    <div class="app-main">
+      <RouterView :key="routeKey" />
     </div>
   </div>
 
@@ -485,3 +463,318 @@ const routeKey = computed(() => (route.params.projectId as string) ?? route.path
     </div>
   </Teleport>
 </template>
+
+<style scoped>
+/* App shell — sidebar + content */
+.app-shell {
+  display: grid;
+  grid-template-columns: 232px 1fr;
+  min-height: 100vh;
+  background: var(--color-paper);
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────────────── */
+.app-sidebar {
+  background: var(--color-paper-2);
+  border-right: 1px solid var(--color-rule);
+  display: flex;
+  flex-direction: column;
+  padding: 20px 14px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar-logo-row {
+  padding: 4px 8px 28px;
+}
+.sidebar-logo {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+  line-height: 1;
+  text-decoration: none;
+}
+.sidebar-logo:hover { color: var(--color-ink); }
+
+/* Project switcher: labeled pill */
+.project-switch-wrap { position: relative; margin: 0 0 22px 0; }
+.project-switch {
+  width: 100%;
+  padding: 7px 10px;
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 4px;
+  color: var(--color-ink-light);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: border-color .12s ease, box-shadow .12s ease;
+}
+.project-switch:hover { border-color: var(--color-accent-rule); }
+.project-switch.open {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-tint);
+}
+.project-switch-inner {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+}
+.project-switch-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+.project-switch-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.project-switch-caret {
+  color: var(--color-ink-muted);
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform .15s ease, color .15s ease;
+  flex-shrink: 0;
+}
+.project-switch:hover .project-switch-caret { color: var(--color-ink); }
+.project-switch.open .project-switch-caret {
+  transform: rotate(180deg);
+  color: var(--color-accent);
+}
+
+.project-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(30,27,24,.08), 0 2px 6px rgba(30,27,24,.04);
+  padding: 6px;
+  z-index: 40;
+}
+.project-menu-head {
+  padding: 6px 8px 4px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+.project-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font: inherit;
+  color: var(--color-ink-light);
+  cursor: pointer;
+  text-align: left;
+}
+.project-menu-item:hover { background: var(--color-paper-2); }
+.project-menu-item.active {
+  background: var(--color-accent-tint);
+  color: var(--color-accent);
+}
+.project-menu-item.new {
+  color: var(--color-accent);
+  font-weight: 500;
+}
+.project-menu-name { font-size: 13px; font-weight: 500; }
+.project-menu-item.active .project-menu-name { color: var(--color-accent); }
+.project-menu-divider {
+  height: 1px;
+  background: var(--color-rule);
+  margin: 6px 4px;
+}
+
+/* Nav */
+.nav-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 12px 10px 6px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: 5px;
+  font-size: 13px;
+  color: var(--color-ink-light);
+  cursor: pointer;
+  line-height: 1.4;
+  text-decoration: none;
+}
+.nav-item:hover { background: white; }
+.nav-item.active {
+  background: var(--color-accent-tint);
+  color: var(--color-accent);
+  font-weight: 500;
+}
+.nav-item .nav-icon {
+  width: 14px;
+  color: var(--color-ink-muted);
+  display: inline-flex;
+  flex-shrink: 0;
+}
+.nav-item.active .nav-icon { color: var(--color-accent); }
+
+.nav-empty {
+  padding: 10px 12px;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--color-ink-muted);
+}
+
+.sidebar-spacer { flex: 1; }
+
+/* Bottom: credits + user */
+.sidebar-bottom {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--color-rule);
+}
+.credits {
+  padding: 10px 8px 4px;
+  font-size: 11px;
+  color: var(--color-ink-muted);
+}
+.credits-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.credits-num {
+  font-family: var(--font-mono);
+  color: var(--color-ink-light);
+  font-weight: 500;
+}
+.credits-total { color: var(--color-ink-faint); }
+.credits-bar {
+  height: 3px;
+  background: var(--color-paper-3);
+  border-radius: 2px;
+  overflow: hidden;
+  cursor: help;
+}
+.credits-bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  transition: width .2s ease;
+}
+.credits-bar-fill.low {
+  background: linear-gradient(90deg, #f59e0b, #ef4444);
+}
+.credits-sub {
+  font-size: 10px;
+  color: var(--color-ink-faint);
+  margin-top: 4px;
+}
+
+.user-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 8px 4px;
+}
+.user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-accent-tint);
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.user-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.user-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pro-chip {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--color-picked-tint);
+  color: var(--color-picked);
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+.icon-btn {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-ink-muted);
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.icon-btn:hover {
+  background: var(--color-paper-3);
+  color: var(--color-ink-light);
+}
+
+/* Main area */
+.app-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 100vh;
+}
+
+/* Responsive: collapse sidebar on narrow screens */
+@media (max-width: 860px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .app-sidebar {
+    position: static;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--color-rule);
+  }
+}
+</style>

--- a/saas/dashboard/src/assets/main.css
+++ b/saas/dashboard/src/assets/main.css
@@ -5,7 +5,10 @@
   --color-ink: #1a1a2e;
   --color-ink-light: #3d3d5c;
   --color-ink-muted: #6b6b8a;
+  --color-ink-faint: #9a9388;
   --color-paper: #faf9f7;
+  --color-paper-2: #f3f1ec;
+  --color-paper-3: #e8e5de;
   --color-paper-warm: #f5f3ef;
   --color-paper-white: #ffffff;
 
@@ -13,6 +16,8 @@
   --color-accent: #0d7377;
   --color-accent-light: #14919b;
   --color-accent-pale: #e0f4f4;
+  --color-accent-tint: oklch(96% 0.015 190);
+  --color-accent-rule: oklch(85% 0.03 190);
   --color-accent-deep: #065a5e;
 
   /* Amber accent — warm ochre complement */
@@ -20,6 +25,11 @@
   --color-amber-light: #c99a48;
   --color-amber-pale: #faf0dc;
   --color-amber-deep: #7d5518;
+
+  /* Picked — muted ochre, editorial/archival (replaces plum for "in-work" state) */
+  --color-picked: oklch(52% 0.11 65);
+  --color-picked-tint: oklch(96% 0.025 75);
+  --color-picked-rule: oklch(80% 0.05 70);
 
   /* Violet accent — muted academic secondary */
   --color-violet: #6b5f8a;
@@ -44,9 +54,25 @@
   --color-rule: #e8e5df;
   --color-rule-light: #f0ede8;
 
+  /* Intent colors — one oklch family (L=40 ink / L=96 bg, varying hue) */
+  --color-intent-bg-ink: oklch(40% 0.09 265);
+  --color-intent-bg-bg: oklch(96% 0.028 265);
+  --color-intent-method-ink: oklch(40% 0.09 310);
+  --color-intent-method-bg: oklch(96% 0.028 310);
+  --color-intent-result-ink: oklch(40% 0.09 155);
+  --color-intent-result-bg: oklch(96% 0.028 155);
+  --color-intent-ext-ink: oklch(40% 0.09 200);
+  --color-intent-ext-bg: oklch(96% 0.028 200);
+  --color-intent-contrast-ink: oklch(40% 0.09 40);
+  --color-intent-contrast-bg: oklch(96% 0.028 40);
+  --color-intent-data-ink: oklch(40% 0.09 90);
+  --color-intent-data-bg: oklch(96% 0.028 90);
+
   /* Fonts */
   --font-display: 'Literata', 'Georgia', serif;
   --font-body: 'Source Sans 3', 'Segoe UI', sans-serif;
+  --font-body-serif: 'Source Serif 4', 'Georgia', serif;
+  --font-ui: 'Inter', 'Source Sans 3', 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }
 

--- a/saas/dashboard/src/views/FragmentReviewView.vue
+++ b/saas/dashboard/src/views/FragmentReviewView.vue
@@ -88,32 +88,24 @@ const intentLabel: Record<string, string> = {
   uses_data: 'Данные',
 }
 
-const intentColor: Record<string, string> = {
-  background: 'bg-[#dbeafe] text-[#1d4ed8]',
-  method: 'bg-[#ede9fe] text-[#6d28d9]',
-  result_comparison: 'bg-[#dcfce7] text-[#15803d]',
-  extends: 'bg-[#ccfbf1] text-[#0f766e]',
-  contrasts: 'bg-[#ffedd5] text-[#c2410c]',
-  uses_data: 'bg-[#fef9c3] text-[#a16207]',
+// Map intent keys to CSS variable suffixes (tokens defined in main.css on one
+// oklch family — same L/C, varying hue — so chips feel like one visual family).
+const intentTokenKey: Record<string, string> = {
+  background: 'bg',
+  method: 'method',
+  result_comparison: 'result',
+  extends: 'ext',
+  contrasts: 'contrast',
+  uses_data: 'data',
 }
 
-// Saturated (filled) variant for active filter chips — same hue as the card chip,
-// but fully saturated so the active state is obvious at a glance.
-const intentColorActive: Record<string, string> = {
-  background: 'bg-[#1d4ed8] text-white border-[#1d4ed8]',
-  method: 'bg-[#6d28d9] text-white border-[#6d28d9]',
-  result_comparison: 'bg-[#15803d] text-white border-[#15803d]',
-  extends: 'bg-[#0f766e] text-white border-[#0f766e]',
-  contrasts: 'bg-[#c2410c] text-white border-[#c2410c]',
-  uses_data: 'bg-[#a16207] text-white border-[#a16207]',
-}
-
-function filterChipClasses(filter: string): string {
-  const active = activeFilter.value === filter
-  if (active) return intentColorActive[filter] + ' border'
-  // Inactive: match the card chip's bg+text, transparent border for layout parity
-  const c = intentColor[filter]
-  return c ? `${c} border border-transparent hover:opacity-75` : ''
+function intentChipStyle(intent: string): Record<string, string> {
+  const key = intentTokenKey[intent]
+  if (!key) return {}
+  return {
+    background: `var(--color-intent-${key}-bg)`,
+    color: `var(--color-intent-${key}-ink)`,
+  }
 }
 
 function isPicked(id: string): boolean {
@@ -129,6 +121,10 @@ const pickedCount = computed(() =>
 )
 const hiddenCount = computed(() =>
   Object.values(verdicts.value).filter(v => v === 'rejected').length,
+)
+// Pool = visible (not hidden) minus picked — the "awaiting decision" bucket.
+const poolCount = computed(() =>
+  allFragments.value.filter(f => !isPicked(f.fragment_id) && !isHidden(f.fragment_id)).length,
 )
 
 const visibleFragments = computed(() =>
@@ -610,94 +606,102 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="w-full overflow-y-auto" style="background: var(--color-paper-bg, #faf9f7)">
-    <div class="max-w-[780px] mx-auto py-6 px-5">
+  <div class="fr-root">
+    <div class="fr-content">
 
       <!-- Back link -->
-      <div class="mb-4">
-        <router-link :to="`/${projectId}/library`" class="text-sm text-[#0d7377] no-underline hover:underline">&larr; Библиотека</router-link>
-      </div>
+      <router-link :to="`/${projectId}/library`" class="doc-back">&larr; Библиотека</router-link>
 
       <!-- Loading -->
-      <div v-if="loading" class="flex items-center justify-center py-24">
-        <div class="h-5 w-5 animate-spin rounded-full border-2 border-[#0d7377] border-t-transparent"></div>
+      <div v-if="loading" class="fr-loading">
+        <div class="fr-spinner"></div>
       </div>
 
       <template v-else>
-        <!-- Header -->
-        <div class="flex items-start justify-between gap-3 mb-5">
-          <div class="flex-1 min-w-0">
-            <h1 class="text-lg font-semibold tracking-tight mb-1 leading-snug">{{ sourceTitle || citekey }}</h1>
-            <div class="text-sm text-[#6b6b8a]">
-              {{ sourceDisplay }}<template v-if="totalCount > 0"> &middot; {{ totalCount }} фрагментов</template>
+        <!-- Header: title + metadata + overflow -->
+        <div class="doc-head">
+          <div class="doc-title-row">
+            <div class="doc-title-block">
+              <h1 class="doc-title">{{ sourceTitle || citekey }}</h1>
+              <div class="doc-sub">
+                <span>{{ sourceDisplay }}</span>
+                <span class="dot">·</span>
+                <span class="citekey-slug">{{ citekey }}</span>
+                <template v-if="totalCount > 0">
+                  <span class="dot">·</span>
+                  <span>{{ totalCount }} фрагментов</span>
+                </template>
+              </div>
             </div>
-          </div>
-          <div class="flex items-center gap-1 shrink-0 mt-0.5">
-            <div class="relative" id="source-overflow-menu">
+            <div class="doc-overflow-wrap" id="source-overflow-menu">
               <button
+                class="doc-overflow"
+                title="Действия"
                 @click.stop="menuOpen = !menuOpen"
-                class="w-7 h-7 rounded-md border border-transparent bg-transparent text-[#9ca3af] hover:bg-[#f0ede8] hover:text-[#3d3d5c] flex items-center justify-center cursor-pointer text-[16px] leading-none"
-                title="Ещё"
               >⋯</button>
-              <div
-                v-if="menuOpen"
-                class="absolute right-0 top-8 bg-white border border-[#e8e5df] rounded-lg shadow-lg py-1 min-w-[160px] z-20"
-              >
+              <div v-if="menuOpen" class="doc-overflow-menu">
                 <button
                   @click="deleteSource"
                   :disabled="deleting"
-                  class="w-full text-left px-3 py-2 text-[13px] text-[#c62828] hover:bg-[#fff0f0] cursor-pointer bg-transparent border-none disabled:opacity-50"
+                  class="doc-overflow-item danger"
                 >Удалить источник</button>
               </div>
             </div>
           </div>
+
+          <!-- Tally: decision-state, not progress -->
+          <div v-if="hasFragments" class="tally">
+            <div class="tally-cell">
+              <div class="tally-label">в работе</div>
+              <div class="tally-value picked">{{ pickedCount
+                }}<span class="tally-unit">&nbsp;{{ pluralizeCitations(pickedCount) }}</span></div>
+            </div>
+            <div class="tally-cell">
+              <div class="tally-label">в пуле</div>
+              <div class="tally-value">{{ poolCount
+                }}<span class="tally-unit">&nbsp;на решении</span></div>
+            </div>
+            <div v-if="hiddenCount > 0" class="tally-cell">
+              <div class="tally-label">скрыто</div>
+              <div class="tally-value">{{ hiddenCount }}</div>
+            </div>
+            <div class="tally-cell tally-hint-cell">
+              <div class="tally-hint">Решайте по сути, а не по числу — не все {{ totalCount }} должны попасть в работу.</div>
+            </div>
+          </div>
         </div>
 
-        <!-- Source processing states (unchanged) -->
-        <div v-if="isPending" class="rounded-xl border-2 border-dashed border-[#e8e5df] p-12 text-center">
-          <div class="mx-auto w-12 h-12 rounded-xl bg-[#e6f3f3] flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-[#0d7377]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <!-- Source processing states -->
+        <div v-if="isPending" class="fr-empty">
+          <div class="fr-empty-icon">
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-[#1a1a2e]">Источник ещё не обработан</h3>
-          <p class="mt-2 text-sm text-[#6b6b8a]">Нажмите «Обработать», чтобы извлечь фрагменты из PDF.</p>
-          <button
-            @click="startProcessing(false)"
-            class="mt-5 inline-flex items-center gap-2 rounded-lg bg-[#0d7377] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#065a5e] transition-colors cursor-pointer border-none"
-          >Обработать</button>
+          <h3 class="fr-empty-title">Источник ещё не обработан</h3>
+          <p class="fr-empty-sub">Нажмите «Обработать», чтобы извлечь фрагменты из PDF.</p>
+          <button @click="startProcessing(false)" class="btn primary">Обработать</button>
         </div>
 
-        <div v-if="isProcessing" class="rounded-xl border border-[#0d7377] bg-[#e6f3f3] p-5">
-          <div class="flex items-center gap-3">
-            <div class="h-4 w-4 animate-spin rounded-full border-2 border-[#0d7377] border-t-transparent"></div>
-            <span class="text-sm font-medium text-[#065a5e]">Извлекаем фрагменты из PDF...</span>
-            <span class="text-[13px] text-[#6b6b8a]">{{ jobStatus }}</span>
-          </div>
+        <div v-if="isProcessing" class="fr-status">
+          <div class="fr-spinner"></div>
+          <span class="fr-status-text">Извлекаем фрагменты из PDF…</span>
+          <span class="fr-status-sub">{{ jobStatus }}</span>
         </div>
 
-        <div v-if="jobError" class="mt-3 rounded-xl border border-[#c62828] bg-[#fff0f0] p-4">
-          <p class="text-sm text-[#c62828]">{{ jobError }}</p>
-          <button
-            @click="startProcessing(true)"
-            class="mt-2 text-sm text-[#0d7377] cursor-pointer border-none bg-transparent hover:underline"
-          >Попробовать снова</button>
+        <div v-if="jobError" class="fr-error">
+          <p>{{ jobError }}</p>
+          <button @click="startProcessing(true)" class="fr-error-retry">Попробовать снова</button>
         </div>
 
-        <div v-if="sourceStatus === 'failed' && !processing && !jobError" class="rounded-xl border border-[#c62828] bg-[#fff0f0] p-5 text-center">
-          <p class="text-sm text-[#c62828] mb-3">Обработка завершилась с ошибкой</p>
-          <button
-            @click="startProcessing(true)"
-            class="inline-flex items-center gap-2 rounded-lg bg-[#0d7377] px-4 py-2 text-sm font-semibold text-white hover:bg-[#065a5e] transition-colors cursor-pointer border-none"
-          >Переобработать</button>
+        <div v-if="sourceStatus === 'failed' && !processing && !jobError" class="fr-error center">
+          <p>Обработка завершилась с ошибкой</p>
+          <button @click="startProcessing(true)" class="btn primary">Переобработать</button>
         </div>
 
-        <div v-if="sourceStatus === 'completed' && totalCount === 0 && !loading" class="rounded-xl border-2 border-dashed border-[#e8e5df] p-12 text-center">
-          <p class="text-sm text-[#6b6b8a]">Фрагменты не найдены.</p>
-          <button
-            @click="startProcessing(true)"
-            class="mt-3 text-sm text-[#0d7377] cursor-pointer border-none bg-transparent hover:underline"
-          >Переобработать</button>
+        <div v-if="sourceStatus === 'completed' && totalCount === 0 && !loading" class="fr-empty">
+          <p class="fr-empty-sub">Фрагменты не найдены.</p>
+          <button @click="startProcessing(true)" class="fr-link">Переобработать</button>
         </div>
 
         <!-- Fragment pool -->
@@ -705,38 +709,41 @@ onUnmounted(() => {
 
           <!-- Empty state: no sentences yet -->
           <template v-if="showEmptyState && firstFragment">
-            <article class="bg-white border border-[#e8e5df] rounded-[10px] overflow-hidden">
-              <div class="px-[18px] pt-5 pb-4 border-b border-[#f0ede8] flex gap-3 items-start">
-                <div class="w-7 h-7 rounded-md bg-[#e6f3f3] text-[#0d7377] flex items-center justify-center shrink-0 text-sm">✨</div>
+            <article class="frag">
+              <div class="sentence-empty-head">
+                <div class="sentence-empty-icon">✨</div>
                 <div>
-                  <h3 class="text-sm font-semibold text-[#1a1a2e] mb-1">Академические предложения ещё не сгенерированы</h3>
-                  <p class="text-sm text-[#6b6b8a] leading-snug">
+                  <h3 class="sentence-empty-title">Академические предложения ещё не сгенерированы</h3>
+                  <p class="sentence-empty-sub">
                     Klemma создаст парафразы на русском для всех {{ totalCount }} фрагментов —
                     чтобы можно было сразу взять в работу самые ценные.
                   </p>
                 </div>
               </div>
-              <div class="px-[18px] py-4">
-                <div class="border-l-2 border-[#e8e5df] pl-3 py-1 mb-4">
-                  <div class="text-[12px] uppercase tracking-[0.8px] text-[#9ca3af] font-semibold mb-1">
-                    Исходный фрагмент<template v-if="firstFragment.page"> · стр. {{ firstFragment.page }}</template>
+              <div class="sentence-empty-body">
+                <div class="frag-orig">
+                  <div class="frag-orig-header">
+                    <span class="frag-orig-label">
+                      Исходный фрагмент<template v-if="firstFragment.page"> · стр. {{ firstFragment.page }}</template>
+                    </span>
                   </div>
-                  <div class="text-sm text-[#6b6b8a] leading-relaxed" style="font-family:'Georgia',serif">"{{ firstFragment.text }}"</div>
+                  <div class="frag-orig-text">«{{ firstFragment.text }}»</div>
                 </div>
-                <div class="flex items-center gap-2">
-                  <span
-                    class="text-[12px] font-medium px-2 py-0.5 rounded"
-                    :class="intentColor[firstFragment.citation_intent] || 'bg-gray-100 text-gray-600'"
-                  >{{ intentLabel[firstFragment.citation_intent] || firstFragment.citation_intent }}</span>
-                  <span class="text-[13px] text-[#9ca3af]">· предварительная классификация</span>
+                <div class="frag-meta" style="margin-top: 14px;">
+                  <div class="frag-meta-left">
+                    <span class="chip intent-chip" :style="intentChipStyle(firstFragment.citation_intent)">
+                      {{ intentLabel[firstFragment.citation_intent] || firstFragment.citation_intent }}
+                    </span>
+                    <span class="meta-aside">· предварительная классификация</span>
+                  </div>
                 </div>
               </div>
-              <div class="px-[18px] py-[10px] border-t border-[#f0ede8] bg-[#fafaf8] rounded-b-[10px] flex items-center justify-between">
-                <span class="text-[13px] text-[#9ca3af]">{{ totalCount }} фрагментов готовы к обработке</span>
+              <div class="sentence-empty-foot">
+                <span>{{ totalCount }} фрагментов готовы к обработке</span>
                 <button
                   :disabled="isGeneratingSentences"
                   @click="generateSentences('missing')"
-                  class="inline-flex items-center gap-1.5 px-3 py-[5px] rounded-md text-[13px] font-medium cursor-pointer border-none bg-[#0d7377] text-white hover:bg-[#065a5e] disabled:opacity-60 disabled:cursor-not-allowed"
+                  class="btn primary sm"
                 >✨ Сгенерировать предложения</button>
               </div>
             </article>
@@ -744,286 +751,1004 @@ onUnmounted(() => {
 
           <!-- Active state: pool with picks -->
           <template v-else>
-            <!-- Toolbar: filters + regenerate -->
-            <div class="flex items-center justify-between gap-3 mb-4 flex-wrap">
-              <div class="flex gap-1.5 flex-wrap items-center">
+            <!-- Toolbar: intent filter chips + regenerate -->
+            <div class="filters">
+              <div class="filter-group">
                 <button
-                  class="px-3 py-1 rounded-md text-[13px] font-medium border cursor-pointer transition-all"
-                  :class="activeFilter === 'all'
-                    ? 'bg-[#1a1a2e] text-white border-[#1a1a2e]'
-                    : 'bg-white text-[#6b6b8a] border-[#e8e5df] hover:border-[#d4d0ca] hover:text-[#1a1a2e]'"
+                  class="chip filter-chip"
+                  :class="{ active: activeFilter === 'all' }"
                   @click="activeFilter = 'all'"
-                >Все<span class="opacity-50 font-normal ml-1">{{ filterCount('all') }}</span></button>
+                >Все<span class="count">{{ filterCount('all') }}</span></button>
 
                 <button
                   v-for="filter in ['background', 'method', 'result_comparison', 'extends', 'contrasts', 'uses_data']"
                   :key="filter"
                   v-show="filterCount(filter) > 0"
-                  class="px-3 py-1 rounded-md text-[13px] font-medium cursor-pointer transition-all"
-                  :class="filterChipClasses(filter)"
-                  @click="activeFilter = filter"
-                >{{ intentLabel[filter] || filter }}<span class="opacity-60 font-normal ml-1">{{ filterCount(filter) }}</span></button>
+                  class="chip intent-chip"
+                  :class="{ active: activeFilter === filter }"
+                  :style="intentChipStyle(filter)"
+                  @click="activeFilter = filter === activeFilter ? 'all' : filter"
+                >{{ intentLabel[filter] || filter }}<span class="count">{{ filterCount(filter) }}</span></button>
+
+                <span v-if="hiddenCount > 0" class="filter-divider"></span>
 
                 <button
                   v-if="hiddenCount > 0"
-                  class="px-3 py-1 rounded-md text-[13px] font-medium border cursor-pointer transition-all ml-2"
-                  :class="activeFilter === 'hidden'
-                    ? 'bg-[#6b6b8a] text-white border-[#6b6b8a]'
-                    : 'bg-white text-[#9ca3af] border-[#e8e5df] hover:border-[#d4d0ca] hover:text-[#6b6b8a]'"
-                  @click="activeFilter = 'hidden'"
-                >Скрытые<span class="opacity-60 font-normal ml-1">{{ hiddenCount }}</span></button>
+                  class="chip filter-chip"
+                  :class="{ active: activeFilter === 'hidden' }"
+                  @click="activeFilter = activeFilter === 'hidden' ? 'all' : 'hidden'"
+                >Скрытые<span class="count">{{ hiddenCount }}</span></button>
               </div>
 
               <button
                 v-if="allFragments.length > 0"
                 :disabled="isGeneratingSentences"
                 @click="generateSentences('force')"
-                class="inline-flex items-center gap-1.5 px-3 py-[5px] rounded-md text-[13px] cursor-pointer border border-[#e8e5df] bg-transparent text-[#6b6b8a] hover:text-[#1a1a2e] hover:border-[#d4d0ca] disabled:opacity-50 disabled:cursor-not-allowed"
+                class="btn"
               >↻ Перегенерировать</button>
             </div>
 
-            <div
-              v-if="sentenceToast"
-              class="mb-3 rounded-md border border-[#fbbf24] bg-[#fef9c3] px-3 py-2 text-[13px] text-[#78350f]"
-            >{{ sentenceToast }}</div>
+            <div v-if="sentenceToast" class="fr-toast">{{ sentenceToast }}</div>
 
-            <!-- Two-section grouping: ⭐ В работе  /  В пуле  (or flat Hidden list) -->
+            <!-- Two-section grouping: ★ В работе / В пуле (or flat Hidden list) -->
             <template v-for="(group, gidx) in viewGroups" :key="group.key">
-              <!-- Gap between groups (not before the first) -->
-              <div v-if="gidx > 0" class="h-7"></div>
+              <div v-if="gidx > 0" class="group-gap"></div>
 
-              <!-- Group header: picked (thistle purple) -->
-              <div
-                v-if="group.header === 'gold'"
-                class="flex items-baseline justify-between font-semibold text-[13px] mb-3 px-0.5 text-[#3b1f47]"
-              >
-                <span class="inline-flex items-center gap-2">
-                  <span class="text-[#934eb1] text-[14px]">★</span>В работе
-                </span>
-                <span class="text-[13px] text-[#934eb1]/75 font-normal">{{ group.count }} {{ pluralizeCitations(group.count) }}</span>
+              <div v-if="group.header === 'gold'" class="section-head">
+                <span class="section-title picked">★ В работе</span>
+                <span class="section-count">{{ group.count }} {{ pluralizeCitations(group.count) }}</span>
               </div>
 
-              <!-- Group header: pool -->
-              <div
-                v-if="group.header === 'pool'"
-                class="flex items-baseline justify-between font-semibold text-[13px] mb-3 px-0.5 text-[#3d3d5c]"
-              >
-                <span>В пуле</span>
-                <span class="text-[13px] text-[#9ca3af] font-normal">{{ group.count }} {{ pluralizeCitations(group.count) }} · ещё не взяты</span>
+              <div v-if="group.header === 'pool'" class="section-head">
+                <span class="section-title">В пуле</span>
+                <span class="section-count">{{ group.count }} {{ pluralizeCitations(group.count) }}</span>
+                <span class="section-trailing">ещё не взяты</span>
               </div>
 
-              <!-- Cards -->
-              <div
-                v-for="f in group.fragments"
-                :key="f.fragment_id"
-              class="relative group bg-white border rounded-[10px] mb-3 overflow-visible transition-all"
-              :class="{
-                'border-[#be95d0] bg-[#f4edf7]': isPicked(f.fragment_id),
-                'border-[#e8e5df] opacity-70': isHidden(f.fragment_id),
-                'border-[#e8e5df] hover:border-[#d4d0ca]': !isPicked(f.fragment_id) && !isHidden(f.fragment_id),
-              }"
-            >
-              <!-- Overflow menu trigger (hidden until hover unless picked/menu-open) -->
-              <div
-                v-if="!isHidden(f.fragment_id)"
-                class="absolute top-2 right-2 z-10"
-                data-card-menu-root
-              >
-                <button
-                  @click="toggleCardMenu(f.fragment_id, $event)"
-                  class="w-7 h-7 rounded-md border-none bg-transparent text-[#9ca3af] hover:bg-black/5 hover:text-[#1a1a2e] flex items-center justify-center cursor-pointer text-[16px] leading-none transition-all opacity-60 group-hover:opacity-100"
-                  :class="{ '!opacity-100 bg-black/5 text-[#1a1a2e]': openCardMenu === f.fragment_id }"
-                  title="Ещё действия"
-                >⋯</button>
-
-                <div
-                  v-if="openCardMenu === f.fragment_id"
-                  class="absolute top-[34px] right-0 bg-white border border-[#e8e5df] rounded-lg shadow-lg min-w-[260px] z-30 py-1"
+              <div class="stack">
+                <article
+                  v-for="f in group.fragments"
+                  :key="f.fragment_id"
+                  class="frag"
+                  :class="{
+                    picked: isPicked(f.fragment_id),
+                    hidden: isHidden(f.fragment_id),
+                  }"
                 >
-                  <div class="text-[12px] uppercase tracking-[0.8px] text-[#9ca3af] font-semibold px-[14px] pt-2.5 pb-1.5">Скрыть из пула</div>
-                  <button
-                    @click="hideFragment(f.fragment_id, 'ошибка извлечения')"
-                    class="block w-full text-left px-[14px] py-2 bg-transparent border-none cursor-pointer hover:bg-[#f0ede8]"
-                  >
-                    <span class="block text-[13px] font-medium text-[#1a1a2e]">Ошибка извлечения</span>
-                    <span class="block text-[12px] text-[#6b6b8a] mt-0.5">OCR-мусор, список литературы, формула</span>
-                  </button>
-                  <button
-                    @click="hideFragment(f.fragment_id, 'нерелевантно')"
-                    class="block w-full text-left px-[14px] py-2 bg-transparent border-none cursor-pointer hover:bg-[#f0ede8]"
-                  >
-                    <span class="block text-[13px] font-medium text-[#1a1a2e]">Нерелевантно</span>
-                    <span class="block text-[12px] text-[#6b6b8a] mt-0.5">не по теме диссертации</span>
-                  </button>
-                  <button
-                    @click="hideFragment(f.fragment_id, 'другое')"
-                    class="block w-full text-left px-[14px] py-2 bg-transparent border-none cursor-pointer hover:bg-[#f0ede8]"
-                  >
-                    <span class="block text-[13px] font-medium text-[#1a1a2e]">Другое…</span>
-                  </button>
-                  <div class="h-px bg-[#e8e5df] my-1"></div>
-                  <div class="text-[12px] text-[#6b6b8a] px-[14px] py-1.5 pb-2 leading-snug">Цитату можно вернуть через фильтр «Скрытые».</div>
-                </div>
-              </div>
-
-              <!-- Hidden card: compact -->
-              <template v-if="isHidden(f.fragment_id)">
-                <div class="px-[18px] py-3">
+                  <!-- Overflow menu (not shown on hidden cards — they use "вернуть в пул" link) -->
                   <div
-                    v-if="(suggestedTexts[f.fragment_id] || '').trim()"
-                    class="text-[13px] leading-[1.6] text-[#6b6b8a] mb-2"
-                  >{{ suggestedTexts[f.fragment_id] }}</div>
-                  <div
-                    v-else
-                    class="text-[13px] leading-[1.6] text-[#6b6b8a] mb-2"
-                    style="font-family:'Georgia',serif"
-                  >"{{ f.text }}"</div>
-                  <div class="flex items-center gap-1.5 flex-wrap">
-                    <span
-                      class="text-[12px] font-medium px-2 py-0.5 rounded"
-                      :class="intentColor[f.citation_intent] || 'bg-gray-100 text-gray-600'"
-                    >{{ intentLabel[f.citation_intent] || f.citation_intent }}</span>
-                    <span v-if="f.page" class="text-[13px] text-[#9ca3af]">&middot; стр. {{ f.page }}</span>
-                    <span v-if="hideReasons[f.fragment_id]" class="text-[13px] text-[#9ca3af]">&middot; {{ hideReasons[f.fragment_id] }}</span>
-                  </div>
-                </div>
-                <div class="px-[18px] py-[10px] border-t border-[#f0ede8] bg-[#fafaf8] rounded-b-[10px] flex items-center justify-between">
-                  <span class="text-[13px] text-[#9ca3af]">Скрыто</span>
-                  <button
-                    class="text-[13px] text-[#6b6b8a] cursor-pointer border-none bg-transparent px-2 py-1 rounded-md hover:bg-black/5 hover:text-[#1a1a2e]"
-                    @click="undo(f.fragment_id)"
-                  >↶ вернуть в пул</button>
-                </div>
-              </template>
-
-              <!-- Active card: pool or picked -->
-              <template v-else>
-                <div class="pl-[18px] pr-11 py-4">
-                  <!-- Paraphrase -->
-                  <div class="mb-3">
-                    <div
-                      v-if="inProgressIds.has(f.fragment_id)"
-                      class="animate-pulse rounded-lg bg-[#e6f3f3] border border-[#b8dcdc] px-3 py-2 text-[13px] text-[#065a5e] italic"
-                    >✨ Генерируем академическое предложение…</div>
-
-                    <div
-                      v-else-if="(suggestedTexts[f.fragment_id] || '').trim() && !editingSuggested[f.fragment_id]"
-                      class="text-[15px] leading-[1.65] text-[#1a1a2e] cursor-text select-text"
-                      @click="startEditSuggested(f.fragment_id)"
-                    >{{ formatParaphrase(suggestedTexts[f.fragment_id] || '') }}</div>
-
-                    <div
-                      v-else-if="!editingSuggested[f.fragment_id]"
-                      class="text-[14px] leading-[1.65] text-[#9ca3af] italic cursor-text"
-                      @click="startEditSuggested(f.fragment_id)"
-                    >{{ failedIds.has(f.fragment_id) ? 'Не удалось сгенерировать. Нажмите 🔄, чтобы повторить.' : 'Академическое предложение появится здесь после генерации.' }}</div>
-
-                    <textarea
-                      v-else
-                      :data-edit-id="f.fragment_id"
-                      class="w-full rounded-lg border border-[#e8e5df] bg-white px-3 py-2 text-[15px] leading-[1.65] text-[#1a1a2e] resize-y min-h-[56px] focus:outline-none focus:border-[#0d7377]"
-                      :value="suggestedTexts[f.fragment_id] || ''"
-                      @input="onSuggestedInput(f.fragment_id, ($event.target as HTMLTextAreaElement).value)"
-                      @blur="finishEditSuggested(f.fragment_id)"
-                    />
-
+                    v-if="!isHidden(f.fragment_id)"
+                    class="overflow-wrap"
+                    data-card-menu-root
+                  >
                     <button
-                      v-if="failedIds.has(f.fragment_id) && !inProgressIds.has(f.fragment_id)"
-                      class="mt-1 text-[13px] text-[#c62828] cursor-pointer border-none bg-transparent hover:underline"
-                      @click="retryFragmentSentence(f.fragment_id)"
-                    >🔄 повторить</button>
+                      @click="toggleCardMenu(f.fragment_id, $event)"
+                      class="overflow-btn"
+                      :class="{ open: openCardMenu === f.fragment_id }"
+                      title="Ещё действия"
+                    >⋯</button>
+
                     <div
-                      v-if="sentenceModels[f.fragment_id] && !failedIds.has(f.fragment_id)"
-                      class="mt-1 text-[12px] text-[#9ca3af] inline-flex items-center gap-1 font-mono"
-                    ><span class="text-[10px] opacity-70">✨</span>{{ humanizeModel(sentenceModels[f.fragment_id] || '') }}</div>
-                  </div>
+                      v-if="openCardMenu === f.fragment_id"
+                      class="overflow-menu"
+                    >
+                      <template v-if="isPicked(f.fragment_id)">
+                        <button @click="undo(f.fragment_id)" class="overflow-item">
+                          <span class="overflow-item-title">↶ Убрать из работы</span>
+                          <span class="overflow-item-sub">вернуть в пул</span>
+                        </button>
+                      </template>
 
-                  <!-- Original -->
-                  <div
-                    class="border-l-2 pl-3 py-1 mb-4"
-                    :class="isPicked(f.fragment_id) ? 'border-[#be95d0]' : 'border-[#e8e5df]'"
-                  >
-                    <div class="text-[12px] uppercase tracking-[0.8px] text-[#9ca3af] font-semibold mb-1">
-                      Оригинал<template v-if="f.page"> · стр. {{ f.page }}</template>
+                      <div class="overflow-section-label">Скрыть из пула</div>
+                      <button
+                        @click="hideFragment(f.fragment_id, 'ошибка извлечения')"
+                        class="overflow-item"
+                      >
+                        <span class="overflow-item-title">Ошибка извлечения</span>
+                        <span class="overflow-item-sub">OCR-мусор, список литературы, формула</span>
+                      </button>
+                      <button
+                        @click="hideFragment(f.fragment_id, 'нерелевантно')"
+                        class="overflow-item"
+                      >
+                        <span class="overflow-item-title">Нерелевантно</span>
+                        <span class="overflow-item-sub">не по теме диссертации</span>
+                      </button>
+                      <button
+                        @click="hideFragment(f.fragment_id, 'другое')"
+                        class="overflow-item"
+                      >
+                        <span class="overflow-item-title">Другое…</span>
+                      </button>
+                      <div class="overflow-divider"></div>
+                      <div class="overflow-hint">Цитату можно вернуть через фильтр «Скрытые».</div>
                     </div>
-                    <div class="text-sm text-[#6b6b8a] leading-relaxed" style="font-family:'Georgia',serif">"{{ f.text }}"</div>
                   </div>
 
-                  <!-- Meta row (intent + verbatim/paraphrase chip, note link) -->
-                  <div class="flex items-center justify-between flex-wrap gap-2">
-                    <div class="flex items-center gap-2 flex-wrap">
-                      <span
-                        class="text-[12px] font-medium px-2 py-0.5 rounded"
-                        :class="intentColor[f.citation_intent] || 'bg-gray-100 text-gray-600'"
-                      >{{ intentLabel[f.citation_intent] || f.citation_intent }}</span>
-                      <span
-                        v-if="f.verbatim"
-                        class="text-[12px] font-medium px-2 py-0.5 rounded bg-[#f0ede8] text-[#3d3d5c]"
-                        title="Дословная цитата"
-                      >Цитата</span>
-                      <span
-                        v-else
-                        class="text-[12px] font-medium px-2 py-0.5 rounded bg-[#f0ede8] text-[#3d3d5c]"
-                        title="Парафраз — проверьте перед цитированием"
-                      >Парафраз</span>
-                    </div>
-                    <button
-                      v-if="!openNotes[f.fragment_id]"
-                      class="text-[13px] text-[#6b6b8a] cursor-pointer border-none bg-transparent p-0 hover:text-[#0d7377]"
-                      @click="toggleNote(f.fragment_id)"
-                    >✎ заметка</button>
-                  </div>
-
-                  <!-- Note area -->
-                  <div v-if="openNotes[f.fragment_id]" class="mt-3">
-                    <template v-if="notes[f.fragment_id] && !editingNote[f.fragment_id]">
-                      <div class="text-[13px] text-[#6b6b8a] italic leading-6">
-                        {{ notes[f.fragment_id] }}
-                        <button class="text-[#0d7377] not-italic cursor-pointer ml-1 border-none bg-transparent" @click="startEditNote(f.fragment_id)">(изм.)</button>
+                  <!-- Hidden card: compact, meta row + "вернуть в пул" on the right -->
+                  <template v-if="isHidden(f.fragment_id)">
+                    <div
+                      v-if="(suggestedTexts[f.fragment_id] || '').trim()"
+                      class="hidden-para"
+                    >{{ suggestedTexts[f.fragment_id] }}</div>
+                    <div v-else class="hidden-para serif-italic">«{{ f.text }}»</div>
+                    <div class="frag-meta">
+                      <div class="frag-meta-left">
+                        <span class="chip intent-chip" :style="intentChipStyle(f.citation_intent)">
+                          {{ intentLabel[f.citation_intent] || f.citation_intent }}
+                        </span>
+                        <span v-if="hideReasons[f.fragment_id]" class="meta-aside">скрыто · {{ hideReasons[f.fragment_id] }}</span>
+                        <span v-else class="meta-aside">скрыто</span>
                       </div>
-                    </template>
-                    <template v-else>
-                      <textarea
-                        class="w-full border border-[#e8e5df] rounded-md p-2 text-[13px] font-sans resize-y min-h-12 text-[#3d3d5c] focus:outline-none focus:border-[#0d7377]"
-                        placeholder="Как использовать эту цитату..."
-                        :value="notes[f.fragment_id] || ''"
-                        @blur="saveNote(f.fragment_id, ($event.target as HTMLTextAreaElement).value)"
-                      />
-                    </template>
-                  </div>
-                </div>
+                      <div class="frag-meta-right">
+                        <button class="note-link" @click="undo(f.fragment_id)">↶ вернуть в пул</button>
+                      </div>
+                    </div>
+                  </template>
 
-                <!-- Card actions footer -->
-                <div
-                  class="px-[18px] py-[10px] border-t flex items-center justify-between rounded-b-[10px]"
-                  :class="isPicked(f.fragment_id)
-                    ? 'bg-[#e9dcef] border-[#a971c1]'
-                    : 'bg-[#fafaf8] border-[#f0ede8]'"
-                >
-                  <template v-if="isPicked(f.fragment_id)">
-                    <span class="text-[13px] font-bold text-[#3b1f47] flex items-center gap-1.5">
-                      <span class="text-[#934eb1] text-[17px] leading-none">★</span>В работе
-                    </span>
-                    <button
-                      class="text-[13px] text-[#6b6b8a] cursor-pointer border-none bg-transparent px-2 py-1 rounded-md hover:bg-black/5 hover:text-[#1a1a2e]"
-                      @click="undo(f.fragment_id)"
-                    >убрать</button>
-                  </template>
+                  <!-- Active card: pool or picked -->
                   <template v-else>
-                    <span class="text-[13px] text-[#9ca3af]">В пуле</span>
-                    <button
-                      class="inline-flex items-center px-[10px] py-[5px] rounded-md text-[13px] font-medium cursor-pointer bg-transparent text-[#065a5e] border border-transparent hover:bg-[#e6f3f3] hover:border-[#0d7377]"
-                      @click="pickFragment(f.fragment_id)"
-                    >＋ В работу</button>
+                    <!-- Paraphrase (editable on click) -->
+                    <div class="paraphrase">
+                      <div
+                        v-if="inProgressIds.has(f.fragment_id)"
+                        class="paraphrase-loading"
+                      >✨ Генерируем академическое предложение…</div>
+
+                      <div
+                        v-else-if="(suggestedTexts[f.fragment_id] || '').trim() && !editingSuggested[f.fragment_id]"
+                        class="frag-para"
+                        @click="startEditSuggested(f.fragment_id)"
+                      >{{ formatParaphrase(suggestedTexts[f.fragment_id] || '') }}</div>
+
+                      <div
+                        v-else-if="!editingSuggested[f.fragment_id]"
+                        class="paraphrase-placeholder"
+                        @click="startEditSuggested(f.fragment_id)"
+                      >{{ failedIds.has(f.fragment_id) ? 'Не удалось сгенерировать. Нажмите 🔄, чтобы повторить.' : 'Академическое предложение появится здесь после генерации.' }}</div>
+
+                      <textarea
+                        v-else
+                        :data-edit-id="f.fragment_id"
+                        class="paraphrase-edit"
+                        :value="suggestedTexts[f.fragment_id] || ''"
+                        @input="onSuggestedInput(f.fragment_id, ($event.target as HTMLTextAreaElement).value)"
+                        @blur="finishEditSuggested(f.fragment_id)"
+                      />
+
+                      <button
+                        v-if="failedIds.has(f.fragment_id) && !inProgressIds.has(f.fragment_id)"
+                        class="retry-link"
+                        @click="retryFragmentSentence(f.fragment_id)"
+                      >🔄 повторить</button>
+                      <div
+                        v-if="sentenceModels[f.fragment_id] && !failedIds.has(f.fragment_id)"
+                        class="model-chip"
+                      ><span class="model-chip-icon">✨</span>{{ humanizeModel(sentenceModels[f.fragment_id] || '') }}</div>
+                    </div>
+
+                    <!-- Original + trust badge -->
+                    <div class="frag-orig">
+                      <div class="frag-orig-header">
+                        <span class="frag-orig-label">
+                          оригинал<template v-if="f.page"> · стр. {{ f.page }}</template>
+                        </span>
+                        <span
+                          v-if="sentenceModels[f.fragment_id]"
+                          class="trust-badge"
+                          :title="`Парафраз сверен с оригиналом · ${humanizeModel(sentenceModels[f.fragment_id] || '')}`"
+                        >✓ совпадает с источником · {{ humanizeModel(sentenceModels[f.fragment_id] || '') }}</span>
+                      </div>
+                      <div class="frag-orig-text">«{{ f.text }}»</div>
+                    </div>
+
+                    <!-- Meta row: intent + verbatim chip + (note/action) -->
+                    <div class="frag-meta">
+                      <div class="frag-meta-left">
+                        <span class="chip intent-chip" :style="intentChipStyle(f.citation_intent)">
+                          {{ intentLabel[f.citation_intent] || f.citation_intent }}
+                        </span>
+                        <span
+                          v-if="f.verbatim"
+                          class="chip type-chip"
+                          title="Дословная цитата"
+                        >Цитата</span>
+                        <span
+                          v-else
+                          class="chip type-chip"
+                          title="Парафраз — проверьте перед цитированием"
+                        >Парафраз</span>
+                      </div>
+                      <div class="frag-meta-right">
+                        <button
+                          v-if="!openNotes[f.fragment_id]"
+                          class="note-link"
+                          @click="toggleNote(f.fragment_id)"
+                        >+ заметка</button>
+                        <button
+                          v-if="!isPicked(f.fragment_id)"
+                          class="btn primary sm"
+                          @click="pickFragment(f.fragment_id)"
+                        >+ В работу</button>
+                      </div>
+                    </div>
+
+                    <!-- Note area -->
+                    <div v-if="openNotes[f.fragment_id]" class="note-area">
+                      <template v-if="notes[f.fragment_id] && !editingNote[f.fragment_id]">
+                        <div class="note-display">
+                          {{ notes[f.fragment_id] }}
+                          <button class="note-edit-link" @click="startEditNote(f.fragment_id)">(изм.)</button>
+                        </div>
+                      </template>
+                      <template v-else>
+                        <textarea
+                          class="note-input"
+                          placeholder="Как использовать эту цитату…"
+                          :value="notes[f.fragment_id] || ''"
+                          @blur="saveNote(f.fragment_id, ($event.target as HTMLTextAreaElement).value)"
+                        />
+                      </template>
+                    </div>
                   </template>
-                </div>
-              </template>
-            </div>
+                </article>
+              </div>
+            </template>
           </template>
 
         </template>
       </template>
-      </template>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* ── Layout ──────────────────────────────────────────────────────────── */
+.fr-root {
+  flex: 1;
+  width: 100%;
+  overflow-y: auto;
+  background: var(--color-paper);
+  font-family: var(--font-ui);
+  color: var(--color-ink);
+  font-feature-settings: 'ss01', 'cv11';
+  -webkit-font-smoothing: antialiased;
+}
+.fr-content {
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 40px 48px 120px;
+}
+@media (max-width: 1100px) {
+  .fr-content { padding: 32px 32px 80px; }
+}
+
+/* ── Back link, loading, status ───────────────────────────────────── */
+.doc-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--color-accent);
+  margin-bottom: 16px;
+  text-decoration: none;
+}
+.doc-back:hover { border-bottom: 1px solid var(--color-accent); padding-bottom: 1px; }
+
+.fr-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 96px 0;
+}
+.fr-spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--color-accent);
+  border-top-color: transparent;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Document head ───────────────────────────────────────────────────── */
+.doc-head { margin-bottom: 28px; }
+.doc-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+.doc-title-block { min-width: 0; flex: 1; }
+.doc-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 34px;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 10px 0;
+  max-width: 760px;
+  color: var(--color-ink);
+}
+.doc-sub {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--color-ink-muted);
+  font-family: var(--font-mono);
+  flex-wrap: wrap;
+}
+.doc-sub .dot { color: var(--color-ink-faint); }
+.citekey-slug { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 320px; }
+
+.doc-overflow-wrap { position: relative; flex-shrink: 0; margin-top: 2px; }
+.doc-overflow {
+  width: 32px; height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-ink-muted);
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+.doc-overflow:hover { background: var(--color-paper-2); color: var(--color-ink); }
+.doc-overflow-menu {
+  position: absolute; right: 0; top: 36px;
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(30,27,24,.08);
+  padding: 4px 0;
+  min-width: 180px;
+  z-index: 20;
+}
+.doc-overflow-item {
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 13px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.doc-overflow-item.danger { color: var(--color-err); }
+.doc-overflow-item.danger:hover { background: var(--color-err-bg); }
+.doc-overflow-item:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Tally: decision state (not progress) ────────────────────────────── */
+.tally {
+  margin-top: 22px;
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border-top: 1px solid var(--color-rule);
+  border-bottom: 1px solid var(--color-rule);
+  padding: 14px 0;
+}
+.tally-cell {
+  padding: 0 24px;
+  border-right: 1px solid var(--color-rule);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.tally-cell:first-child { padding-left: 0; }
+.tally-cell:last-child { border-right: none; padding-right: 0; }
+.tally-hint-cell {
+  margin-left: auto;
+  text-align: right;
+  justify-content: center;
+  border-right: none;
+}
+.tally-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+.tally-value {
+  font-family: var(--font-body-serif);
+  font-size: 24px;
+  font-weight: 500;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.tally-value.picked { color: var(--color-picked); }
+.tally-unit {
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  font-weight: 400;
+  font-family: var(--font-ui);
+  margin-left: 2px;
+  font-style: italic;
+}
+.tally-hint {
+  font-size: 12px;
+  color: var(--color-ink-muted);
+  font-style: italic;
+  max-width: 240px;
+  line-height: 1.45;
+}
+
+/* ── Processing / empty states ───────────────────────────────────────── */
+.fr-empty {
+  border: 2px dashed var(--color-rule);
+  border-radius: 12px;
+  padding: 48px;
+  text-align: center;
+}
+.fr-empty-icon {
+  margin: 0 auto 16px;
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  background: var(--color-accent-tint);
+  color: var(--color-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.fr-empty-title { font-size: 18px; font-weight: 600; color: var(--color-ink); margin: 0; }
+.fr-empty-sub { margin-top: 8px; font-size: 13px; color: var(--color-ink-muted); }
+
+.fr-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent-tint);
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+.fr-status-text { font-size: 13px; font-weight: 500; color: var(--color-accent-deep); }
+.fr-status-sub { font-size: 13px; color: var(--color-ink-muted); }
+
+.fr-error {
+  margin-top: 12px;
+  border: 1px solid var(--color-err);
+  background: var(--color-err-bg);
+  border-radius: 12px;
+  padding: 16px;
+  color: var(--color-err);
+  font-size: 13px;
+}
+.fr-error.center { text-align: center; padding: 20px; }
+.fr-error-retry {
+  margin-top: 6px;
+  font-size: 13px;
+  color: var(--color-accent);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.fr-error-retry:hover { text-decoration: underline; }
+.fr-link {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--color-accent);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.fr-link:hover { text-decoration: underline; }
+
+/* ── Buttons ─────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  border: 1px solid var(--color-rule);
+  background: white;
+  color: var(--color-ink-light);
+  cursor: pointer;
+  line-height: 1.4;
+}
+.btn:hover { background: var(--color-paper-2); }
+.btn.primary {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+.btn.primary:hover { background: var(--color-accent-deep); }
+.btn.primary:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn.sm { padding: 4px 10px; font-size: 12px; }
+
+/* ── Filters ─────────────────────────────────────────────────────────── */
+.filters {
+  margin-top: 32px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.filter-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.filter-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--color-rule);
+  margin: 0 4px;
+}
+
+/* ── Chips ───────────────────────────────────────────────────────────── */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: default;
+}
+.chip .count {
+  opacity: 0.55;
+  font-weight: 400;
+  margin-left: 2px;
+}
+.chip.filter-chip {
+  background: var(--color-paper-2);
+  color: var(--color-ink-light);
+  cursor: pointer;
+}
+.chip.filter-chip:hover { background: var(--color-paper-3); }
+.chip.filter-chip.active {
+  background: white;
+  color: var(--color-ink);
+  border-color: var(--color-rule);
+  box-shadow: 0 1px 2px rgba(30,27,24,.05);
+}
+.chip.intent-chip { cursor: pointer; }
+.chip.intent-chip.active {
+  box-shadow: 0 0 0 1.5px currentColor inset, 0 1px 2px rgba(30,27,24,.05);
+}
+button.chip {
+  font-family: inherit;
+  border: 1px solid transparent;
+}
+.chip.type-chip {
+  background: transparent;
+  color: var(--color-ink-muted);
+  border: 1px solid var(--color-rule);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-weight: 400;
+}
+
+/* ── Toast ───────────────────────────────────────────────────────────── */
+.fr-toast {
+  margin-bottom: 12px;
+  border: 1px solid #fbbf24;
+  background: #fef9c3;
+  color: #78350f;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+/* ── Section headers ─────────────────────────────────────────────────── */
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 32px 0 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-rule);
+}
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  font-weight: 500;
+}
+.section-title.picked { color: var(--color-picked); }
+.section-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+.section-trailing {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--color-ink-muted);
+}
+.group-gap { height: 28px; }
+
+/* ── Fragment cards ──────────────────────────────────────────────────── */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.frag {
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 6px;
+  padding: 20px 22px;
+  position: relative;
+  transition: box-shadow .15s ease, border-color .15s ease;
+}
+.frag:hover {
+  border-color: var(--color-paper-3);
+  box-shadow: 0 1px 2px rgba(30,27,24,.04);
+}
+/* Picked: 3px inset left bar + ochre tint, no frame — the bar IS the state */
+.frag.picked {
+  background: var(--color-picked-tint);
+  border-color: transparent;
+  box-shadow: inset 3px 0 0 var(--color-picked);
+  padding-left: 24px;
+}
+.frag.picked:hover {
+  box-shadow: inset 3px 0 0 var(--color-picked), 0 1px 2px rgba(30,27,24,.05);
+}
+.frag.hidden {
+  opacity: 0.55;
+  padding: 14px 22px;
+  background: transparent;
+  border-style: dashed;
+}
+
+/* Paraphrase (the primary text) */
+.paraphrase { margin-bottom: 14px; margin-right: 36px; }
+.frag-para {
+  font-size: 15px;
+  line-height: 1.62;
+  color: var(--color-ink);
+  text-wrap: pretty;
+  cursor: text;
+}
+.paraphrase-loading {
+  animation: pulse-soft 1.8s ease-in-out infinite;
+  border-radius: 8px;
+  background: var(--color-accent-tint);
+  border: 1px solid var(--color-accent-rule);
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--color-accent-deep);
+  font-style: italic;
+}
+.paraphrase-placeholder {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--color-ink-faint);
+  font-style: italic;
+  cursor: text;
+}
+.paraphrase-edit {
+  width: 100%;
+  border-radius: 6px;
+  border: 1px solid var(--color-rule);
+  background: white;
+  padding: 8px 12px;
+  font-size: 15px;
+  font-family: inherit;
+  line-height: 1.65;
+  color: var(--color-ink);
+  resize: vertical;
+  min-height: 56px;
+}
+.paraphrase-edit:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+.retry-link {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--color-err);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.retry-link:hover { text-decoration: underline; }
+.model-chip {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+}
+.model-chip-icon { font-size: 10px; opacity: 0.7; }
+
+/* Original block: paper bg + left rule + mono label + trust badge + serif italic text */
+.frag-orig {
+  margin-top: 14px;
+  padding: 12px 14px 13px;
+  background: var(--color-paper);
+  border-radius: 4px;
+  border-left: 2px solid var(--color-rule);
+}
+.frag.picked .frag-orig {
+  background: rgba(255,255,255,.5);
+  border-left-color: var(--color-picked-rule);
+}
+.frag-orig-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.frag-orig-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+.trust-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-accent);
+  background: var(--color-accent-tint);
+  padding: 2px 7px;
+  border-radius: 3px;
+  white-space: nowrap;
+  cursor: help;
+}
+.frag-orig-text {
+  font-family: var(--font-body-serif);
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.58;
+  color: var(--color-ink-light);
+}
+
+/* Meta row: intent + type + (note/action) */
+.frag-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.frag-meta-left {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.frag-meta-right {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--color-ink-muted);
+}
+.meta-aside {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-ink-faint);
+  margin-left: 4px;
+}
+
+/* Note link (inline action) */
+.note-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-accent);
+  font-size: 13px;
+  padding: 2px 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+.note-link:hover {
+  border-bottom: 1px solid var(--color-accent);
+  padding-bottom: 1px;
+  margin-bottom: -1px;
+}
+
+/* Note area */
+.note-area { margin-top: 12px; }
+.note-display {
+  font-size: 13px;
+  color: var(--color-ink-muted);
+  font-style: italic;
+  line-height: 1.6;
+}
+.note-edit-link {
+  color: var(--color-accent);
+  font-style: normal;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  margin-left: 4px;
+  font-family: inherit;
+  font-size: inherit;
+}
+.note-input {
+  width: 100%;
+  border: 1px solid var(--color-rule);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 48px;
+  color: var(--color-ink-light);
+  background: white;
+}
+.note-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+/* Hidden-card compact text */
+.hidden-para {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-ink-muted);
+  margin-bottom: 8px;
+  margin-right: 36px;
+}
+.hidden-para.serif-italic {
+  font-family: var(--font-body-serif);
+  font-style: italic;
+}
+
+/* Overflow menu on the card */
+.overflow-wrap {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 10;
+}
+.overflow-btn {
+  width: 28px; height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-ink-faint);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-size: 15px;
+  line-height: 1;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+.overflow-btn:hover,
+.overflow-btn.open {
+  background: var(--color-paper-2);
+  color: var(--color-ink-light);
+}
+.overflow-menu {
+  position: absolute;
+  top: 34px;
+  right: 0;
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(30,27,24,.08);
+  min-width: 260px;
+  z-index: 30;
+  padding: 4px 0;
+}
+.overflow-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+  padding: 10px 14px 6px;
+}
+.overflow-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 14px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.overflow-item:hover { background: var(--color-paper-2); }
+.overflow-item-title {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+.overflow-item-sub {
+  display: block;
+  font-size: 12px;
+  color: var(--color-ink-muted);
+  margin-top: 2px;
+}
+.overflow-divider {
+  height: 1px;
+  background: var(--color-rule);
+  margin: 4px 0;
+}
+.overflow-hint {
+  font-size: 12px;
+  color: var(--color-ink-muted);
+  padding: 6px 14px 8px;
+  line-height: 1.4;
+}
+
+/* ── Sentence-empty onboarding card ──────────────────────────────────── */
+.sentence-empty-head {
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid var(--color-rule-light);
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin: -20px -22px 0;
+}
+.sentence-empty-icon {
+  width: 28px; height: 28px;
+  border-radius: 6px;
+  background: var(--color-accent-tint);
+  color: var(--color-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 14px;
+}
+.sentence-empty-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-ink);
+  margin: 0 0 4px 0;
+}
+.sentence-empty-sub {
+  font-size: 13px;
+  color: var(--color-ink-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+.sentence-empty-body { padding: 16px 0 0; }
+.sentence-empty-foot {
+  margin: 16px -22px -20px;
+  padding: 10px 22px;
+  border-top: 1px solid var(--color-rule-light);
+  background: var(--color-paper);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--color-ink-faint);
+  border-radius: 0 0 6px 6px;
+}
+
+@keyframes pulse-soft {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+</style>


### PR DESCRIPTION
## Summary
Migrated FragmentReviewView from inline Tailwind styles to semantic CSS classes defined in main.css. Replaced hardcoded color values with CSS custom properties (tokens) for intent chips. Restructured the app shell layout in App.vue to use a sidebar-based navigation pattern instead of a top bar.

## Key Changes

### FragmentReviewView.vue
- **Intent chip styling**: Replaced `intentColor` and `intentColorActive` objects with `intentTokenKey` mapping and `intentChipStyle()` function that returns CSS variables (`--color-intent-{key}-bg` and `--color-intent-{key}-ink`)
- **Layout refactoring**: Converted inline Tailwind classes to semantic CSS classes:
  - `.fr-root`, `.fr-content` for main container
  - `.doc-head`, `.doc-title`, `.doc-sub` for header
  - `.frag` for fragment cards with `.picked` and `.hidden` modifiers
  - `.filters`, `.filter-group`, `.chip`, `.intent-chip` for filter toolbar
  - `.section-head`, `.section-title`, `.section-count` for group headers
  - `.paraphrase`, `.frag-para`, `.frag-meta` for content sections
  - `.overflow-menu`, `.overflow-item` for card action menus
- **New computed property**: `poolCount` to track fragments awaiting decision (visible but not picked)
- **Tally section**: Added `.tally` display showing "в работе" (picked), "в пуле" (pool), and "скрыто" (hidden) counts with explanatory hint
- **Removed**: Inline color definitions; all colors now sourced from CSS variables

### App.vue
- **Sidebar-based layout**: Restructured from top bar + side nav to unified sidebar navigation
  - `.app-shell`, `.app-sidebar` for main layout structure
  - `.sidebar-logo`, `.sidebar-logo-row` for brand
  - `.project-switch`, `.project-menu` for project selector
  - `.nav-item`, `.nav-label` for navigation links
  - `.sidebar-bottom` for user profile (pinned to bottom)
- **Navigation items**: Added icons and labels for Library, Map, and Feed routes
- **Removed**: Separate topbar header; navigation now integrated into sidebar

### main.css
- **New CSS variables**: Added `--color-ink-faint`, `--color-paper-2`, `--color-paper-3`, `--color-accent-tint`, `--color-accent-rule` for expanded palette
- **Intent token colors**: Defined `--color-intent-{bg,method,result,ext,contrast,data}-{bg,ink}` variables using oklch color space for consistent hue family
- **New semantic classes**: Added `.fr-*`, `.doc-*`, `.frag-*`, `.chip-*`, `.filter-*`, `.section-*`, `.tally-*`, `.app-*`, `.sidebar-*`, `.nav-*`, `.project-*` class definitions

## Implementation Details
- Intent chips now use CSS variables instead of hardcoded Tailwind classes, enabling dynamic theming and consistent color relationships across the oklch color space
- Fragment card styling uses BEM-like modifiers (`.frag.picked`, `.frag.hidden`) for state-based styling
- Sidebar navigation uses active route detection to highlight current section
- All spacing, typography, and color values moved to CSS for maintainability and consistency

https://claude.ai/code/session_01PSePYQewwRVj7KjxWptZ4K