### PR TITLE
feat(library): semantic fragment search endpoint (M2)

### DIFF
--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -397,15 +397,11 @@ async def semantic_search_fragments(
     cross-lingual citation verification where the citing paper and the cited
     paper share no token overlap.
     """
-    from klemma.stores.paper_store import LocalPaperStore
-
     from ..tasks import _create_embeddings_provider
 
     limit = max(1, min(body.limit, 50))
 
     paper_store = get_paper_store()
-    if not isinstance(paper_store, LocalPaperStore):
-        return SemanticSearchResponse(results=[], total=0, query=body.query)
 
     try:
         emb_provider = _create_embeddings_provider()
@@ -447,11 +443,10 @@ async def semantic_search_fragments(
     display_map = library.get_display_citekeys(internal_cks, user_id=user.user_id)
 
     # Enrich with paper metadata in one pass
-    paper_store_local = paper_store
     paper_ids = list({r["paper_id"] for r in raw})
     papers: dict[str, object] = {}
     for pid in paper_ids:
-        p = paper_store_local.get_paper_by_id(pid)
+        p = paper_store.get_paper_by_id(pid)
         if p:
             papers[pid] = p
 

--- a/src/klemma/api/routes/library.py
+++ b/src/klemma/api/routes/library.py
@@ -106,6 +106,29 @@ class FragmentSearchResponse(BaseModel):
     query: str
 
 
+class SemanticSearchRequest(BaseModel):
+    query: str
+    limit: int = 20
+    citekey: str | None = None
+
+
+class SemanticSearchResult(BaseModel):
+    fragment_id: str
+    citekey: str
+    title: str = ""
+    authors: str = ""
+    year: int | None = None
+    text: str
+    similarity: float
+    page_number: int | None = None
+
+
+class SemanticSearchResponse(BaseModel):
+    results: list[SemanticSearchResult]
+    total: int
+    query: str
+
+
 class SectionServed(BaseModel):
     section: str
     count: int
@@ -357,6 +380,95 @@ async def search_fragments(
         for r in raw
     ]
     return FragmentSearchResponse(results=results, total=len(results), query=q)
+
+
+@router.post("/fragments/semantic-search", response_model=SemanticSearchResponse)
+async def semantic_search_fragments(
+    body: SemanticSearchRequest,
+    user: UserRecord = Depends(get_current_user),
+) -> SemanticSearchResponse:
+    """Semantic (vector) search over citation fragments in the user's library.
+
+    Embeds *query* via the active embedding provider, then runs KNN against
+    the sqlite-vec index.  When the vec extension is unavailable the endpoint
+    returns an empty result set rather than raising.
+
+    Optional *citekey* restricts the search to a single source — useful for
+    cross-lingual citation verification where the citing paper and the cited
+    paper share no token overlap.
+    """
+    from klemma.stores.paper_store import LocalPaperStore
+
+    from ..tasks import _create_embeddings_provider
+
+    limit = max(1, min(body.limit, 50))
+
+    paper_store = get_paper_store()
+    if not isinstance(paper_store, LocalPaperStore):
+        return SemanticSearchResponse(results=[], total=0, query=body.query)
+
+    try:
+        emb_provider = _create_embeddings_provider()
+    except Exception as exc:
+        logger.warning("Embedding provider unavailable for semantic search: %s", exc)
+        return SemanticSearchResponse(results=[], total=0, query=body.query)
+
+    try:
+        vector = emb_provider.embed(body.query, "")
+    except Exception as exc:
+        logger.warning("Failed to embed semantic search query: %s", exc)
+        return SemanticSearchResponse(results=[], total=0, query=body.query)
+
+    if not vector:
+        return SemanticSearchResponse(results=[], total=0, query=body.query)
+
+    # Resolve citekey filter to internal key when caller used external_citekey
+    internal_citekey: str | None = None
+    if body.citekey:
+        library = get_user_library()
+        src = library.get_source_by_any_key(body.citekey, user_id=user.user_id)
+        if src is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Source '{body.citekey}' not found",
+            )
+        internal_citekey = src.citekey
+
+    raw = paper_store.find_similar_fragments(
+        vector, user.user_id, limit=limit, citekey_filter=internal_citekey
+    )
+
+    if not raw:
+        return SemanticSearchResponse(results=[], total=0, query=body.query)
+
+    # Batch-resolve display citekeys
+    library = get_user_library()
+    internal_cks = list({r["citekey"] for r in raw})
+    display_map = library.get_display_citekeys(internal_cks, user_id=user.user_id)
+
+    # Enrich with paper metadata in one pass
+    paper_store_local = paper_store
+    paper_ids = list({r["paper_id"] for r in raw})
+    papers: dict[str, object] = {}
+    for pid in paper_ids:
+        p = paper_store_local.get_paper_by_id(pid)
+        if p:
+            papers[pid] = p
+
+    results = [
+        SemanticSearchResult(
+            fragment_id=r["fragment_id"],
+            citekey=display_map.get(r["citekey"], r["citekey"]),
+            title=getattr(papers.get(r["paper_id"]), "title", "") or "",
+            authors=getattr(papers.get(r["paper_id"]), "authors", "") or "",
+            year=getattr(papers.get(r["paper_id"]), "year", None),
+            text=r["fragment_text"],
+            similarity=r["similarity"],
+            page_number=r.get("page_number"),
+        )
+        for r in raw
+    ]
+    return SemanticSearchResponse(results=results, total=len(results), query=body.query)
 
 
 @router.get("/sources/{citekey}", response_model=SourceDetailResponse)

--- a/tests/test_api_search_detach.py
+++ b/tests/test_api_search_detach.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import sqlite3
 
@@ -261,3 +262,146 @@ class TestDetachSourceFromSection:
         sections = resp.json()["sections"]
         assert "1.1" not in sections
         assert "2.1" in sections
+
+
+# ---------------------------------------------------------------------------
+# POST /library/fragments/semantic-search
+# ---------------------------------------------------------------------------
+
+_VEC_AVAILABLE = importlib.util.find_spec("sqlite_vec") is not None
+_skip_no_vec = pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not installed")
+
+
+class TestSemanticSearch:
+    """Tests for POST /library/fragments/semantic-search (M2)."""
+
+    _DIM = 1024
+
+    def _seed_library(self, data_dir, mock_user):
+        """Seed library.db with two papers, each with one fragment + embedding."""
+        from klemma.models import FragmentRecord
+        from klemma.stores.paper_store import LocalPaperStore
+        from klemma.stores.user_library import LocalUserLibrary
+
+        os.environ["KLEMMA_EMBEDDINGS_MODEL"] = "test-model"
+        lib_db = data_dir / "library.db"
+        ps = LocalPaperStore(lib_db)
+        ul = LocalUserLibrary(lib_db)
+
+        def _vec(hot: int) -> list[float]:
+            v = [0.0] * self._DIM
+            v[hot] = 1.0
+            return v
+
+        papers = [
+            ("paper-A", "hash-A", "Ice Edge Prediction", "Author A", 2021),
+            ("paper-B", "hash-B", "Sea Ice Forecasting", "Author B", 2022),
+        ]
+        frags = [
+            ("frag-A", "paper-A", "IIEE metric measures ice edge location error", _vec(0)),
+            ("frag-B", "paper-B", "SPS index for Southern Ocean ice forecasting", _vec(1)),
+        ]
+
+        for paper_id, pdf_hash, title, authors, year in papers:
+            ps.register_paper(title=title, authors=authors, year=year, pdf_hash=pdf_hash)
+            # Insert with explicit paper_id
+            raw_conn = sqlite3.connect(str(lib_db))
+            raw_conn.execute(
+                "UPDATE papers SET paper_id=? WHERE pdf_hash=?", (paper_id, pdf_hash)
+            )
+            raw_conn.commit()
+            raw_conn.close()
+            ul.add_source(paper_id, paper_id.lower().replace("-", "_"),
+                          status="completed", user_id=mock_user.user_id)
+
+        for frag_id, paper_id, text, vec in frags:
+            frag = FragmentRecord(
+                fragment_id=frag_id,
+                paper_id=paper_id,
+                fragment_text=text,
+                fragment_type="key_idea",
+                page_number=1,
+                citation_intent="background",
+                content_hash=frag_id,
+            )
+            ps.save_fragments(paper_id, [frag], prompt_hash="p", ai_model="m")
+            ps.save_fragment_embedding(frag_id, vec, "test-model")
+
+        return ps
+
+    @_skip_no_vec
+    def test_semantic_search_returns_ranked_results(self, client, data_dir, mock_user):
+        """Query similar to frag-A should return frag-A first."""
+        from unittest.mock import MagicMock, patch
+
+        self._seed_library(data_dir, mock_user)
+
+        # Mock embedding provider to return vec close to frag-A (hot=0)
+        mock_emb = MagicMock()
+        mock_emb.embed.return_value = [1.0] + [0.0] * (self._DIM - 1)
+
+        with patch("klemma.api.tasks._create_embeddings_provider", return_value=mock_emb):
+            resp = client.post(
+                "/library/fragments/semantic-search",
+                json={"query": "ice edge error metric", "limit": 5},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        # frag-A must appear (closest to query vec)
+        fragment_ids = [r["fragment_id"] for r in data["results"]]
+        assert "frag-A" in fragment_ids
+        assert data["results"][0]["fragment_id"] == "frag-A"
+        assert data["results"][0]["similarity"] > 0.9
+
+    @_skip_no_vec
+    def test_semantic_search_citekey_filter(self, client, data_dir, mock_user):
+        """Restricting to paper_b citekey must exclude frag-A."""
+        from unittest.mock import MagicMock, patch
+
+        self._seed_library(data_dir, mock_user)
+
+        mock_emb = MagicMock()
+        mock_emb.embed.return_value = [1.0] + [0.0] * (self._DIM - 1)
+
+        with patch("klemma.api.tasks._create_embeddings_provider", return_value=mock_emb):
+            resp = client.post(
+                "/library/fragments/semantic-search",
+                json={"query": "ice forecasting", "limit": 5, "citekey": "paper_b"},
+            )
+
+        assert resp.status_code == 200
+        ids = [r["fragment_id"] for r in resp.json()["results"]]
+        assert "frag-A" not in ids
+
+    def test_semantic_search_returns_empty_when_provider_unavailable(self, client, data_dir):
+        """When embedding provider raises, endpoint returns empty results (not 500)."""
+        from unittest.mock import patch
+
+        with patch(
+            "klemma.api.tasks._create_embeddings_provider",
+            side_effect=RuntimeError("no embeddings"),
+        ):
+            resp = client.post(
+                "/library/fragments/semantic-search",
+                json={"query": "any query"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_semantic_search_citekey_not_found_returns_404(self, client):
+        """Unknown citekey filter returns 404."""
+        from unittest.mock import MagicMock, patch
+
+        mock_emb = MagicMock()
+        mock_emb.embed.return_value = [1.0] + [0.0] * (self._DIM - 1)
+
+        with patch("klemma.api.tasks._create_embeddings_provider", return_value=mock_emb):
+            resp = client.post(
+                "/library/fragments/semantic-search",
+                json={"query": "query", "citekey": "nonexistent_key"},
+            )
+
+        assert resp.status_code == 404


### PR DESCRIPTION
Closes #364

## Release Note

### Problem
Cross-lingual citation verification was impossible: a Russian-language claim citing an English-language paper shares zero token overlap, so `GET /library/fragments/search` (keyword-only) always returned empty results. The `cross_validate_draft.py` script produced false-negative `missing` verdicts for these cases. Additionally, `find_alt_citekey()` ran 3 sequential keyword-search requests per missing citation — slow and ineffective for semantic matches.

### Academic Foundation
Retrieval-Augmented Generation requires embedding-based retrieval to bridge lexical gaps between query and document languages [@lewis2020rag]. Dense retrieval significantly outperforms BM25-style keyword matching on cross-lingual tasks, particularly for Slavic–Germanic language pairs, where token overlap approaches zero even for topically identical sentences [@muennighoff2022mteb].

### Implementation
**`src/klemma/api/routes/library.py`** — new `POST /library/fragments/semantic-search` endpoint:
- Embeds the query string via `_create_embeddings_provider()` (same provider used in extraction tasks)
- Delegates to `paper_store.find_similar_fragments()` (M1 sqlite-vec KNN)
- Accepts optional `citekey` to restrict search to one source — cross-lingual per-source verification
- Gracefully returns `[]` when the embedding provider raises or vec extension is unavailable

**`~/.klemma/scripts/cross_validate_draft.py`**:
- `KlemmaAPI.semantic_search()` — single POST call, degrades to `[]` on 404/503 (pre-M2 servers)
- `find_alt_citekey()` — one semantic call replaces the 3×keyword loop; keyword fallback preserved
- `verify_citation()` — semantic similarity scores as a second signal alongside token overlap; final verdict = `max(token_status, semantic_status)` by rank `{missing < weak < ok}`
- `--no-semantic` flag disables all semantic paths for reproducible comparison

### Results
- 4 new tests in `TestSemanticSearch`: ranked results, citekey filter, provider-unavailable graceful degradation, 404 on unknown citekey
- 2008 passed, 13 pre-existing auth failures (403 vs 401, unrelated), 2 skipped
- Ruff: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)