### PR TITLE
fix(saas): re-upload of owned PDF moves source to current project

### DIFF
--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -732,6 +732,21 @@ async def upload_pdf(
             existing.paper_id, user_id=user.user_id
         )
         if existing_source:
+            # User already owns this PDF. If they're re-uploading into a
+            # different project (or into a project when the row had no
+            # project_id), repoint the row to the current project so the
+            # source actually appears in that project's library list.
+            # Without this, the upload silently "disappears" — the source
+            # stays attached to whichever project it was first uploaded
+            # into and the UI never shows it in the current view (#347).
+            if project_id and project_id != existing_source.project_id:
+                library.add_source(
+                    existing.paper_id,
+                    existing_source.citekey,
+                    status=existing_source.status,
+                    project_id=project_id,
+                    user_id=user.user_id,
+                )
             return UploadResponse(
                 citekey=existing_source.citekey,
                 paper_id=existing.paper_id,

--- a/src/klemma/models.py
+++ b/src/klemma/models.py
@@ -81,3 +81,4 @@ class UserSource:
     chapters: list[int] = field(default_factory=list)
     sections: list[str] = field(default_factory=list)
     external_citekey: str | None = None
+    project_id: str | None = None

--- a/src/klemma/stores/user_library.py
+++ b/src/klemma/stores/user_library.py
@@ -296,6 +296,7 @@ class LocalUserLibrary:
             chapters=chapters,
             sections=sections,
             external_citekey=_safe_ext_ck(row),
+            project_id=_safe_col(row, "project_id"),
         )
 
     def resolve_paper_id(
@@ -375,6 +376,7 @@ class LocalUserLibrary:
             chapters=chapters,
             sections=sections,
             external_citekey=_safe_ext_ck(row),
+            project_id=_safe_col(row, "project_id"),
         )
 
     # ------------------------------------------------------------------ #
@@ -626,5 +628,13 @@ def _safe_ext_ck(row: sqlite3.Row) -> Optional[str]:
     """Read external_citekey from a row, tolerating pre-v6 schemas in tests."""
     try:
         return row["external_citekey"]
+    except (IndexError, KeyError):
+        return None
+
+
+def _safe_col(row: sqlite3.Row, col: str) -> Optional[str]:
+    """Read a column from a sqlite3.Row, tolerating missing column in old schemas."""
+    try:
+        return row[col]
     except (IndexError, KeyError):
         return None

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -263,6 +263,57 @@ def test_upload_citekey_collision_uses_bbt_suffix(client):
     assert r1.json()["paper_id"] != r2.json()["paper_id"] != r3.json()["paper_id"]
 
 
+def test_upload_dedup_moves_source_to_current_project(client, stores):
+    """Re-uploading an already-owned PDF into a different project should move
+    the source to the new project. Before #347 the source stayed attached to
+    the original project and silently disappeared from the current library view.
+    """
+    user_store, _, user_library, _, _ = stores
+    token = _register_and_get_token(client)
+    user_id = client.get("/auth/me", headers=_auth_headers(token)).json()["user_id"]
+
+    proj_a = user_store.create_project(user_id=user_id, name="Project A")
+    proj_b = user_store.create_project(user_id=user_id, name="Project B")
+
+    pdf = _fake_pdf()
+
+    r1 = client.post(
+        "/library/upload",
+        files={"file": ("paper.pdf", pdf, "application/pdf")},
+        data={"project_id": proj_a["project_id"]},
+        headers=_auth_headers(token),
+    )
+    assert r1.status_code == 201, r1.json()
+    citekey = r1.json()["citekey"]
+
+    # Confirm initial project attachment
+    src = user_library.get_source_by_citekey(citekey, user_id=user_id)
+    assert src.project_id == proj_a["project_id"]
+
+    # Second upload of same PDF into a different project
+    r2 = client.post(
+        "/library/upload",
+        files={"file": ("paper.pdf", pdf, "application/pdf")},
+        data={"project_id": proj_b["project_id"]},
+        headers=_auth_headers(token),
+    )
+    assert r2.status_code == 201
+    assert r2.json()["already_owned"] is True
+    assert r2.json()["citekey"] == citekey
+
+    # Source now belongs to project B
+    src = user_library.get_source_by_citekey(citekey, user_id=user_id)
+    assert src.project_id == proj_b["project_id"]
+
+    # Library list of project B shows it
+    resp = client.get(
+        f"/library/sources?project_id={proj_b['project_id']}",
+        headers=_auth_headers(token),
+    )
+    citekeys_b = {s["citekey"] for s in resp.json()["sources"]}
+    assert citekey in citekeys_b
+
+
 def test_upload_dedup_same_user_preserves_citekey(client):
     """Re-uploading the same PDF by the same user returns the original citekey (issue #268)."""
     token = _register_and_get_token(client)


### PR DESCRIPTION
Closes #347.

## Summary
Re-uploading a PDF the user already owns into a different project left the source silently attached to the first project — library list of the *current* project skipped it (the filter is `project_id = ? OR project_id IS NULL`), so the source appeared to vanish after processing.

Hit today on prod: `andersson2021_seasonal_arctic_sea_ice_foreca` was uploaded into `immfegi-2026` but stayed glued to `Диссертация`. Data-fixed manually via direct UPDATE.

## Fix
In the \"already owned by this user\" branch of `/library/upload`, compare the submitted `project_id` against `existing_source.project_id`. If different (or the row had no project_id), call `library.add_source(project_id=...)` which upserts the column via `COALESCE(excluded.project_id, user_sources.project_id)`. Section assignments in `project_sources` are intentionally left where they are — they're per-project and should follow the user's MapView choices, not the upload path.

`UserSource` dataclass gained a `project_id` field (populated from the existing column); added a `_safe_col` helper mirroring `_safe_ext_ck` so pre-v6 schema tests keep passing.

## Release Note

### Problem
Uploading a PDF already present in one of the user's projects into another project silently kept it in the original project. The frontend got `already_owned=true` with the correct citekey, the source was processed, but it never appeared in the library list the user was looking at — a classic "my upload worked but the thing I uploaded is gone" failure mode.

### Academic Foundation
Explicit user intent must be honored in library operations. A re-upload into project B is a deliberate gesture: "I want this source in this project." Silently absorbing the action without reflecting it in the UI violates least-surprise. The fix picks the simplest semantics (move, not copy) consistent with the existing one-project-per-source schema.

### Implementation
Added a conditional `library.add_source(..., project_id=project_id)` call in the already-owned branch of `upload_pdf` (`src/klemma/api/routes/library.py`). Exposed `UserSource.project_id` (previously read-only in the DB, never surfaced on the dataclass). One regression test walks the two-project scenario end-to-end via the HTTP endpoint.

### Results
One new test (`test_upload_dedup_moves_source_to_current_project`). Full suite: 1993 passed, 1 skipped. No schema migration. No frontend change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)