### PR TITLE
fix(saas): generate Latin citekeys from Russian PDF filenames

### DIFF
--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -1088,13 +1088,36 @@ def _enqueue_processing(paper_id: str, citekey: str, user_id: str, project_id: s
         return None
 
 
+def _clean_author_slug(raw: str) -> str:
+    """Transliterate Cyrillic → Latin, lowercase, strip to ``[a-z0-9]``.
+
+    Used by ``_citekey_from_filename`` to produce a BBT-compatible author
+    surname slug. Returns empty string if nothing usable remains.
+    """
+    if not raw:
+        return ""
+    from klemma.utils.translit import transliterate_ru
+
+    transliterated = transliterate_ru(raw)
+    return re.sub(r"[^a-z0-9]", "", transliterated.lower())
+
+
 def _citekey_from_filename(filename: str) -> str:
-    """Generate a citekey from a PDF filename.
+    """Generate a BBT-style citekey from a PDF filename.
 
-    Matches CLI pattern (acquirer._generate_citekey): author+year+slug.
+    Format: ``{lastname_lat}{year}``. Cyrillic surnames are transliterated
+    via ``transliterate_ru``; the title is NOT included in the slug (BBT
+    default is short and deterministic; title slugs were the primary source
+    of the long Cyrillic keys seen in prod).
 
-    'Andersson et al. - 2021 - Seasonal Arctic sea ice.pdf' → 'andersson2021_seasonal_arctic_sea_ice'
-    'Smith_2020_Machine_Learning.pdf' → 'smith2020_machine_learning'
+    Collision handling lives at the caller (upload_pdf appends
+    ``_{pdf_hash[:6]}`` when the base is already taken).
+
+    Examples:
+        'Воронина - 2023 - Основные направления.pdf' → 'voronina2023'
+        'Andersson et al. - 2021 - Seasonal Arctic sea ice.pdf' → 'andersson2021'
+        'Smith_2020_Machine_Learning.pdf' → 'smith2020'
+        'Иванов 2019.pdf' → 'ivanov2019'
     """
     name = filename.rsplit(".", 1)[0]  # remove .pdf
 
@@ -1103,14 +1126,9 @@ def _citekey_from_filename(filename: str) -> str:
     if m:
         author_part = m.group(1).strip()
         year = m.group(2)
-        title_part = m.group(3).strip()
-        # First author's last name
-        first_author = re.split(r"[,\s]", author_part)[0]
-        first_author = re.sub(r"[^\w]", "", first_author).lower()
-        # Title slug: first ~30 chars, underscore-separated
-        slug = re.sub(r"[^\w\s]", "", title_part).strip()
-        slug = re.sub(r"\s+", "_", slug).lower()[:30].rstrip("_")
-        return f"{first_author}{year}_{slug}" if first_author else f"paper{year}_{slug}"
+        first_author_raw = re.split(r"[,\s]", author_part)[0]
+        first_author = _clean_author_slug(first_author_raw)
+        return f"{first_author}{year}" if first_author else f"paper{year}"
 
     # Fallback: split on separators, extract year if present
     parts = re.split(r"[_\-\s]+", name)
@@ -1118,31 +1136,16 @@ def _citekey_from_filename(filename: str) -> str:
     if not parts:
         return "unknown"
 
-    # Find year
     year = ""
-    year_idx = -1
-    for i, p in enumerate(parts):
+    for p in parts:
         if re.match(r"^\d{4}$", p):
             year = p
-            year_idx = i
             break
 
-    # First part before year = author, rest = title
-    first_author = parts[0].lower() if parts else "unknown"
-    first_author = re.sub(r"[^\w]", "", first_author)
+    first_author = _clean_author_slug(parts[0]) if parts else ""
+    # A digit-only "surname" means the filename started with the year — not a
+    # real author. Fall back to "paper" so we don't emit "20232023".
+    if not first_author or first_author.isdigit():
+        first_author = "paper"
 
-    if year_idx > 0:
-        # Title words after year
-        title_words = parts[year_idx + 1:]
-    elif year_idx == 0:
-        title_words = parts[1:]
-    else:
-        title_words = parts[1:]
-
-    slug = "_".join(w.lower() for w in title_words[:5])
-    slug = re.sub(r"[^\w_]", "", slug)[:30].rstrip("_")
-
-    key = f"{first_author}{year}"
-    if slug:
-        key += f"_{slug}"
-    return key or "unknown"
+    return f"{first_author}{year}" if year else first_author

--- a/src/klemma/utils/__init__.py
+++ b/src/klemma/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Small utility helpers shared across klemma subsystems."""

--- a/src/klemma/utils/translit.py
+++ b/src/klemma/utils/translit.py
@@ -1,0 +1,40 @@
+"""Cyrillic → Latin transliteration for citekey generation.
+
+Simplified phonetic table (BBT-compatible lowercase output). Not strict
+ГОСТ 7.79 — we drop diacritics (`c` instead of `c'`) and use `yo` for ё
+to stay inside the ASCII word-class so downstream citekey slugify rules
+don't need to be Unicode-aware.
+"""
+
+from __future__ import annotations
+
+_RU_TO_LAT: dict[str, str] = {
+    "а": "a",  "б": "b",  "в": "v",  "г": "g",  "д": "d",
+    "е": "e",  "ё": "yo", "ж": "zh", "з": "z",  "и": "i",
+    "й": "y",  "к": "k",  "л": "l",  "м": "m",  "н": "n",
+    "о": "o",  "п": "p",  "р": "r",  "с": "s",  "т": "t",
+    "у": "u",  "ф": "f",  "х": "kh", "ц": "ts", "ч": "ch",
+    "ш": "sh", "щ": "shch","ъ": "",  "ы": "y",  "ь": "",
+    "э": "e",  "ю": "yu", "я": "ya",
+}
+
+
+def transliterate_ru(text: str) -> str:
+    """Lowercase Cyrillic → Latin. Non-Cyrillic chars pass through unchanged.
+
+    Intended for citekey generation (author surnames, short labels). Examples:
+        "Воронина" → "voronina"
+        "Щедрин"   → "shchedrin"
+        "Ёжиков"   → "yozhikov"
+        "Andersson"→ "andersson"
+    """
+    if not text:
+        return ""
+    out: list[str] = []
+    for ch in text:
+        lower = ch.lower()
+        if lower in _RU_TO_LAT:
+            out.append(_RU_TO_LAT[lower])
+        else:
+            out.append(lower)
+    return "".join(out)

--- a/tests/test_citekey_generation.py
+++ b/tests/test_citekey_generation.py
@@ -1,0 +1,87 @@
+"""Tests for `_citekey_from_filename` — BBT-style citekey generation."""
+
+from klemma.api.routes.library import _citekey_from_filename
+
+# ---------------------------------------------------------------------------
+# Zotero "Author - Year - Title" pattern
+# ---------------------------------------------------------------------------
+
+
+def test_zotero_pattern_cyrillic():
+    """The main bug from prod: Russian PDF was generating `воронина2023_...`."""
+    result = _citekey_from_filename(
+        "Воронина - 2023 - Основные направления устойчивого функционирования.pdf"
+    )
+    assert result == "voronina2023"
+
+
+def test_zotero_pattern_latin():
+    assert _citekey_from_filename(
+        "Andersson et al. - 2021 - Seasonal Arctic sea ice.pdf"
+    ) == "andersson2021"
+
+
+def test_zotero_pattern_multiple_authors_cyrillic():
+    """Only first author is used for citekey."""
+    assert _citekey_from_filename(
+        "Смирнов, Иванов - 2021 - Ледовый прогноз.pdf"
+    ) == "smirnov2021"
+
+
+def test_zotero_pattern_em_dash():
+    # Some exports use — instead of -
+    assert _citekey_from_filename(
+        "Smith — 2020 — Machine Learning.pdf"
+    ) == "smith2020"
+
+
+# ---------------------------------------------------------------------------
+# Underscore-separated pattern (Zotero, Mendeley variants)
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_pattern_latin():
+    assert _citekey_from_filename("Smith_2020_Machine_Learning.pdf") == "smith2020"
+
+
+def test_underscore_pattern_cyrillic():
+    assert _citekey_from_filename("Иванов_2019_Статья.pdf") == "ivanov2019"
+
+
+def test_space_separated_cyrillic():
+    assert _citekey_from_filename("Иванов 2019.pdf") == "ivanov2019"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_title_slug_anywhere():
+    """Regression: the old generator produced
+    `воронина2023_основные_направления_устоичиво`. The new one must NEVER emit
+    a title slug — downstream formats rely on a short stable prefix.
+    """
+    bad = _citekey_from_filename("Воронина - 2023 - Основные направления устойчивого функционирования.pdf")
+    assert "_" not in bad
+    # And no Cyrillic characters should leak into the output
+    assert all(c.isascii() for c in bad)
+
+
+def test_author_only_no_year():
+    # Without a year we can't produce a good key, but we still strip to Latin
+    assert _citekey_from_filename("Воронина.pdf") == "voronina"
+
+
+def test_year_only():
+    assert _citekey_from_filename("2023.pdf") == "paper2023"
+
+
+def test_empty_name():
+    # Unlikely in practice but must not crash
+    assert _citekey_from_filename(".pdf") == "unknown"
+
+
+def test_special_chars_stripped():
+    assert _citekey_from_filename("O'Brien - 2020 - Title.pdf") == "obrien2020"
+    assert _citekey_from_filename("Müller - 2018 - Paper.pdf") == "mller2018"

--- a/tests/test_translit.py
+++ b/tests/test_translit.py
@@ -1,0 +1,45 @@
+"""Tests for Cyrillic → Latin transliteration used in citekey generation."""
+
+from klemma.utils.translit import transliterate_ru
+
+
+def test_cyrillic_surname_basic():
+    assert transliterate_ru("Воронина") == "voronina"
+    assert transliterate_ru("Иванов") == "ivanov"
+    assert transliterate_ru("Смирнов") == "smirnov"
+
+
+def test_cyrillic_with_hushers():
+    assert transliterate_ru("Щедрин") == "shchedrin"
+    assert transliterate_ru("Жуков") == "zhukov"
+    assert transliterate_ru("Чехов") == "chekhov"
+    assert transliterate_ru("Шишкин") == "shishkin"
+
+
+def test_cyrillic_with_yo():
+    assert transliterate_ru("Ёжиков") == "yozhikov"
+    assert transliterate_ru("Фёдоров") == "fyodorov"
+
+
+def test_cyrillic_soft_hard_signs_dropped():
+    # ь and ъ collapse to nothing — they don't have phonetic Latin equivalent
+    assert transliterate_ru("Подъезд") == "podezd"
+    assert transliterate_ru("Льдов") == "ldov"
+
+
+def test_latin_passthrough():
+    # Non-Cyrillic ASCII is preserved (lowercased, but table doesn't map it
+    # so the character falls through unchanged after lower())
+    assert transliterate_ru("Andersson") == "andersson"
+    assert transliterate_ru("SMITH") == "smith"
+    assert transliterate_ru("O'Brien") == "o'brien"
+
+
+def test_mixed_script():
+    # Cyrillic letters convert, Latin letters stay
+    assert transliterate_ru("Иван123") == "ivan123"
+
+
+def test_empty_and_none_safe():
+    assert transliterate_ru("") == ""
+    assert transliterate_ru(None) == ""  # type: ignore[arg-type]


### PR DESCRIPTION
Part 1 of 3 in the BBT-parity plan (see [plan file](/Users/ilya/.claude/plans/ok-hazy-dongarra.md)).

## Summary
Uploading `Воронина - 2023 - Основные направления.pdf` produced the citekey `воронина2023_основные_направления_устоичиво` in prod. Cyrillic leaked through Python's Unicode `\w` class, and the title slug inflated everything further.

New generator:
- Transliterates Cyrillic → Latin via a simple phonetic table (`klemma.utils.translit`).
- Strips the result to `[a-z0-9]` only; drops anything non-ASCII.
- Emits `{lastname_lat}{year}` **without a title slug** (matches BBT default).
- Digit-only "author" (filename starts with year) → falls back to `paper`.

Collision handling at the call site (`_{pdf_hash[:6]}`) unchanged — preserves the citekey-stability invariant from issue #268.

## Release Note

### Problem
Klemma SaaS was generating citekeys like `воронина2023_основные_направления_устоичиво` from Russian-language PDF filenames. These keys are unusable downstream: they don't match the user's local BetterBibTeX output (`voronina2023`), so copying cloud-generated citations into a local `draft.md` breaks pandoc + biber, and they're ugly in the UI.

### Academic Foundation
BetterBibTeX default citekey format (`auth + year`) is the de-facto standard in the Russian-language humanities/technical research community (Zotero + BBT is the dominant workflow for non-English academic writing in the Cyrillic alphabet). Producing cloud citekeys that match this convention is a prerequisite for any local/cloud workflow that routes text through pandoc.

### Implementation
New module `klemma.utils.translit` with `transliterate_ru`: a 33-letter simplified phonetic table (Cyrillic → Latin lowercase, soft/hard signs collapse to empty, ё → yo, щ → shch). Updated `_citekey_from_filename` in `api/routes/library.py` to transliterate, strip to `[a-z0-9]`, and emit `{lastname}{year}` — no title slug. Digit-leading filenames (bare year) fall back to `paper` prefix to avoid `20232023`.

### Results
19 new unit tests (translit + citekey generation). Full suite: 1942 passed / 1 skipped / 0 failed. No API contract change, no schema migration, no UI change. Follow-up parts: BBT JSON import (external_citekey field) and project settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)