### PR TITLE
fix(saas): address Codex review on display switchover (#349)

### DIFF
--- a/src/klemma/api/routes/curation.py
+++ b/src/klemma/api/routes/curation.py
@@ -555,9 +555,12 @@ async def generate_sentences_endpoint(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Source '{body.citekey}' not found in library",
         )
-    # Worker reads source by the citekey the client sent; it will re-resolve
-    # and pick up external_citekey for display. No internal rewrite needed
-    # here because the task looks up the source fresh by the submitted key.
+    # Pass the INTERNAL citekey to the worker — generate_sentences_task looks
+    # up the source via get_source_by_citekey (not dual-key), so it would
+    # async-fail with "Source not found" if the client sent an external key.
+    # Echo the client's submitted citekey back in the response so the UI
+    # keeps its existing round-trip semantics.
+    internal_citekey = src.citekey
 
     from ..tasks import generate_sentences_task
 
@@ -571,7 +574,7 @@ async def generate_sentences_endpoint(
             job = q.enqueue(
                 generate_sentences_task,
                 project_id,
-                body.citekey,
+                internal_citekey,
                 data_dir,
                 user.user_id,
                 mode,
@@ -594,7 +597,7 @@ async def generate_sentences_endpoint(
             job_id,
             generate_sentences_task,
             project_id,
-            body.citekey,
+            internal_citekey,
             data_dir,
             user.user_id,
             mode,

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -1074,8 +1074,11 @@ def generate_draft(section: str, data_dir: str, project_id: str = "", user_id: s
         if not result.text:
             return {"status": "error", "detail": "AI returned no draft text"}
 
-        # Convert Obsidian wikilinks [[@citekey]] → [@citekey] for SaaS output
-        text = re.sub(r"\[\[@([\w\-]+)\]\]", r"[@\1]", result.text)
+        # Convert Obsidian wikilinks [[@citekey]] → [@citekey] for SaaS output.
+        # Charset must match drafter._extract_citations (Biber/BibTeX valid:
+        # word + : . + -) — otherwise BBT keys with "." / ":" / "+" leak
+        # through as raw [[@key]] wikilinks in API draft output.
+        text = re.sub(r"\[\[@([\w:.+\-]+)\]\]", r"[@\1]", result.text)
 
         if user_id:
             user_store.record_usage(

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -1018,6 +1018,74 @@ def test_import_bbt_doi_matches_url_wrapped_stored_doi(client, stores):
 # ---------------------------------------------------------------------------
 
 
+def test_draft_wikilink_conversion_handles_extended_charset():
+    """tasks.py post-processes [[@key]] → [@key] after drafter output.
+    The regex charset must match drafter._extract_citations (word + : . + -)
+    or BBT keys with those characters leak as raw Obsidian wikilinks in
+    API draft text. Regression: Codex P2 on #349.
+    """
+    import re
+    # This is the exact regex used in api/tasks.py::generate_draft
+    pattern = r"\[\[@([\w:.+\-]+)\]\]"
+
+    cases = [
+        ("[[@smith2020]]", "[@smith2020]"),
+        ("[[@smith-2020]]", "[@smith-2020]"),
+        ("[[@doe.2019]]", "[@doe.2019]"),
+        ("[[@brown:v2]]", "[@brown:v2]"),
+        ("[[@a+b]]", "[@a+b]"),
+        ("See [[@smith:2023]] and [[@jones.2020]].",
+         "See [@smith:2023] and [@jones.2020]."),
+    ]
+    for inp, expected in cases:
+        assert re.sub(pattern, r"[@\1]", inp) == expected, f"failed for {inp!r}"
+
+
+def test_generate_sentences_rewrites_external_to_internal(client, stores, monkeypatch):
+    """generate_sentences_task looks up sources via get_source_by_citekey
+    (not dual-key). The route must therefore rewrite body.citekey to the
+    internal key before enqueue, otherwise external-key submissions fail
+    async with "Source not found". Regression: Codex P1 on #349.
+    """
+    user_store, paper_store, user_library, _, _ = stores
+    token = _register_and_get_token(client)
+    user_id = client.get("/auth/me", headers=_auth_headers(token)).json()["user_id"]
+
+    pid = paper_store.register_paper(title="X", pdf_hash="hgs")
+    user_library.add_source(pid, "internal_key", status="completed", user_id=user_id)
+    user_library.set_external_citekey("internal_key", "ext2023", user_id=user_id)
+
+    project = user_store.create_project(user_id=user_id, name="Proj")
+    project_id = project["project_id"]
+
+    enqueued: dict = {}
+
+    async def fake_run_local_job(job_id, func, *args):
+        enqueued["args"] = args
+
+    monkeypatch.setattr(
+        "klemma.api.routes.process._run_local_job", fake_run_local_job
+    )
+
+    resp = client.post(
+        f"/projects/{project_id}/fragments/generate-sentences",
+        json={"citekey": "ext2023", "mode": "missing"},
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 202, resp.json()
+    assert resp.json()["citekey"] == "ext2023"  # echoed
+
+    import time as _time
+    for _ in range(50):
+        if enqueued.get("args"):
+            break
+        _time.sleep(0.02)
+    assert enqueued.get("args"), "task was not enqueued"
+    assert enqueued["args"][0] == project_id
+    # Internal citekey, not the external one the client submitted
+    assert enqueued["args"][1] == "internal_key"
+
+
 def test_gaps_recency_filter(client, stores):
     """Papers older than 10 years with cited_by_count<3 are filtered out."""
     user_store, paper_store, user_library, _, _ = stores


### PR DESCRIPTION
Two Codex findings on the merged #349 — both already in prod, both need fixes before users import BBT.

## P1 — generate-sentences breaks on external citekey

`curation.py::generate_sentences_endpoint` dual-key-resolved the submitted citekey for the ownership check but then forwarded `body.citekey` (possibly external) to the worker. `generate_sentences_task` uses `get_source_by_citekey` (not dual-key), so external-key submissions passed the route check and then failed async with "Source not found in library".

Fix: pass `src.citekey` (internal) to the worker in both rq and local-asyncio paths. Response still echoes `body.citekey` so the client's display round-trip is preserved.

## P2 — wikilink charset mismatch

`tasks.py::generate_draft` converts drafter wikilinks `[[@key]] → [@key]` via a regex that still used `[\w\-]+`. #349 widened the drafter's own extraction regex to `[\w:.+\-]+`, but this post-processing step wasn't — so BBT keys with `.`, `:`, or `+` leaked as raw `[[@key]]` wikilinks into API draft output.

Fix: widen the post-processing charset to match the drafter.

## Tests
- `test_generate_sentences_rewrites_external_to_internal` — patches the local-job runner, asserts the worker gets the internal key even when the client sends the external one.
- `test_draft_wikilink_conversion_handles_extended_charset` — pure regex test covering `smith-2020`, `doe.2019`, `brown:v2`, `a+b`, mixed inline.

Full suite: 1997 passed, 1 skipped.

## Release Note

### Problem
After #349 merged and deployed, two regressions were live. First, any user who had imported a BBT JSON and clicked a `[@external]` citekey link to regenerate sentences got a 202 followed by a silent job failure — the worker couldn't find the source because it looked up by `citekey` only. Second, any generated draft containing a citekey with `.`, `:`, or `+` emitted raw `[[@smith:2023]]` wikilinks instead of Pandoc-style `[@smith:2023]`, breaking downstream tools.

### Academic Foundation
When resolution rules widen on one side of a pipeline (drafter charset in #349), every downstream consumer must widen to match — otherwise the new character class leaks as invalid output. Same principle applies to the route/worker boundary: if the route accepts two forms of a key, it must normalize to one canonical form before the work crosses an async boundary.

### Implementation
One-line regex change in `api/tasks.py:1078`; three-line change in `api/routes/curation.py` to hoist `internal_citekey = src.citekey` and pass it instead of `body.citekey` to both enqueue paths. Two regression tests.

### Results
Full suite: 1997 passed, 1 skipped. No schema migration, no API contract breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)