### PR TITLE
fix(saas): allow one source in many projects

### DIFF
--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -748,21 +748,21 @@ async def upload_pdf(
             existing.paper_id, user_id=user.user_id
         )
         if existing_source:
-            # User already owns this PDF. If they're re-uploading into a
-            # different project (or into a project when the row had no
-            # project_id), repoint the row to the current project so the
-            # source actually appears in that project's library list.
-            # Without this, the upload silently "disappears" — the source
-            # stays attached to whichever project it was first uploaded
-            # into and the UI never shows it in the current view (#347).
-            if project_id and project_id != existing_source.project_id:
+            # User already owns this PDF. Re-uploading into another project
+            # should attach the existing source to that project, not move it
+            # away from the original one. Keep source metadata intact.
+            if project_id and project_id not in existing_source.project_ids:
                 library.add_source(
                     existing.paper_id,
                     existing_source.citekey,
                     status=existing_source.status,
+                    pdf_path=existing_source.pdf_path,
+                    note_path=existing_source.note_path,
+                    quality_score=existing_source.quality_score,
                     project_id=project_id,
                     user_id=user.user_id,
                 )
+                invalidate_for_user(paper_store, user.user_id)
             return UploadResponse(
                 citekey=existing_source.citekey,
                 paper_id=existing.paper_id,

--- a/src/klemma/models.py
+++ b/src/klemma/models.py
@@ -82,3 +82,4 @@ class UserSource:
     sections: list[str] = field(default_factory=list)
     external_citekey: str | None = None
     project_id: str | None = None
+    project_ids: list[str] = field(default_factory=list)

--- a/src/klemma/stores/user_library.py
+++ b/src/klemma/stores/user_library.py
@@ -4,7 +4,8 @@ Adds user_sources tables to ~/.klemma/library.db (same file as LocalPaperStore).
 Maps citekey → paper_id for the User Library tier.
 
 Multi-user support (v4): user_id column added to user_sources for SaaS data
-isolation. CLI mode passes user_id=None to skip filtering (single-user on disk).
+isolation. Project membership is many-to-many via user_source_projects (v7).
+CLI mode passes user_id=None to skip filtering (single-user on disk).
 """
 
 from __future__ import annotations
@@ -17,7 +18,7 @@ from typing import TYPE_CHECKING, Generator, Optional
 if TYPE_CHECKING:
     from ..models import UserSource
 
-_SCHEMA_VERSION = 6  # v6: external_citekey column for BBT display override
+_SCHEMA_VERSION = 7  # v7: many-to-many source ↔ project links
 
 _CREATE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS user_sources (
@@ -49,6 +50,15 @@ CREATE TABLE IF NOT EXISTS user_source_sections (
     user_id TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (user_id, citekey, section)
 );
+
+CREATE TABLE IF NOT EXISTS user_source_projects (
+    citekey    TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    user_id    TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (user_id, citekey, project_id)
+);
+CREATE INDEX IF NOT EXISTS idx_usp_project_user ON user_source_projects(project_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_usp_citekey_user ON user_source_projects(citekey, user_id);
 """
 
 
@@ -180,6 +190,27 @@ class LocalUserLibrary:
                 "CREATE INDEX IF NOT EXISTS idx_user_sources_external_ck"
                 " ON user_sources(user_id, external_citekey)"
             )
+        has_project_links = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='user_source_projects'"
+        ).fetchone()
+        if version < 7 or not has_project_links:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS user_source_projects (
+                    citekey    TEXT NOT NULL,
+                    project_id TEXT NOT NULL,
+                    user_id    TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY (user_id, citekey, project_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_usp_project_user
+                    ON user_source_projects(project_id, user_id);
+                CREATE INDEX IF NOT EXISTS idx_usp_citekey_user
+                    ON user_source_projects(citekey, user_id);
+                INSERT OR IGNORE INTO user_source_projects
+                    (citekey, project_id, user_id)
+                SELECT citekey, project_id, COALESCE(user_id, '')
+                FROM user_sources
+                WHERE project_id IS NOT NULL AND TRIM(project_id) <> '';
+            """)
         if version < _SCHEMA_VERSION:
             conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
@@ -187,6 +218,74 @@ class LocalUserLibrary:
     def _uid(user_id: Optional[str]) -> str:
         """Normalize user_id: None → '' for composite PK compatibility."""
         return user_id if user_id is not None else ""
+
+    @staticmethod
+    def _project(project_id: Optional[str]) -> Optional[str]:
+        """Normalize project_id: empty strings become None."""
+        if project_id is None:
+            return None
+        project_id = project_id.strip()
+        return project_id or None
+
+    def _attach_source_to_project(
+        self,
+        conn: sqlite3.Connection,
+        citekey: str,
+        project_id: Optional[str],
+        user_id: Optional[str],
+    ) -> None:
+        """Attach a source to a project without affecting source metadata."""
+        project_id = self._project(project_id)
+        if project_id is None:
+            return
+        conn.execute(
+            """INSERT OR IGNORE INTO user_source_projects
+               (citekey, project_id, user_id) VALUES (?, ?, ?)""",
+            (citekey, project_id, self._uid(user_id)),
+        )
+
+    def _row_to_source(
+        self, conn: sqlite3.Connection, row: sqlite3.Row
+    ) -> "UserSource":
+        """Hydrate a UserSource from a user_sources row."""
+        from ..models import UserSource
+
+        citekey = row["citekey"]
+        row_uid = row["user_id"] or ""
+        chapters = [
+            r[0]
+            for r in conn.execute(
+                "SELECT chapter FROM user_source_chapters WHERE citekey = ? AND user_id = ? ORDER BY chapter",
+                (citekey, row_uid),
+            ).fetchall()
+        ]
+        sections = [
+            r[0]
+            for r in conn.execute(
+                "SELECT section FROM user_source_sections WHERE citekey = ? AND user_id = ? ORDER BY section",
+                (citekey, row_uid),
+            ).fetchall()
+        ]
+        project_ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT project_id FROM user_source_projects WHERE citekey = ? AND user_id = ? ORDER BY project_id",
+                (citekey, row_uid),
+            ).fetchall()
+        ]
+        return UserSource(
+            citekey=citekey,
+            paper_id=row["paper_id"],
+            status=row["status"] or "pending",
+            pdf_path=row["pdf_path"],
+            note_path=row["note_path"],
+            quality_score=row["quality_score"],
+            chapters=chapters,
+            sections=sections,
+            external_citekey=_safe_ext_ck(row),
+            project_id=_safe_col(row, "project_id"),
+            project_ids=project_ids,
+        )
 
     # ------------------------------------------------------------------ #
     # UserLibrary Protocol implementation                                 #
@@ -214,6 +313,7 @@ class LocalUserLibrary:
         same global paper but are independent library entries).
         """
         uid = self._uid(user_id)
+        project_id = self._project(project_id)
         with self._conn() as conn:
             conn.execute(
                 """INSERT INTO user_sources
@@ -223,14 +323,15 @@ class LocalUserLibrary:
                    ON CONFLICT(user_id, citekey) DO UPDATE SET
                        paper_id=excluded.paper_id,
                        status=excluded.status,
-                       pdf_path=excluded.pdf_path,
-                       note_path=excluded.note_path,
-                       quality_score=excluded.quality_score,
-                       project_id=COALESCE(excluded.project_id, user_sources.project_id),
+                       pdf_path=COALESCE(excluded.pdf_path, user_sources.pdf_path),
+                       note_path=COALESCE(excluded.note_path, user_sources.note_path),
+                       quality_score=COALESCE(excluded.quality_score, user_sources.quality_score),
+                       project_id=COALESCE(user_sources.project_id, excluded.project_id),
                        updated_at=datetime('now')""",
                 (citekey, paper_id, status, pdf_path, note_path, quality_score,
                  project_id, uid),
             )
+            self._attach_source_to_project(conn, citekey, project_id, user_id)
             if chapters:
                 conn.execute(
                     "DELETE FROM user_source_chapters WHERE citekey = ? AND user_id = ?",
@@ -257,8 +358,6 @@ class LocalUserLibrary:
 
         In SaaS mode, pass user_id to scope lookup to a specific user.
         """
-        from ..models import UserSource
-
         with self._conn() as conn:
             if user_id is not None:
                 row = conn.execute(
@@ -271,33 +370,7 @@ class LocalUserLibrary:
                 ).fetchone()
             if not row:
                 return None
-            row_uid = row["user_id"] or ""
-            chapters = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT chapter FROM user_source_chapters WHERE citekey = ? AND user_id = ? ORDER BY chapter",
-                    (citekey, row_uid),
-                ).fetchall()
-            ]
-            sections = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT section FROM user_source_sections WHERE citekey = ? AND user_id = ? ORDER BY section",
-                    (citekey, row_uid),
-                ).fetchall()
-            ]
-        return UserSource(
-            citekey=row["citekey"],
-            paper_id=row["paper_id"],
-            status=row["status"] or "pending",
-            pdf_path=row["pdf_path"],
-            note_path=row["note_path"],
-            quality_score=row["quality_score"],
-            chapters=chapters,
-            sections=sections,
-            external_citekey=_safe_ext_ck(row),
-            project_id=_safe_col(row, "project_id"),
-        )
+            return self._row_to_source(conn, row)
 
     def resolve_paper_id(
         self, citekey: str, user_id: Optional[str] = None
@@ -334,8 +407,6 @@ class LocalUserLibrary:
         Used to detect when the same PDF is re-uploaded (same paper_id).
         Scoped to user_id in SaaS mode to avoid cross-user leakage.
         """
-        from ..models import UserSource
-
         with self._conn() as conn:
             if user_id is not None:
                 row = conn.execute(
@@ -349,35 +420,7 @@ class LocalUserLibrary:
                 ).fetchone()
             if not row:
                 return None
-            citekey = row["citekey"]
-            _uid = row["user_id"]
-            row_uid = row["user_id"] or ""
-            chapters = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT chapter FROM user_source_chapters WHERE citekey = ? AND user_id = ? ORDER BY chapter",
-                    (citekey, row_uid),
-                ).fetchall()
-            ]
-            sections = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT section FROM user_source_sections WHERE citekey = ? AND user_id = ? ORDER BY section",
-                    (citekey, row_uid),
-                ).fetchall()
-            ]
-        return UserSource(
-            citekey=citekey,
-            paper_id=row["paper_id"],
-            status=row["status"] or "pending",
-            pdf_path=row["pdf_path"],
-            note_path=row["note_path"],
-            quality_score=row["quality_score"],
-            chapters=chapters,
-            sections=sections,
-            external_citekey=_safe_ext_ck(row),
-            project_id=_safe_col(row, "project_id"),
-        )
+            return self._row_to_source(conn, row)
 
     # ------------------------------------------------------------------ #
     # Additional helpers (beyond Protocol minimum)                        #
@@ -405,6 +448,10 @@ class LocalUserLibrary:
                     "DELETE FROM user_source_sections WHERE citekey = ? AND user_id = ?",
                     (citekey, user_id),
                 )
+                conn.execute(
+                    "DELETE FROM user_source_projects WHERE citekey = ? AND user_id = ?",
+                    (citekey, user_id),
+                )
                 cursor = conn.execute(
                     "DELETE FROM user_sources WHERE citekey = ? AND user_id = ?",
                     (citekey, user_id),
@@ -412,6 +459,7 @@ class LocalUserLibrary:
             else:
                 conn.execute("DELETE FROM user_source_chapters WHERE citekey = ?", (citekey,))
                 conn.execute("DELETE FROM user_source_sections WHERE citekey = ?", (citekey,))
+                conn.execute("DELETE FROM user_source_projects WHERE citekey = ?", (citekey,))
                 cursor = conn.execute("DELETE FROM user_sources WHERE citekey = ?", (citekey,))
         return cursor.rowcount > 0
 
@@ -440,12 +488,12 @@ class LocalUserLibrary:
         with self._conn() as conn:
             if user_id is not None:
                 rows = conn.execute(
-                    "SELECT citekey FROM user_sources WHERE project_id = ? AND user_id = ?",
+                    "SELECT citekey FROM user_source_projects WHERE project_id = ? AND user_id = ?",
                     (project_id, user_id),
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT citekey FROM user_sources WHERE project_id = ?",
+                    "SELECT citekey FROM user_source_projects WHERE project_id = ?",
                     (project_id,),
                 ).fetchall()
         return {r["citekey"] for r in rows}
@@ -469,20 +517,36 @@ class LocalUserLibrary:
             params: list = []
 
             if user_id is not None:
-                conditions.append("user_id = ?")
+                conditions.append("us.user_id = ?")
                 params.append(user_id)
 
             if project_id is not None:
-                conditions.append("(project_id = ? OR project_id IS NULL)")
+                conditions.append(
+                    """(
+                        EXISTS (
+                            SELECT 1
+                            FROM user_source_projects usp
+                            WHERE usp.citekey = us.citekey
+                              AND usp.user_id = us.user_id
+                              AND usp.project_id = ?
+                        )
+                        OR NOT EXISTS (
+                            SELECT 1
+                            FROM user_source_projects usp_any
+                            WHERE usp_any.citekey = us.citekey
+                              AND usp_any.user_id = us.user_id
+                        )
+                    )"""
+                )
                 params.append(project_id)
 
             if since is not None:
-                conditions.append("added_at >= ?")
+                conditions.append("us.added_at >= ?")
                 params.append(since)
 
             where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
             rows = conn.execute(
-                f"SELECT citekey, user_id FROM user_sources {where} ORDER BY added_at",
+                f"SELECT us.citekey, us.user_id FROM user_sources us {where} ORDER BY us.added_at",
                 params,
             ).fetchall()
         return [  # type: ignore[return-value]

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -263,10 +263,9 @@ def test_upload_citekey_collision_uses_bbt_suffix(client):
     assert r1.json()["paper_id"] != r2.json()["paper_id"] != r3.json()["paper_id"]
 
 
-def test_upload_dedup_moves_source_to_current_project(client, stores):
-    """Re-uploading an already-owned PDF into a different project should move
-    the source to the new project. Before #347 the source stayed attached to
-    the original project and silently disappeared from the current library view.
+def test_upload_dedup_attaches_source_to_current_project(client, stores):
+    """Re-uploading an already-owned PDF into a different project should
+    attach the source to the new project without removing it from the old one.
     """
     user_store, _, user_library, _, _ = stores
     token = _register_and_get_token(client)
@@ -289,6 +288,7 @@ def test_upload_dedup_moves_source_to_current_project(client, stores):
     # Confirm initial project attachment
     src = user_library.get_source_by_citekey(citekey, user_id=user_id)
     assert src.project_id == proj_a["project_id"]
+    assert src.project_ids == [proj_a["project_id"]]
 
     # Second upload of same PDF into a different project
     r2 = client.post(
@@ -301,16 +301,22 @@ def test_upload_dedup_moves_source_to_current_project(client, stores):
     assert r2.json()["already_owned"] is True
     assert r2.json()["citekey"] == citekey
 
-    # Source now belongs to project B
+    # Source remains attached to A and is now also attached to B
     src = user_library.get_source_by_citekey(citekey, user_id=user_id)
-    assert src.project_id == proj_b["project_id"]
+    assert src.project_id == proj_a["project_id"]
+    assert set(src.project_ids) == {proj_a["project_id"], proj_b["project_id"]}
 
-    # Library list of project B shows it
-    resp = client.get(
+    resp_a = client.get(
+        f"/library/sources?project_id={proj_a['project_id']}",
+        headers=_auth_headers(token),
+    )
+    resp_b = client.get(
         f"/library/sources?project_id={proj_b['project_id']}",
         headers=_auth_headers(token),
     )
-    citekeys_b = {s["citekey"] for s in resp.json()["sources"]}
+    citekeys_a = {s["citekey"] for s in resp_a.json()["sources"]}
+    citekeys_b = {s["citekey"] for s in resp_b.json()["sources"]}
+    assert citekey in citekeys_a
     assert citekey in citekeys_b
 
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -59,6 +59,7 @@ class TestUserSource:
         assert s.quality_score is None
         assert s.chapters == []
         assert s.sections == []
+        assert s.project_ids == []
 
     def test_all_fields(self):
         s = UserSource(
@@ -69,9 +70,11 @@ class TestUserSource:
             quality_score=4,
             chapters=[1, 2],
             sections=["1.1", "2.3"],
+            project_ids=["proj-a", "proj-b"],
         )
         assert s.quality_score == 4
         assert len(s.chapters) == 2
+        assert s.project_ids == ["proj-a", "proj-b"]
 
 
 class TestProtocolsAreRuntimeCheckable:

--- a/tests/test_user_library.py
+++ b/tests/test_user_library.py
@@ -17,13 +17,13 @@ def lib(tmp_path) -> LocalUserLibrary:
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_6(tmp_path):
+def test_schema_version_is_7(tmp_path):
     db_path = tmp_path / "library.db"
     LocalUserLibrary(db_path)
     conn = sqlite3.connect(str(db_path))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version == 6
+    assert version == 7
 
 
 def test_tables_created(tmp_path):
@@ -37,7 +37,12 @@ def test_tables_created(tmp_path):
         ).fetchall()
     }
     conn.close()
-    assert {"user_sources", "user_source_chapters", "user_source_sections"} <= tables
+    assert {
+        "user_sources",
+        "user_source_chapters",
+        "user_source_sections",
+        "user_source_projects",
+    } <= tables
 
 
 def test_paper_store_schema_coexists(tmp_path):
@@ -57,7 +62,7 @@ def test_paper_store_schema_coexists(tmp_path):
         ).fetchall()
     }
     conn.close()
-    assert version == 6
+    assert version == 7
     # Both sets of tables present
     assert "papers" in tables
     assert "user_sources" in tables
@@ -199,12 +204,84 @@ def test_project_id_filter(lib):
     assert len(all_sources) == 3
 
 
+def test_source_can_belong_to_multiple_projects(lib):
+    lib.add_source(
+        "pid1",
+        "src_multi",
+        project_id="proj1",
+        status="completed",
+        pdf_path="/tmp/src_multi.pdf",
+        note_path="/tmp/src_multi.md",
+        quality_score=4,
+    )
+    lib.add_source("pid1", "src_multi", project_id="proj2", status="completed")
+
+    src = lib.get_source_by_citekey("src_multi")
+    assert src.project_ids == ["proj1", "proj2"]
+    assert src.project_id == "proj1"
+    assert src.pdf_path == "/tmp/src_multi.pdf"
+    assert src.note_path == "/tmp/src_multi.md"
+    assert src.quality_score == 4
+    assert lib.get_project_citekeys("proj1") == {"src_multi"}
+    assert lib.get_project_citekeys("proj2") == {"src_multi"}
+
+
 def test_project_id_preserved_on_status_upsert(lib):
     """project_id is not overwritten when updating status without project_id."""
     lib.add_source("pid1", "src_x", project_id="proj1")
     lib.add_source("pid1", "src_x", status="completed")  # no project_id
     src = lib.get_source_by_citekey("src_x")
     assert src.status == "completed"
+    assert src.project_ids == ["proj1"]
+    assert src.project_id == "proj1"
+
+
+def test_migration_backfills_project_links_from_legacy_project_id(tmp_path):
+    db_path = tmp_path / "library.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE user_sources (
+            citekey     TEXT NOT NULL,
+            paper_id    TEXT NOT NULL,
+            status      TEXT DEFAULT 'pending',
+            pdf_path    TEXT,
+            note_path   TEXT,
+            quality_score INTEGER,
+            added_at    TEXT DEFAULT (datetime('now')),
+            updated_at  TEXT DEFAULT (datetime('now')),
+            project_id  TEXT,
+            user_id     TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (user_id, citekey)
+        );
+        CREATE TABLE user_source_chapters (
+            citekey TEXT NOT NULL,
+            chapter INTEGER NOT NULL,
+            user_id TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (user_id, citekey, chapter)
+        );
+        CREATE TABLE user_source_sections (
+            citekey TEXT NOT NULL,
+            section TEXT NOT NULL,
+            user_id TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (user_id, citekey, section)
+        );
+    """)
+    conn.execute(
+        """INSERT INTO user_sources
+           (citekey, paper_id, status, project_id, user_id)
+           VALUES (?, ?, ?, ?, ?)""",
+        ("legacy_src", "pid-legacy", "completed", "proj-legacy", "alice"),
+    )
+    conn.execute("PRAGMA user_version = 6")
+    conn.commit()
+    conn.close()
+
+    lib = LocalUserLibrary(db_path)
+    src = lib.get_source_by_citekey("legacy_src", user_id="alice")
+    assert src is not None
+    assert src.project_id == "proj-legacy"
+    assert src.project_ids == ["proj-legacy"]
+    assert lib.get_project_citekeys("proj-legacy", user_id="alice") == {"legacy_src"}
 
 
 def test_get_all_sources_since_future_returns_empty(lib):

--- a/tests/test_user_library.py
+++ b/tests/test_user_library.py
@@ -224,6 +224,8 @@ def test_source_can_belong_to_multiple_projects(lib):
     assert src.quality_score == 4
     assert lib.get_project_citekeys("proj1") == {"src_multi"}
     assert lib.get_project_citekeys("proj2") == {"src_multi"}
+    assert {s.citekey for s in lib.get_all_sources(project_id="proj1")} >= {"src_multi"}
+    assert {s.citekey for s in lib.get_all_sources(project_id="proj2")} >= {"src_multi"}
 
 
 def test_project_id_preserved_on_status_upsert(lib):

--- a/tests/test_user_library_external_citekey.py
+++ b/tests/test_user_library_external_citekey.py
@@ -15,15 +15,15 @@ def lib(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Schema v6 migration
+# Schema v7 migration
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_6(lib, tmp_path):
+def test_schema_version_is_7(lib, tmp_path):
     conn = sqlite3.connect(str(tmp_path / "library.db"))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version == 6
+    assert version == 7
 
 
 def test_external_citekey_column_exists(lib, tmp_path):
@@ -33,7 +33,7 @@ def test_external_citekey_column_exists(lib, tmp_path):
     assert "external_citekey" in cols
 
 
-def test_v6_migration_idempotent(tmp_path):
+def test_v7_migration_idempotent(tmp_path):
     db = tmp_path / "library.db"
     LocalUserLibrary(db)
     # Second init must not raise or duplicate the column


### PR DESCRIPTION
Summary:
- store source-to-project membership in a new user_source_projects join table with backfill from legacy user_sources.project_id
- keep external_citekey and legacy project_id compatibility while exposing project_ids on UserSource
- make already-owned PDF re-uploads attach the source to the current project instead of moving it, without clearing source metadata

Why:
PR #348 fixes the disappearing-source symptom by moving an existing source row to the current project. That still breaks the previous project and cannot represent one paper belonging to multiple projects. This change makes project membership many-to-many while preserving the existing unassigned-source semantics.

Testing:
- PYTHONPATH=src /opt/anaconda3/bin/python -m pytest tests/test_user_library.py tests/test_user_library_external_citekey.py tests/test_library_api.py tests/test_protocols.py -q