### PR TITLE
feat(saas): display citekey (external_citekey) everywhere in user-visible text

### DIFF
--- a/src/klemma/api/routes/curation.py
+++ b/src/klemma/api/routes/curation.py
@@ -191,17 +191,21 @@ async def get_pending_fragments(
     user_store = get_user_store()
     outline = project.get("outline")
 
-    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
+    # Dual-key: accept internal citekey or external_citekey override.
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
     if not src:
         raise HTTPException(status_code=404, detail="Source not found")
+    internal_ck = src.citekey
+    display_ck = src.external_citekey or src.citekey
 
     all_fragments = paper_store.get_fragments(src.paper_id)
     curated_ids = user_store.get_curated_fragment_ids(project_id)
 
     # Existing curation rows for this source (needed for suggested_text lookup).
+    # DB stores the internal citekey regardless of what the client sent.
     curated_rows = {
         c["fragment_id"]: c
-        for c in user_store.get_curated(project_id, citekey=citekey)
+        for c in user_store.get_curated(project_id, citekey=internal_ck)
     }
 
     pending = []
@@ -214,7 +218,7 @@ async def get_pending_fragments(
                 citation_intent=f.citation_intent or "",
                 fragment_type=f.fragment_type or "",
                 page=f.page_number,
-                citekey=citekey,
+                citekey=display_ck,
                 suggested_section=auto_assign_section(f.citation_intent, outline),
                 verbatim=f.verbatim,
                 suggested_text=row.get("suggested_text"),
@@ -239,27 +243,31 @@ async def curate_fragments(
     user_store = get_user_store()
     outline = project.get("outline")
 
+    # Resolve each decision's citekey via dual-key so the UI can round-trip
+    # display citekeys through /suggest → /curate. DB writes always use the
+    # internal citekey.
+    library = get_user_library()
+    paper_store = get_paper_store()
+
     decisions = []
     accepted = 0
     rejected = 0
     for d in body.decisions:
+        src = library.get_source_by_any_key(d.citekey, user_id=user.user_id)
+        internal_ck = src.citekey if src else d.citekey
+
         section = d.assigned_section
-        if d.verdict == "accepted" and not section:
-            # Try auto-assignment via intent→section_type mapping
-            paper_store = get_paper_store()
-            library = get_user_library()
-            src = library.get_source_by_citekey(d.citekey, user_id=user.user_id)
+        if d.verdict == "accepted" and not section and src:
             intent = None
-            if src:
-                for f in paper_store.get_fragments(src.paper_id):
-                    if f.fragment_id == d.fragment_id:
-                        intent = f.citation_intent
-                        break
+            for f in paper_store.get_fragments(src.paper_id):
+                if f.fragment_id == d.fragment_id:
+                    intent = f.citation_intent
+                    break
             section = auto_assign_section(intent, outline)
 
         decisions.append({
             "fragment_id": d.fragment_id,
-            "citekey": d.citekey,
+            "citekey": internal_ck,
             "verdict": d.verdict,
             "assigned_section": section,
             "note": d.note,
@@ -283,17 +291,32 @@ async def get_curated_fragments(
     citekey: Optional[str] = None,
     user: UserRecord = Depends(get_current_user),
 ) -> CuratedBankResponse:
-    """Get curated fragments with optional filters."""
+    """Get curated fragments with optional filters.
+
+    ``citekey`` filter accepts either internal citekey or external_citekey
+    (BBT override); response echoes display citekey consistently.
+    """
     _get_project_or_404(project_id, user)
     user_store = get_user_store()
+    library = get_user_library()
+
+    # Resolve filter citekey → internal for DB query.
+    internal_citekey_filter: Optional[str] = None
+    if citekey:
+        src = library.get_source_by_any_key(citekey, user_id=user.user_id)
+        if src is None:
+            # Unknown key: return empty rather than leak all curated rows.
+            return CuratedBankResponse(fragments=[], total=0, by_section={})
+        internal_citekey_filter = src.citekey
 
     curated = user_store.get_curated(
-        project_id, verdict=verdict, section=section, citekey=citekey
+        project_id, verdict=verdict, section=section, citekey=internal_citekey_filter
     )
 
-    # Collect unique citekeys to fetch fragment text
+    # Collect unique citekeys to fetch fragment text + build display map.
     citekeys = {c["citekey"] for c in curated}
     text_map = _build_fragment_text_map(user.user_id, citekeys)
+    display_map = library.get_display_citekeys(list(citekeys), user_id=user.user_id)
 
     fragments = []
     by_section: dict[str, int] = {}
@@ -303,7 +326,7 @@ async def get_curated_fragments(
         by_section[sec] = by_section.get(sec, 0) + 1
         fragments.append(CuratedFragment(
             fragment_id=c["fragment_id"],
-            citekey=c["citekey"],
+            citekey=display_map.get(c["citekey"], c["citekey"]),
             text=frag_data.get("text", ""),
             citation_intent=frag_data.get("citation_intent", ""),
             assigned_section=c["assigned_section"],
@@ -377,6 +400,8 @@ async def suggest_fragments(
     all_sources = library.get_all_sources(user_id=user.user_id)
     known_citekeys = {s.citekey for s in all_sources}
     text_map = _build_fragment_text_map(user.user_id, known_citekeys)
+    # Batch-resolve display citekeys so UI sees external_citekey when set.
+    display_map = library.get_display_citekeys(list(known_citekeys), user_id=user.user_id)
 
     suggestions: list[SuggestFragment] = []
     seen_intents: set[str] = set()
@@ -408,12 +433,14 @@ async def suggest_fragments(
         if intent:
             seen_intents.add(intent)
 
+        internal_ck = frag_data.get("citekey", "")
+        display_ck = display_map.get(internal_ck, internal_ck)
         suggestions.append(SuggestFragment(
             fragment_id=frag_id,
             text=frag_data.get("text", ""),
             citation_intent=intent,
-            source=frag_data.get("citekey", ""),
-            citekey=frag_data.get("citekey", ""),
+            source=display_ck,
+            citekey=display_ck,
             match_reason=match_reason,
             score=score,
         ))
@@ -521,11 +548,16 @@ async def generate_sentences_endpoint(
     mode = body.mode if body.mode in ("missing", "force") else "missing"
 
     library = get_user_library()
-    if not library.get_source_by_citekey(body.citekey, user_id=user.user_id):
+    # Dual-key: accept either internal citekey or external_citekey.
+    src = library.get_source_by_any_key(body.citekey, user_id=user.user_id)
+    if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Source '{body.citekey}' not found in library",
         )
+    # Worker reads source by the citekey the client sent; it will re-resolve
+    # and pick up external_citekey for display. No internal rewrite needed
+    # here because the task looks up the source fresh by the submitted key.
 
     from ..tasks import generate_sentences_task
 

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -290,17 +290,22 @@ async def list_sources(
         paper = paper_store.get_paper_by_id(src.paper_id)
         title = paper.title if paper else ""
         authors = paper.authors if paper else ""
+        display_ck = src.external_citekey or src.citekey
+        # q matches both internal citekey and external_citekey, so searching
+        # for "voronina2023" finds a source with internal "воронина2023_ugly"
+        # and external_citekey "voronina2023".
         if q_lower and not (
             q_lower in title.lower()
             or q_lower in authors.lower()
             or q_lower in src.citekey.lower()
+            or (src.external_citekey and q_lower in src.external_citekey.lower())
         ):
             continue
         project_sections = project_store.get_source_sections(src.citekey, user_id=user.user_id)
         sections = project_sections if project_sections else src.sections
         results.append(
             SourceResponse(
-                citekey=src.citekey,
+                citekey=display_ck,
                 paper_id=src.paper_id,
                 status=src.status,
                 title=title,
@@ -335,10 +340,14 @@ async def search_fragments(
         return FragmentSearchResponse(results=[], total=0, query=q)
 
     raw = paper_store.search_fragments_for_user(user.user_id, q, limit)
+    # Batch-resolve display citekeys so results echo external_citekey when set.
+    library = get_user_library()
+    internal_cks = list({r["citekey"] for r in raw})
+    display_map = library.get_display_citekeys(internal_cks, user_id=user.user_id)
     results = [
         FragmentSearchResult(
             fragment_id=r["fragment_id"],
-            citekey=r["citekey"],
+            citekey=display_map.get(r["citekey"], r["citekey"]),
             title=r["title"],
             authors=r["authors"],
             year=r["year"],
@@ -355,11 +364,16 @@ async def get_source(
     citekey: str,
     user: UserRecord = Depends(get_current_user),
 ) -> SourceDetailResponse:
-    """Get a source with its fragments. Only accessible if owned by the authenticated user."""
+    """Get a source with its fragments. Only accessible if owned by the authenticated user.
+
+    Accepts either the internal citekey or the external_citekey (BBT
+    display override); response echoes display citekey so the UI stays
+    in one namespace.
+    """
     library = get_user_library()
     paper_store = get_paper_store()
 
-    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -368,9 +382,10 @@ async def get_source(
 
     paper = paper_store.get_paper_by_id(src.paper_id)
     fragments = paper_store.get_fragments(src.paper_id)
+    display_ck = src.external_citekey or src.citekey
 
     return SourceDetailResponse(
-        citekey=src.citekey,
+        citekey=display_ck,
         paper_id=src.paper_id,
         status=src.status,
         title=paper.title if paper else "",
@@ -649,14 +664,15 @@ async def delete_source(
     """
     library = get_user_library()
 
-    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Source '{citekey}' not found",
         )
 
-    library.remove_source(citekey, user_id=user.user_id)
+    # Delete by internal citekey — external_citekey is not a PK.
+    library.remove_source(src.citekey, user_id=user.user_id)
     invalidate_for_user(get_paper_store(), user.user_id)
 
 
@@ -829,10 +845,11 @@ async def metadata_preview(
     paper_store = get_paper_store()
     file_store = get_file_store()
 
-    # Ownership check
-    paper_id = library.resolve_paper_id(citekey, user_id=user.user_id)
-    if not paper_id:
+    # Ownership check (dual-key — accepts internal or external citekey)
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
+    if src is None:
         raise HTTPException(status_code=404, detail=f"Source '{citekey}' not found")
+    paper_id = src.paper_id
 
     paper = paper_store.get_paper_by_id(paper_id)
     current = MetadataCurrentFields.from_paper(paper)
@@ -874,10 +891,13 @@ async def enrich_metadata(
     library = get_user_library()
     paper_store = get_paper_store()
 
-    # Ownership check
-    paper_id = library.resolve_paper_id(citekey, user_id=user.user_id)
-    if not paper_id:
+    # Ownership check (dual-key — accepts internal or external citekey)
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
+    if src is None:
         raise HTTPException(status_code=404, detail=f"Source '{citekey}' not found")
+    paper_id = src.paper_id
+    # Rewrite the caller's view to the internal citekey for downstream writes.
+    citekey = src.citekey
 
     paper = paper_store.get_paper_by_id(paper_id)
     if not paper:

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -101,12 +101,15 @@ async def submit_process_job(
     Falls back to in-process thread execution when Redis is unavailable.
     """
     library = get_user_library()
-    src = library.get_source_by_citekey(citekey, user_id=user.user_id)
+    # Dual-key: accept either internal citekey or external_citekey.
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Source '{citekey}' not found in library",
         )
+    # Use internal citekey for all downstream DB writes (fragments, curation).
+    citekey = src.citekey
 
     # Validate project ownership — project_id is a write path (auto-suggestion)
     if project_id:

--- a/src/klemma/api/routes/projects.py
+++ b/src/klemma/api/routes/projects.py
@@ -264,13 +264,21 @@ async def get_section_sources(
     section: str,
     user: UserRecord = Depends(get_current_user),
 ) -> SectionSourcesResponse:
-    """List sources assigned to a specific section."""
+    """List sources assigned to a specific section.
+
+    Response echoes display citekeys (``external_citekey`` when set via BBT
+    import, else the internal citekey) so the frontend's text → assignment
+    merging in SectionEditor compares values from the same citekey-space.
+    """
     store = get_project_store()
-    citekeys = store.get_sources_by_section(section, user_id=user.user_id)
+    library = get_user_library()
+    internal_cks = store.get_sources_by_section(section, user_id=user.user_id)
+    display_map = library.get_display_citekeys(internal_cks, user_id=user.user_id)
+    display_cks = [display_map.get(ck, ck) for ck in internal_cks]
     return SectionSourcesResponse(
         section=section,
-        citekeys=citekeys,
-        count=len(citekeys),
+        citekeys=display_cks,
+        count=len(display_cks),
     )
 
 
@@ -279,12 +287,16 @@ async def assign_source_sections(
     body: AssignSectionRequest,
     user: UserRecord = Depends(get_current_user),
 ) -> dict:
-    """Assign a source to sections in the project."""
+    """Assign a source to sections in the project.
+
+    ``body.citekey`` may be either the internal citekey or the
+    ``external_citekey`` override (BBT display); writes always use the
+    internal citekey for DB consistency, response echoes display.
+    """
     store = get_project_store()
     library = get_user_library()
 
-    # Verify source exists in the authenticated user's library
-    src = library.get_source_by_citekey(body.citekey, user_id=user.user_id)
+    src = library.get_source_by_any_key(body.citekey, user_id=user.user_id)
     if src is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -292,9 +304,10 @@ async def assign_source_sections(
         )
 
     store.set_source_sections(
-        body.citekey, src.paper_id, body.sections, body.chapters, user_id=user.user_id
+        src.citekey, src.paper_id, body.sections, body.chapters, user_id=user.user_id
     )
-    return {"citekey": body.citekey, "sections": body.sections}
+    display_ck = src.external_citekey or src.citekey
+    return {"citekey": display_ck, "sections": body.sections}
 
 
 @router.get("/sources/{citekey}/sections")
@@ -302,10 +315,17 @@ async def get_source_sections(
     citekey: str,
     user: UserRecord = Depends(get_current_user),
 ) -> dict:
-    """Get sections assigned to a source in the project."""
+    """Get sections assigned to a source in the project.
+
+    Accepts internal citekey or external_citekey. Response echoes display.
+    """
     store = get_project_store()
-    sections = store.get_source_sections(citekey, user_id=user.user_id)
-    return {"citekey": citekey, "sections": sections}
+    library = get_user_library()
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
+    internal_ck = src.citekey if src else citekey
+    display_ck = (src.external_citekey or src.citekey) if src else citekey
+    sections = store.get_source_sections(internal_ck, user_id=user.user_id)
+    return {"citekey": display_ck, "sections": sections}
 
 
 @router.delete(
@@ -331,7 +351,11 @@ async def detach_source_from_section(
             detail="detach not supported on this backend",
         )
 
-    removed = store.remove_source_from_section(citekey, section, user_id=user.user_id)
+    # Dual-key: accept internal citekey or external_citekey in the path.
+    library = get_user_library()
+    src = library.get_source_by_any_key(citekey, user_id=user.user_id)
+    internal_ck = src.citekey if src else citekey
+    removed = store.remove_source_from_section(internal_ck, section, user_id=user.user_id)
     if not removed:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -969,22 +969,31 @@ def generate_draft(section: str, data_dir: str, project_id: str = "", user_id: s
         except Exception as exc:
             logger.warning("Failed to load project outline: %s", exc)
 
-    # Load section citekeys and build source_summaries + fragments
+    # Load section citekeys and build source_summaries + fragments. Everything
+    # the model sees (valid_citekeys, source_summaries[].citekey,
+    # fragments[].source, candidate_sentences[].citekey below) must live in the
+    # same citekey-space, otherwise the drafter's hallucination filter
+    # (drafter._filter_hallucinated_citations) will reject [@external] in
+    # output. Display map maps internal → external_citekey-if-set.
     source_summaries: list[dict] = []
     fragments: list[dict] = []
     valid_citekeys: set[str] = set()
 
     try:
         section_citekeys = project_store.get_sources_by_section(section, user_id=user_id or None)
+        display_map = user_library.get_display_citekeys(
+            list(section_citekeys), user_id=user_id or None,
+        )
         for citekey in section_citekeys:
-            valid_citekeys.add(citekey)
+            display_ck = display_map.get(citekey, citekey)
+            valid_citekeys.add(display_ck)
             src = user_library.get_source_by_citekey(citekey, user_id=user_id or None)
             if not src:
                 continue
             paper = paper_store.get_paper_by_id(src.paper_id)
             if paper:
                 source_summaries.append({
-                    "citekey": citekey,
+                    "citekey": display_ck,
                     "quality": "?",
                     "priority": "medium",
                     "summary": (paper.abstract or "")[:300],
@@ -992,7 +1001,7 @@ def generate_draft(section: str, data_dir: str, project_id: str = "", user_id: s
             paper_fragments = paper_store.get_fragments(src.paper_id)
             for f in paper_fragments:
                 fragments.append({
-                    "source": citekey,
+                    "source": display_ck,
                     "type": f.fragment_type or "key_idea",
                     "relevance": 3,
                     "text": f.fragment_text,
@@ -1019,11 +1028,18 @@ def generate_draft(section: str, data_dir: str, project_id: str = "", user_id: s
             accepted_rows = user_store.get_curated(
                 project_id, verdict="accepted", section=section
             )
+            # Resolve display for all candidate citekeys in one batch (may
+            # extend display_map with citekeys that belong to other sections).
+            candidate_cks = list({row["citekey"] for row in accepted_rows})
+            candidate_display_map = user_library.get_display_citekeys(
+                candidate_cks, user_id=user_id or None,
+            )
             for row in accepted_rows:
                 sentence = (row.get("suggested_text") or "").strip()
                 if sentence:
+                    internal_ck = row["citekey"]
                     candidate_sentences.append({
-                        "citekey": row["citekey"],
+                        "citekey": candidate_display_map.get(internal_ck, internal_ck),
                         "sentence": sentence,
                     })
         except Exception as exc:
@@ -1173,6 +1189,10 @@ def generate_sentences_task(
 
     language = os.getenv("KLEMMA_SENTENCE_LANGUAGE", "Russian")
 
+    # Use display citekey (external_citekey if set via BBT import) in the
+    # generated sentence text. Internal citekey stays for DB writes below.
+    display_ck = src.external_citekey or src.citekey
+
     try:
         ai, ai_config = _create_ai_provider()
         from klemma.config import _SHIPPED_PROMPTS_DIR
@@ -1182,7 +1202,7 @@ def generate_sentences_task(
 
         result = generate_sentences(
             fragments_payload,
-            citekey=citekey,
+            citekey=display_ck,
             authors=(paper.authors if paper else "") or "",
             year=(paper.year if paper else None),
             outline=outline_payload,

--- a/src/klemma/skills/drafter.py
+++ b/src/klemma/skills/drafter.py
@@ -27,7 +27,7 @@ class DraftResult:
 
 def _extract_citations(text: str) -> list[str]:
     """Extract all [@citekey] references from text."""
-    return re.findall(r"\[@([\w\-]+)\]", text)
+    return re.findall(r"\[@([\w:.+\-]+)\]", text)
 
 
 def _filter_hallucinated_citations(
@@ -47,7 +47,7 @@ def _filter_hallucinated_citations(
         removed.append(citekey)
         return ""
 
-    cleaned = re.sub(r"\[@([\w\-]+)\]", _replace, text)
+    cleaned = re.sub(r"\[@([\w:.+\-]+)\]", _replace, text)
     # Clean up double spaces left by removals
     cleaned = re.sub(r"  +", " ", cleaned)
     return cleaned, sorted(set(removed))
@@ -157,7 +157,7 @@ def generate_draft(
         )
 
     # Convert [@citekey] → [[@citekey]] for Obsidian wikilinks
-    text = re.sub(r"\[@([\w\-]+)\]", r"[[@\1]]", text)
+    text = re.sub(r"\[@([\w:.+\-]+)\]", r"[[@\1]]", text)
 
     word_count = len(text.split())
 

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -944,6 +944,45 @@ def test_import_bbt_fuzzy_matches_given_family_format(client, stores):
     assert data["matched"][0]["external_citekey"] == "smith2022"
 
 
+def test_get_source_accepts_external_citekey(client, stores):
+    """GET /library/sources/{ck} must resolve either internal or external
+    citekey (dual-key) and echo display in the response.
+    """
+    token = _register_and_get_token(client)
+    _, paper_store, user_library, _, _ = stores
+    user_id = client.get("/auth/me", headers=_auth_headers(token)).json()["user_id"]
+
+    pid = paper_store.register_paper(title="X", pdf_hash="h_dk")
+    user_library.add_source(pid, "internal_ugly", status="completed", user_id=user_id)
+    user_library.set_external_citekey("internal_ugly", "smith2023", user_id=user_id)
+
+    # By internal — response echoes display
+    r1 = client.get("/library/sources/internal_ugly", headers=_auth_headers(token))
+    assert r1.status_code == 200
+    assert r1.json()["citekey"] == "smith2023"
+
+    # By external — same result
+    r2 = client.get("/library/sources/smith2023", headers=_auth_headers(token))
+    assert r2.status_code == 200
+    assert r2.json()["citekey"] == "smith2023"
+
+
+def test_list_sources_q_searches_external_citekey(client, stores):
+    """?q=<external> finds source whose internal citekey doesn't match q."""
+    token = _register_and_get_token(client)
+    _, paper_store, user_library, _, _ = stores
+    user_id = client.get("/auth/me", headers=_auth_headers(token)).json()["user_id"]
+
+    pid = paper_store.register_paper(title="Some Title", pdf_hash="h_qlist")
+    user_library.add_source(pid, "internal_xyz", status="completed", user_id=user_id)
+    user_library.set_external_citekey("internal_xyz", "voronina2023", user_id=user_id)
+
+    resp = client.get("/library/sources?q=voronina2023", headers=_auth_headers(token))
+    assert resp.status_code == 200
+    citekeys = [s["citekey"] for s in resp.json()["sources"]]
+    assert "voronina2023" in citekeys
+
+
 def test_import_bbt_doi_matches_url_wrapped_stored_doi(client, stores):
     """Paper DOI stored with URL prefix (e.g. ``https://doi.org/10.x``) must
     normalize-match a bare DOI in the BBT entry. Regression: Codex P2 on #346.


### PR DESCRIPTION
Third and final backend step of the citekey-parity plan.

- #344 & #345 → latin/transliteration + BBT-style collisions at citekey generation
- #346 → data layer (external_citekey column, BBT import endpoint)
- **this PR → display switchover: external_citekey is now what the cloud emits into generated text and echoes in API responses**
- follow-up → UI settings view with BBT upload form + frontend regex widening

Nothing changes for users who haven't imported BBT — the display citekey equals the internal one. Users who have imported get their own BBT keys in fresh sentences/drafts and clickable `[@voronina2023]` links in-app.

## Three layers changed

### 1. Worker display resolution (`api/tasks.py`)

- `generate_sentences_task` — resolves `display_ck = src.external_citekey or src.citekey` before calling the sentence generator, so `{{ citekey }}` in `suggest_sentence.md` emits the BBT-style key.
- `generate_draft` — builds a `display_map` over `section_citekeys + candidate_citekeys` and applies it to **four** structures the drafter sees:
  - `valid_citekeys` (drafter hallucination filter — must match)
  - `source_summaries[].citekey` (prompt section_draft.md:64)
  - `fragments[].source` (prompt section_draft.md:88)
  - `candidate_sentences[].citekey`
  
  Without reconciling all four in display-space, `_filter_hallucinated_citations` would drop every `[@external]` as "not in valid_citekeys".

### 2. Dual-key resolver on read routes

`LocalUserLibrary.get_source_by_any_key(key, user_id)` accepts either the internal citekey or external_citekey. Applied to:

- **library.py**: GET `/sources` (+ q filter), GET `/fragments/search` (response echo), GET/DELETE `/sources/{ck}`, GET `/sources/{ck}/metadata-preview`, POST `/sources/{ck}/enrich-metadata`.
- **process.py**: POST `/process/sources/{ck}`.
- **curation.py**: GET `/{pid}/fragments/pending`, POST `/{pid}/fragments/curate` (per-decision resolve), GET `/{pid}/fragments/curated` (query-param resolve), GET `/{pid}/fragments/suggest` (batch display echo), POST `/{pid}/fragments/generate-sentences`.
- **projects.py**: GET `/sections/{section}/sources`, POST `/sections/assign`, GET `/sources/{ck}/sections`, DELETE `/sections/{section}/sources/{ck}`.

**Invariant:** all DB writes use the internal `source.citekey`. Dual-key is a resolve-at-entry pattern only. All responses echo display so the UI lives in one citekey-space.

### 3. Drafter citekey charset (`skills/drafter.py`)

`_extract_citations` + `_filter_hallucinated_citations` regexes widened from `[\w-]+` to `[\w:.+\-]+` so BBT keys with `.`, `:`, `+` are recognized (full Biber/BibTeX valid charset).

## Release Note

### Problem
After #344/#345/#346, the `external_citekey` column was populated by BBT import — but nothing read it. Users who imported their Zotero library still saw cloud-generated sentences embed `[@воронина2023_ugly]` (the internal citekey) instead of `[@voronina2023]` (their BBT key), so pandoc+biber round-trips through local drafts still broke.

### Academic Foundation
Any multi-source workflow through citekey references needs the reference token the end tool (Biber/Biblatex/Pandoc) sees to match the reference token the author's bibliography database maps to the source — otherwise the resolver simply can't find the entry (Lehman 2006; Patashnik 1988). Making external_citekey the display across every prompt and API response closes that round-trip.

### Implementation
~195 insertions across 7 files: worker-level display resolution in two tasks, dual-key resolver on 12 routes, drafter regex widened, two new tests. No schema migration, no API contract breakage.

### Results
Full suite: 1995 passed, 1 skipped. Manual end-to-end after deploy: user with BBT import should see `[@voronina2023]` in regenerated sentences and be able to click them to navigate to the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)