### PR TITLE
feat(saas): project settings page with BBT import UI + frontend citekey charset

### DIFF
--- a/saas/dashboard/src/App.vue
+++ b/saas/dashboard/src/App.vue
@@ -296,6 +296,17 @@ const routeKey = computed(() => (route.params.projectId as string) ?? route.path
         </span>
         <span>Лента</span>
       </RouterLink>
+      <RouterLink
+        v-if="effectiveProjectId"
+        :to="`/${effectiveProjectId}/settings`"
+        class="nav-item"
+        :class="{ active: route.name === 'project-settings' }"
+      >
+        <span class="nav-icon">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"><circle cx="7" cy="7" r="2"/><path d="M7 1v2M7 11v2M1 7h2M11 7h2M2.8 2.8l1.4 1.4M9.8 9.8l1.4 1.4M2.8 11.2l1.4-1.4M9.8 4.2l1.4-1.4"/></svg>
+        </span>
+        <span>Настройки</span>
+      </RouterLink>
 
       <div v-if="!effectiveProjectId" class="nav-empty">
         <span v-if="projectStore.loading">Загрузка…</span>

--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -162,6 +162,26 @@ export const library = {
     }>
   },
 
+  importBbt: async (file: File) => {
+    const token = localStorage.getItem('access_token')
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetch(`${API_BASE}/library/import-bbt`, {
+      method: 'POST',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      body: formData,
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new ApiError(res.status, body.detail || res.statusText || `Ошибка сервера (${res.status})`)
+    }
+    return res.json() as Promise<{
+      matched: { citekey: string; external_citekey: string; strategy: string; title: string }[]
+      unmatched: { bbt_citekey: string; title: string; first_author_lastname: string; year: number | null; doi: string | null }[]
+      ambiguous: { bbt_citekey: string; title: string; candidates: string[] }[]
+    }>
+  },
+
   gaps: () =>
     request<{
       gaps: {

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -85,6 +85,12 @@ const router = createRouter({
       component: () => import('../views/SectionEditorView.vue'),
       meta: { requiresAuth: true },
     },
+    {
+      path: '/:projectId/settings',
+      name: 'project-settings',
+      component: () => import('../views/ProjectSettingsView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/saas/dashboard/src/utils/markdown.ts
+++ b/saas/dashboard/src/utils/markdown.ts
@@ -12,9 +12,10 @@ export function formatMarkdown(text: string, projectId: string = 'demo'): string
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    // [@citekey] — clickable link to source page (bold variant too)
+    // [@citekey] — clickable link to source page (bold variant too).
+    // Charset matches Biber/BibTeX valid citekey chars: word + : . + -
     .replace(
-      /\*?\*?\[(@([\w]+))\]\*?\*?/g,
+      /\*?\*?\[(@([\w:.+\-]+))\]\*?\*?/g,
       `<a href="/${projectId}/library/$2" class="citekey-link">$1</a>`,
     )
     // **bold**
@@ -31,7 +32,7 @@ export function formatMarkdown(text: string, projectId: string = 'demo'): string
 export function renderDraft(text: string): string {
   // Pre-process [@citekey] before marked (marked would escape the brackets)
   const withCitekeys = text.replace(
-    /\[(@[\w]+)\]/g,
+    /\[(@[\w:.+\-]+)\]/g,
     '<span class="citekey-ref">$1</span>',
   )
   return marked.parse(withCitekeys) as string

--- a/saas/dashboard/src/views/FragmentReviewView.vue
+++ b/saas/dashboard/src/views/FragmentReviewView.vue
@@ -210,7 +210,7 @@ function pluralizeCitations(n: number): string {
 // When citekey matches the current source, use author+year; otherwise keep the key itself.
 function formatParaphrase(text: string): string {
   if (!text) return ''
-  return text.replace(/\[@([\w\d_-]+)\]/g, (_m, key) => {
+  return text.replace(/\[@([\w:.+\-]+)\]/g, (_m, key) => {
     if (key === citekey.value && sourceAuthors.value) {
       const a = sourceAuthors.value
       const short = a.includes(',') ? a.split(',')[0]!.trim() : a

--- a/saas/dashboard/src/views/ProjectSettingsView.vue
+++ b/saas/dashboard/src/views/ProjectSettingsView.vue
@@ -113,7 +113,7 @@ function onFileInput(e: Event) {
               Совпало ({{ report.matched.length }})
             </summary>
             <ul class="px-3 py-2 text-[13px] space-y-1 max-h-[220px] overflow-auto">
-              <li v-for="m in report.matched" :key="m.citekey" class="flex justify-between gap-3">
+              <li v-for="(m, i) in report.matched" :key="`${m.citekey}|${m.external_citekey}|${i}`" class="flex justify-between gap-3">
                 <span class="truncate">{{ m.title || m.citekey }}</span>
                 <span class="text-[12px] text-[#6b6b8a] shrink-0">
                   <span class="font-mono">{{ m.citekey }}</span>
@@ -130,7 +130,7 @@ function onFileInput(e: Event) {
               Неоднозначно ({{ report.ambiguous.length }})
             </summary>
             <ul class="px-3 py-2 text-[13px] space-y-2 max-h-[220px] overflow-auto">
-              <li v-for="a in report.ambiguous" :key="a.bbt_citekey">
+              <li v-for="(a, i) in report.ambiguous" :key="`${a.bbt_citekey}|${i}`">
                 <span class="font-mono text-[12px]">{{ a.bbt_citekey }}</span>
                 — «{{ a.title }}»
                 <div class="text-[12px] text-[#6b6b8a] ml-4">
@@ -145,7 +145,7 @@ function onFileInput(e: Event) {
               Не найдено ({{ report.unmatched.length }})
             </summary>
             <ul class="px-3 py-2 text-[13px] space-y-1 max-h-[220px] overflow-auto">
-              <li v-for="u in report.unmatched" :key="u.bbt_citekey" class="flex justify-between gap-3">
+              <li v-for="(u, i) in report.unmatched" :key="`${u.bbt_citekey}|${i}`" class="flex justify-between gap-3">
                 <span class="truncate">
                   {{ u.title || '(без заголовка)' }}
                   <span class="text-[12px] text-[#6b6b8a]">

--- a/saas/dashboard/src/views/ProjectSettingsView.vue
+++ b/saas/dashboard/src/views/ProjectSettingsView.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { library, ApiError } from '@/api/client'
+import AppLayout from '@/components/AppLayout.vue'
+
+type BbtMatch = { citekey: string; external_citekey: string; strategy: string; title: string }
+type BbtUnmatched = { bbt_citekey: string; title: string; first_author_lastname: string; year: number | null; doi: string | null }
+type BbtAmbiguous = { bbt_citekey: string; title: string; candidates: string[] }
+type BbtReport = { matched: BbtMatch[]; unmatched: BbtUnmatched[]; ambiguous: BbtAmbiguous[] }
+
+const uploading = ref(false)
+const error = ref<string>('')
+const report = ref<BbtReport | null>(null)
+const dragOver = ref(false)
+
+async function handleFile(file: File) {
+  if (!file.name.toLowerCase().endsWith('.json')) {
+    error.value = 'Ожидается .json файл (экспорт Better BibTeX)'
+    return
+  }
+  error.value = ''
+  uploading.value = true
+  try {
+    report.value = await library.importBbt(file)
+  } catch (e) {
+    report.value = null
+    error.value = e instanceof ApiError ? e.message : 'Ошибка загрузки'
+  } finally {
+    uploading.value = false
+  }
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  dragOver.value = false
+  const f = e.dataTransfer?.files[0]
+  if (f) handleFile(f)
+}
+
+function onFileInput(e: Event) {
+  const f = (e.target as HTMLInputElement).files?.[0]
+  if (f) handleFile(f)
+}
+</script>
+
+<template>
+  <AppLayout>
+    <div class="p-6 max-w-[780px] mx-auto">
+      <h1 class="text-[22px] font-semibold text-[#1a1a2e] mb-5">Настройки проекта</h1>
+
+      <!-- Section: BBT import -->
+      <section class="bg-white border border-[#e8e5df] rounded-xl p-5 mb-5">
+        <h2 class="text-[15px] font-semibold text-[#1a1a2e] mb-1">Импорт ключей цитирования из Zotero</h2>
+        <p class="text-[13px] text-[#6b6b8a] leading-relaxed mb-4">
+          Загрузите JSON-экспорт Better BibTeX, чтобы Klemma использовала ваши локальные
+          citekey'и (например, <span class="font-mono text-[12px]">voronina2023</span>)
+          в генерируемых предложениях и ссылках вместо своих внутренних ключей.
+          Pandoc + Biber с вашим локальным <span class="font-mono text-[12px]">.bib</span>
+          будет собираться без ошибок.
+        </p>
+
+        <!-- Drop zone -->
+        <div
+          class="border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors"
+          :class="dragOver ? 'border-[#0d7377] bg-[#e6f3f3]' : 'border-[#e8e5df] bg-[#fafaf8] hover:border-[#d4d0ca]'"
+          @dragover.prevent="dragOver = true"
+          @dragleave="dragOver = false"
+          @drop="onDrop"
+          @click="($refs.fileInput as HTMLInputElement).click()"
+        >
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".json,application/json"
+            class="hidden"
+            @change="onFileInput"
+          />
+          <div class="text-[#6b6b8a] text-[13px] leading-relaxed">
+            <template v-if="uploading">
+              <div class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-[#0d7377] border-t-transparent mb-1"></div>
+              <div>Сопоставляем записи…</div>
+            </template>
+            <template v-else>
+              Перетащите <span class="font-mono text-[12px]">library.json</span>
+              или нажмите для выбора
+            </template>
+          </div>
+        </div>
+
+        <div v-if="error" class="mt-3 rounded-md border border-[#c62828] bg-[#fff0f0] px-3 py-2 text-[13px] text-[#c62828]">
+          {{ error }}
+        </div>
+
+        <!-- Report -->
+        <div v-if="report" class="mt-5 space-y-4">
+          <div class="flex gap-3 text-[13px]">
+            <div class="flex-1 text-center py-2 rounded-md bg-[#dcfce7] text-[#15803d]">
+              <div class="text-[22px] font-semibold">{{ report.matched.length }}</div>
+              <div>совпало</div>
+            </div>
+            <div class="flex-1 text-center py-2 rounded-md bg-[#fef9c3] text-[#a16207]">
+              <div class="text-[22px] font-semibold">{{ report.ambiguous.length }}</div>
+              <div>неоднозначно</div>
+            </div>
+            <div class="flex-1 text-center py-2 rounded-md bg-[#f0ede8] text-[#6b6b8a]">
+              <div class="text-[22px] font-semibold">{{ report.unmatched.length }}</div>
+              <div>не найдено</div>
+            </div>
+          </div>
+
+          <details v-if="report.matched.length" class="border border-[#e8e5df] rounded-md">
+            <summary class="px-3 py-2 text-[13px] font-semibold cursor-pointer hover:bg-[#f0ede8]">
+              Совпало ({{ report.matched.length }})
+            </summary>
+            <ul class="px-3 py-2 text-[13px] space-y-1 max-h-[220px] overflow-auto">
+              <li v-for="m in report.matched" :key="m.citekey" class="flex justify-between gap-3">
+                <span class="truncate">{{ m.title || m.citekey }}</span>
+                <span class="text-[12px] text-[#6b6b8a] shrink-0">
+                  <span class="font-mono">{{ m.citekey }}</span>
+                  <span class="mx-1">→</span>
+                  <span class="font-mono text-[#0d7377]">{{ m.external_citekey }}</span>
+                  <span class="ml-1.5 text-[11px]">({{ m.strategy }})</span>
+                </span>
+              </li>
+            </ul>
+          </details>
+
+          <details v-if="report.ambiguous.length" class="border border-[#fbbf24] rounded-md">
+            <summary class="px-3 py-2 text-[13px] font-semibold cursor-pointer hover:bg-[#fef9c3] text-[#a16207]">
+              Неоднозначно ({{ report.ambiguous.length }})
+            </summary>
+            <ul class="px-3 py-2 text-[13px] space-y-2 max-h-[220px] overflow-auto">
+              <li v-for="a in report.ambiguous" :key="a.bbt_citekey">
+                <span class="font-mono text-[12px]">{{ a.bbt_citekey }}</span>
+                — «{{ a.title }}»
+                <div class="text-[12px] text-[#6b6b8a] ml-4">
+                  Совпадает с: {{ a.candidates.join(', ') }}
+                </div>
+              </li>
+            </ul>
+          </details>
+
+          <details v-if="report.unmatched.length" class="border border-[#e8e5df] rounded-md">
+            <summary class="px-3 py-2 text-[13px] font-semibold cursor-pointer hover:bg-[#f0ede8]">
+              Не найдено ({{ report.unmatched.length }})
+            </summary>
+            <ul class="px-3 py-2 text-[13px] space-y-1 max-h-[220px] overflow-auto">
+              <li v-for="u in report.unmatched" :key="u.bbt_citekey" class="flex justify-between gap-3">
+                <span class="truncate">
+                  {{ u.title || '(без заголовка)' }}
+                  <span class="text-[12px] text-[#6b6b8a]">
+                    {{ u.first_author_lastname }}<template v-if="u.year"> {{ u.year }}</template>
+                  </span>
+                </span>
+                <span class="font-mono text-[12px] text-[#6b6b8a] shrink-0">{{ u.bbt_citekey }}</span>
+              </li>
+            </ul>
+          </details>
+
+          <p class="text-[12px] text-[#6b6b8a] leading-relaxed">
+            Следующие сгенерированные предложения и пересборки черновиков будут использовать
+            ваши citekey'и. Источники, которых нет в проекте, можно пока проигнорировать —
+            они не создаются автоматически.
+          </p>
+        </div>
+      </section>
+    </div>
+  </AppLayout>
+</template>

--- a/saas/dashboard/src/views/SectionEditorView.vue
+++ b/saas/dashboard/src/views/SectionEditorView.vue
@@ -111,7 +111,7 @@ function sectionWordCount(id: string): number {
 function renderWithCitekeys(text: string): string {
   return text
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/\[@([\w\d_:.-]+)\]/g, '<span class="citekey-link" data-citekey="$1">[@$1]</span>')
+    .replace(/\[@([\w:.+\-]+)\]/g, '<span class="citekey-link" data-citekey="$1">[@$1]</span>')
     .replace(/\n/g, '<br>')
 }
 
@@ -132,7 +132,7 @@ const panelSources = computed((): string[] => {
   const id = activeSectionId.value
   if (!id) return []
   const text = currentSectionText(id)
-  const fromText = [...text.matchAll(/\[@([\w\d_:.-]+)\]/g)].map(m => m[1]!)
+  const fromText = [...text.matchAll(/\[@([\w:.+\-]+)\]/g)].map(m => m[1]!)
   return [...new Set([...assignedSources.value, ...fromText])]
 })
 


### PR DESCRIPTION
Closing the citekey-parity plan: user-facing surface so the BBT import endpoint (#346) becomes usable, and frontend `[@key]` regexes match the backend's widened Biber charset (#349).

## Summary
- New route `/:projectId/settings` → `ProjectSettingsView.vue`.
- Sidebar "Настройки" entry in `App.vue`.
- `library.importBbt(file)` in `api/client.ts` (multipart upload, typed response).
- Import UI: drag-drop (or click) → inline report with three details sections (matched / ambiguous / unmatched), headline counters.
- Frontend citekey regex widening to `[\w:.+\-]+` (parity with backend `drafter.py` post-#349). Fixes:
  - `utils/markdown.ts` (`formatMarkdown` + `renderDraft`)
  - `views/FragmentReviewView.vue::formatParaphrase`
  - `views/SectionEditorView.vue::renderWithCitekeys` + `panelSources`

## Release Note

### Problem
The BBT import endpoint and dual-key backend (#346/#349) were shipped, but users had no UI to actually upload their `library.json` — the endpoint was only reachable via `curl`. Without the upload step, the external_citekey column stayed empty and nothing in the new machinery did anything visible. Additionally, the frontend citekey regexes accepted only `[\w\d_:.-]+` while the backend now emits `[\w:.+\-]+`, so BBT keys with `+` (valid in Biber) would silently fail to linkify in UI text rendering.

### Academic Foundation
Zotero + BetterBibTeX is the dominant bibliography manager for Russian-language and European academic writing. Providing a first-class import path (drag-drop + structured post-import report) matches the user's expected workflow rather than forcing them to learn a cloud-specific citekey convention. The three-bucket report (matched / ambiguous / unmatched) surfaces the matching rule's uncertainty explicitly — per "Guidelines for Human-AI Interaction" (Amershi et al. 2019), the user should see what the system is unsure about, not just its confident decisions.

### Implementation
Single new view (~170 lines) reusing the drag-drop pattern from `LibraryView.vue`. Post-upload report renders three collapsible details sections with per-entry metadata so the user can spot BBT entries that didn't land. New sidebar nav entry. Charset widening is one-character-class change in four files. Zero backend changes — endpoint already exists from #346.

### Results
Frontend build: `npm run build` passes, bundle `ProjectSettingsView-*.js` 6.33 kB / 2.58 kB gzip. No TypeScript errors. Manual smoke (after deploy): upload BBT JSON → see matched/ambiguous/unmatched report → subsequently generated sentences for matched sources contain `[@voronina2023]` instead of the internal citekey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)