### PR TITLE
fix(saas): enforce 10-year recency rule on /library/recommendations pre-LLM

### DIFF
--- a/prompts/library_recommendations_system.md
+++ b/prompts/library_recommendations_system.md
@@ -21,6 +21,11 @@ Respond entirely in {{ rationale_language }}.
    methods just because their mechanical score is high.
 5. **Fewer strong picks beat padded lists.** If only 6 candidates are clearly
    relevant, return 6. Do not stretch weak candidates into the top list.
+6. **Prefer recent work.** The candidate list has already been filtered to
+   papers no older than 10 years (or widely-cited classics from the user's
+   own library). Within this pool, still prefer newer work when topical fit
+   is comparable — the researcher wants the current state of the field, not
+   seminal papers they've already read.
 
 ## Evaluation Criteria
 

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -1162,8 +1162,12 @@ async def list_recommendations(
                 warning=warning,
             )
 
-    # Build candidate pool (scored, without recency filter), scoped by project
-    candidates = compute_scored_gaps(
+    # Build candidate pool (scored), then apply recency filter BEFORE
+    # passing to the LLM. Without this the LLM freely picks seminal
+    # classics from 20-30 years ago because the prompt has no recency
+    # guidance — the user-facing rule "не старше 10 лет" was only being
+    # enforced on the AI-down fallback branch.
+    raw_candidates = compute_scored_gaps(
         paper_store=paper_store,
         library=library,
         project_store=project_store,
@@ -1171,6 +1175,7 @@ async def list_recommendations(
         project_id=project_id,
         limit=CANDIDATE_LIMIT,
     )
+    candidates = apply_recency_filter(raw_candidates)
     if not candidates:
         return RecommendationsResponse(
             recommendations=[],

--- a/tests/test_recommendations_api.py
+++ b/tests/test_recommendations_api.py
@@ -468,3 +468,61 @@ def test_gaps_endpoint_three_sources_threshold(client, stores):
     resp = client.get("/library/gaps", headers=_headers(token))
     assert resp.status_code == 200
     assert resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Recency filter — applied BEFORE the LLM so the user's 10-year rule is
+# enforced even when AI is available, not only on the fallback path.
+# ---------------------------------------------------------------------------
+
+
+def test_recommendations_recency_filter_applied_before_llm(client, stores):
+    """Candidates older than 10 years without enough citations (<3 in the
+    user's library) must be dropped BEFORE the LLM call. Previously the
+    filter only fired on the AI-down fallback — the LLM was free to
+    return 20-year-old classics from the full 50-candidate pool.
+    Regression for user-reported recency rule violation.
+    """
+    from datetime import date
+    _, paper_store, user_library, _, _ = stores
+    token = _register(client)
+    pid = _create_project(client, token)
+
+    me = client.get("/auth/me", headers=_headers(token))
+    user_id = me.json()["user_id"]
+    today = date.today().year
+
+    # 3 sources. "Recent Work" cited by all 3 (passes). "Very Old Singleton"
+    # cited by 1 (old + cited_by_count=1 < classic_min_cited_by=3 → filtered).
+    for i in range(1, 4):
+        ck = f"src{i}"
+        p_id = paper_store.register_paper(
+            title=f"Src {i}", authors="A", year=2023,
+            abstract="x", pdf_hash=f"hh{i}",
+        )
+        user_library.add_source(
+            p_id, ck, status="completed",
+            user_id=user_id, project_id=pid,
+        )
+        refs = [{"title": "Recent Work", "authors": "Hersbach",
+                 "year": today - 3, "citation_intent": "uses_data"}]
+        if i == 1:
+            refs.append({"title": "Very Old Singleton", "authors": "Oldman",
+                          "year": today - 30, "citation_intent": "background"})
+        paper_store.save_citation_links(p_id, refs)
+
+    payload = {"recommendations": [
+        {"title": "Recent Work", "authors": "Hersbach", "year": today - 3,
+         "rationale": "recent", "score": 8},
+    ]}
+    ai, cfg = _stub_provider(payload)
+    with patch("klemma.api.tasks._create_ai_provider", return_value=(ai, cfg)):
+        resp = client.get(
+            f"/library/recommendations?project_id={pid}", headers=_headers(token)
+        )
+
+    assert resp.status_code == 200
+    assert len(ai.calls) == 1
+    user_prompt_sent = ai.calls[0]["user"]
+    assert "Very Old Singleton" not in user_prompt_sent
+    assert "Recent Work" in user_prompt_sent


### PR DESCRIPTION
User-reported bug: recommendations list had 7+ entries older than 10 years (Lindsay 2008, Johannessen 2007, Гудкович 1972, Cavalieri 1996, …) despite the "не старше 10 лет" rule being documented for gaps/recommendations.

## Root cause
`apply_recency_filter` was called **only** on the AI-down fallback branch of `/library/recommendations`. In the happy path all 50 scored candidates went into the LLM prompt with no recency guidance, and an LLM-as-librarian naturally prefers highly-cited seminal papers → classics-heavy output.

## Fix
1. **Pre-LLM filter** — `apply_recency_filter` now runs on the candidate pool before building the prompt. The 10-year rule (with classic exception at `cited_by_count >= 3`) is enforced deterministically.
2. **Prompt reinforcement** — added principle #6 to `library_recommendations_system.md` telling the model to prefer newer work within the already-filtered pool.

The classic exception (`cited_by_count ≥ 3`) is kept as documented — a widely-cited paper from 15 years ago that appears as a reference in 3+ of the user's own papers is probably foundational and worth surfacing. If empirical data shows this exception is too loose, a follow-up can tighten the threshold.

## Regression test
- Seed 3 sources. One recent ref cited by all 3 (passes). One old ref cited by 1 (singleton, `cited_by_count=1 < 3` → filtered). Assert old title is **NOT** in the prompt payload sent to the stubbed LLM.

Full suite: 2004 passed, 1 skipped.

## Release Note

### Problem
Despite the code defining `RECENCY_MAX_AGE_YEARS=10` and a sensible classic exception, recommendations surfaced a 1972 paper for a sea-ice forecasting project. The documentation and the fallback path both respected the rule, but the happy-path branch didn't — the filter was structurally inside an `if ai is None:` block rather than applied to the candidate pool.

### Academic Foundation
A literature-review assistant's primary job is surfacing current work. Overrepresenting classics mirrors what a naive citation-count ranker would do and defeats the LLM-curator's value-add. The 10-year cutoff is standard library-science heuristic for "state of the field" reviews (Pautasso 2013); the classic-exception lane preserves foundational references without letting them dominate.

### Implementation
Two-line code change in the route (extract raw_candidates, filter before building prompt); one-line addition to the system prompt; one regression test that asserts the filtered candidate is absent from the LLM prompt payload.

### Results
Full suite: 2004 passed. No schema change. Caching key unchanged — previously-cached recommendations will remain until library/outline changes invalidate them, at which point the corrected filter takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)