### PR TITLE
fix(saas): preserve assigned_section on curate upsert (Codex P1 on #360)

### DIFF
--- a/src/klemma/stores/user_store.py
+++ b/src/klemma/stores/user_store.py
@@ -633,9 +633,12 @@ class LocalUserStore:
 
         Each decision: {fragment_id, citekey, verdict, assigned_section?, note?,
         suggested_text?, sentence_model?}.
-        On upsert, `note`, `suggested_text`, and `sentence_model` are preserved
-        when the new decision omits them (COALESCE). Pass explicit values to
-        overwrite.
+        On upsert, ``assigned_section``, ``note``, ``suggested_text``, and
+        ``sentence_model`` are preserved when the new decision omits them
+        (COALESCE) — only ``verdict`` is always overwritten. This matters
+        for concurrent post-hooks: ``generate_sentences_task`` can fire
+        after ``_run_auto_suggest`` has already stored an auto-assigned
+        section, and we must not clobber it back to NULL.
         Returns count of rows upserted.
         """
         if not decisions:
@@ -649,7 +652,7 @@ class LocalUserStore:
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
                        ON CONFLICT(project_id, fragment_id) DO UPDATE SET
                          verdict = excluded.verdict,
-                         assigned_section = excluded.assigned_section,
+                         assigned_section = COALESCE(excluded.assigned_section, fragment_curation.assigned_section),
                          note = COALESCE(excluded.note, fragment_curation.note),
                          suggested_text = COALESCE(excluded.suggested_text, fragment_curation.suggested_text),
                          sentence_model = COALESCE(excluded.sentence_model, fragment_curation.sentence_model),

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -70,6 +70,65 @@ def test_curate_fragments(store):
     assert accepted[0]["assigned_section"] == "intro"
 
 
+def test_curate_fragments_upsert_preserves_assigned_section_on_none(store):
+    """Regression: concurrent post-hooks. _run_auto_suggest writes
+    assigned_section='intro'; generate_sentences_task later writes a
+    suggestion for the same fragment with suggested_text but
+    assigned_section=None (sentence path doesn't know the auto-assignment).
+    The None must NOT clobber the previously-stored section. Codex P1 on
+    #360.
+    """
+    pid = _make_project(store)
+
+    # First write — auto_suggest with an assigned section
+    store.curate_fragments(pid, [
+        {
+            "fragment_id": "f1",
+            "citekey": "ck",
+            "verdict": "suggested",
+            "assigned_section": "1.1",
+        },
+    ])
+    assert store.get_curated(pid)[0]["assigned_section"] == "1.1"
+
+    # Second write — sentence generator arrives with suggested_text but no section
+    store.curate_fragments(pid, [
+        {
+            "fragment_id": "f1",
+            "citekey": "ck",
+            "verdict": "suggested",
+            "assigned_section": None,
+            "suggested_text": "Academic paraphrase [@ck].",
+            "sentence_model": "sonnet-4",
+        },
+    ])
+    row = store.get_curated(pid)[0]
+    # Preserved — not clobbered to NULL
+    assert row["assigned_section"] == "1.1"
+    # New field landed
+    assert row["suggested_text"] == "Academic paraphrase [@ck]."
+    assert row["sentence_model"] == "sonnet-4"
+
+
+def test_curate_fragments_upsert_allows_explicit_section_overwrite(store):
+    """COALESCE skips the update when new value is NULL, but an explicit
+    non-null value must still overwrite the old one (e.g. user changes
+    section assignment via a curate decision).
+    """
+    pid = _make_project(store)
+    store.curate_fragments(pid, [
+        {"fragment_id": "f1", "citekey": "ck", "verdict": "suggested",
+         "assigned_section": "1.1"},
+    ])
+    store.curate_fragments(pid, [
+        {"fragment_id": "f1", "citekey": "ck", "verdict": "accepted",
+         "assigned_section": "2.3"},
+    ])
+    row = store.get_curated(pid)[0]
+    assert row["assigned_section"] == "2.3"
+    assert row["verdict"] == "accepted"
+
+
 def test_curation_stats(store):
     pid = _make_project(store)
     store.curate_fragments(pid, [


### PR DESCRIPTION
Addresses Codex P1 review on merged #360.

## The race

`process_source` enqueues two post-hooks concurrently:
1. `_run_auto_suggest` — writes `verdict='suggested'` + auto-assigned section (e.g. `'1.1'`) via `curate_fragments`.
2. `_enqueue_auto_sentences` — calls `generate_sentences_task`, which snapshots existing curation rows, runs the AI, then for any fragment not in the snapshot calls `curate_fragments` with `suggested_text` populated but **assigned_section=None** (sentence path doesn't know what section was auto-assigned).

When step 1 arrives first and step 2 second, the upsert's `assigned_section = excluded.assigned_section` clause overwrites the section back to NULL. Review then shows fragments with paraphrases but lost assignments.

## Fix
`assigned_section = COALESCE(excluded.assigned_section, fragment_curation.assigned_section)` — matches the existing COALESCE pattern for `note`/`suggested_text`/`sentence_model`. Explicit non-null updates still overwrite (covered by a new test).

`verdict` stays hard-overwrite — it's always an explicit caller choice.

## Tests
- `test_curate_fragments_upsert_preserves_assigned_section_on_none` — replays the race.
- `test_curate_fragments_upsert_allows_explicit_section_overwrite` — makes sure legitimate section changes still work.
- Full suite: 2003 passed.

## Release Note

### Problem
Auto-generation of sentences (#360) introduced a concurrency bug: uploading a PDF to a project could intermittently strip the auto-assigned section from fragments, leaving them with paraphrased text but no section anchor in MapView. Users would see suggestions that looked orphaned from the outline.

### Academic Foundation
Defensive database writes — "never clobber existing state with NULL unless explicitly requested" — is a standard pattern for idempotent upserts in event-sourced systems. The fix extends the COALESCE-on-null pattern already applied to note/suggested_text/sentence_model to cover assigned_section as well, closing the race without adding lock-based serialization.

### Implementation
One-line SQL change in `user_store.curate_fragments`. The semantics shift is minimal: the insert path still writes NULL when the caller hasn't specified a section (first-write wins), and explicit non-null section updates via subsequent writes still overwrite. Only the None-from-a-concurrent-hook case is now a no-op.

### Results
2 new regression tests. Full suite: 2003 passed, 1 skipped. No schema migration, no API change, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)