### PR TITLE
fix(api): gate in-process job fallback behind KLEMMA_ALLOW_LOCAL_JOBS (#369)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,14 @@
+# Optional: LLM provider for AI-powered routes
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-proj-...
+# KLEMMA_AI_MODEL=anthropic/claude-sonnet-4-20250514
+
+# Local SaaS embeddings are required and must stay on Ollama.
+KLEMMA_EMBEDDINGS_BACKEND=litellm
+KLEMMA_EMBEDDINGS_MODEL=ollama/bge-m3
+KLEMMA_EMBEDDINGS_BASE_URL=http://127.0.0.1:11434
+
+# Enable in-process job fallback when Redis is not running locally.
+# WARNING: never set this in production — the fallback is per-process
+# and breaks with multiple uvicorn workers. Production uses Redis.
+# KLEMMA_ALLOW_LOCAL_JOBS=1

--- a/src/klemma/api/routes/CLAUDE.md
+++ b/src/klemma/api/routes/CLAUDE.md
@@ -81,7 +81,7 @@ Files stored at `KLEMMA_DATA_DIR/drafts/{project_id}/draft/` (ADR-016).
 Process endpoints — mounted with `prefix="/process"`. All require Bearer auth.
 - `POST /process/sources/{citekey}` → `JobSubmitResponse` (202) — enqueue async extraction job; validates `project_id` ownership before enqueueing (project_id is a write path for auto-suggestion)
 - `GET /process/jobs/{job_id}` → `JobStatusResponse` — poll job status (queued/started/finished/failed)
-- Requires Redis + rq; returns 503 if unavailable
+- Requires Redis + rq; returns 503 if unavailable. `KLEMMA_ALLOW_LOCAL_JOBS=1` enables a per-process asyncio fallback for single-worker dev only — never set in production (multi-worker uvicorn loses jobs across workers).
 - Worker entry point: `python -m klemma.api.worker`
 
 ### analyze.py (~190 lines)
@@ -120,7 +120,7 @@ Library-first pivot: users accept/reject fragments, assign them to outline secti
 - `PATCH /projects/{id}/fragments/curate/{fragment_id}` → partial update (verdict, section, note)
 - `GET /projects/{id}/fragments/suggest?section=X` → `SuggestFragmentsResponse` — smart suggestions: intent match + gap alerts for missing intents
 - `POST /projects/{id}/fragments/auto-suggest` → `{suggested: N}` — backfill `verdict='suggested'` entries for all uncurated fragments in a project; idempotent; uses `auto_assign_section()` from `klemma.section_types`
-- `POST /projects/{id}/fragments/generate-sentences` → `{job_id, status, citekey}` (202) — enqueue suggested-sentence generation job (ADR-017). Body: `{citekey, mode: "missing"|"force"}`. Uses Redis/rq when available, falls back to asyncio local job queue (shares `process.py`'s `_local_jobs` registry). Poll result via `GET /process/jobs/{job_id}` — final payload: `{status, generated, failed, failed_ids, sentences: {fragment_id: text}, model}`.
+- `POST /projects/{id}/fragments/generate-sentences` → `{job_id, status, citekey}` (202) — enqueue suggested-sentence generation job (ADR-017). Body: `{citekey, mode: "missing"|"force"}`. Uses Redis/rq when available; returns 503 if Redis is unavailable unless `KLEMMA_ALLOW_LOCAL_JOBS=1` is set (single-worker dev only — the asyncio fallback shares `process.py`'s per-process `_local_jobs` registry and is not multi-worker safe). Poll result via `GET /process/jobs/{job_id}` — final payload: `{status, generated, failed, failed_ids, sentences: {fragment_id: text}, model}`.
 - Uses `INTENT_TO_SECTION_TYPES` and `auto_assign_section()` from `klemma.section_types` for auto-assignment
 - Depends on: `user_store`, `paper_store`, `user_library` from `deps.py`
 - Schemas: `PendingFragmentsResponse`, `CurateRequest`, `CuratedBankResponse`, `CuratedFragmentResponse`, `SuggestFragmentsResponse`, `GenerateSentencesRequest`, `GenerateSentencesResponse`. `PendingFragment` / `CuratedFragmentResponse` include optional `suggested_text` + `sentence_model` (ADR-017).

--- a/src/klemma/api/routes/curation.py
+++ b/src/klemma/api/routes/curation.py
@@ -586,10 +586,13 @@ async def generate_sentences_endpoint(
         except Exception:
             pass  # Fall through to local execution
 
-    # Share process.py's in-memory registry so /process/jobs/{job_id}
-    # can poll results in the Redis-free fallback path.
-    from .process import _local_jobs, _run_local_job
+    from .process import _local_jobs, _local_jobs_allowed, _run_local_job
 
+    if not _local_jobs_allowed():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis unavailable. Set KLEMMA_ALLOW_LOCAL_JOBS=1 for local development without Redis.",
+        )
     job_id = str(uuid.uuid4())
     _local_jobs[job_id] = {"status": "queued", "result": None}
     asyncio.create_task(

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -44,8 +44,13 @@ _local_jobs: dict[str, dict] = {}
 
 
 def _local_jobs_allowed() -> bool:
-    """True only when KLEMMA_ALLOW_LOCAL_JOBS=1 is explicitly set (dev mode)."""
-    return bool(os.environ.get("KLEMMA_ALLOW_LOCAL_JOBS"))
+    """True only when KLEMMA_ALLOW_LOCAL_JOBS=1 is explicitly set (dev mode).
+
+    Strict equality on "1" — `bool(os.environ.get(...))` would treat "0",
+    "false", "no" as truthy (any non-empty string), which would silently
+    re-enable the unsafe fallback in production.
+    """
+    return os.environ.get("KLEMMA_ALLOW_LOCAL_JOBS") == "1"
 
 
 async def _run_local_job(job_id: str, fn: Any, *args: Any) -> None:

--- a/src/klemma/api/routes/process.py
+++ b/src/klemma/api/routes/process.py
@@ -28,12 +28,24 @@ except ImportError:
 router = APIRouter()
 
 # ---------------------------------------------------------------------------
-# In-memory job store — Redis-free fallback for local development
+# In-memory job store — only active when KLEMMA_ALLOW_LOCAL_JOBS=1
 # ---------------------------------------------------------------------------
+# WARNING: _local_jobs is a per-process dict. With uvicorn --workers N > 1,
+# each worker process has its own copy. A job submitted through worker-0 will
+# appear missing when its status is polled through worker-1.
+#
+# This fallback is safe only for single-process local development.
+# In production (Docker Compose with workers=2), KLEMMA_ALLOW_LOCAL_JOBS must
+# NOT be set — Redis is the required job store.
 
 # Keyed by job_id → {"status": str, "result": dict | None}
 # Populated by _run_local_job(); checked by get_job_status() before Redis.
 _local_jobs: dict[str, dict] = {}
+
+
+def _local_jobs_allowed() -> bool:
+    """True only when KLEMMA_ALLOW_LOCAL_JOBS=1 is explicitly set (dev mode)."""
+    return bool(os.environ.get("KLEMMA_ALLOW_LOCAL_JOBS"))
 
 
 async def _run_local_job(job_id: str, fn: Any, *args: Any) -> None:
@@ -98,7 +110,8 @@ async def submit_process_job(
     """Enqueue a source for async extraction processing.
 
     Returns 202 with a job_id that can be polled via GET /process/jobs/{job_id}.
-    Falls back to in-process thread execution when Redis is unavailable.
+    Returns 503 if Redis is unavailable, unless KLEMMA_ALLOW_LOCAL_JOBS=1 is set
+    (single-worker dev mode only — the in-process fallback is not multi-worker safe).
     """
     library = get_user_library()
     # Dual-key: accept either internal citekey or external_citekey.
@@ -124,7 +137,7 @@ async def submit_process_job(
 
     data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
 
-    # Try Redis first; fall back to in-process thread when unavailable
+    # Try Redis first; fall back to in-process thread only when explicitly opted in
     if _RQ_AVAILABLE:
         try:
             redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
@@ -144,7 +157,12 @@ async def submit_process_job(
         except Exception:
             pass  # Redis unavailable — fall through to local execution
 
-    # Local fallback: run in asyncio thread pool, no external dependencies
+    # Local fallback: only allowed in single-worker dev mode
+    if not _local_jobs_allowed():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis unavailable. Set KLEMMA_ALLOW_LOCAL_JOBS=1 for local development without Redis.",
+        )
     job_id = str(uuid.uuid4())
     asyncio.create_task(
         _run_local_job(job_id, process_source, src.paper_id, citekey, data_dir, user.user_id, project_id, force)

--- a/src/klemma/api/routes/write.py
+++ b/src/klemma/api/routes/write.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from klemma.models import UserRecord
 
 from ..auth.deps import get_current_user, get_user_store
-from .process import _run_local_job
+from .process import _local_jobs_allowed, _run_local_job
 
 try:
     from redis import Redis
@@ -108,7 +108,11 @@ async def _enqueue_write_task(
     task_name: str, section: str, project_id: str | None = None, user_id: str = "",
     word_target: int | None = None, instruction: str | None = None,
 ) -> WriteJobResponse:
-    """Enqueue a write task via rq, falling back to in-process thread when Redis is unavailable."""
+    """Enqueue a write task via rq.
+
+    Returns 503 if Redis is unavailable, unless KLEMMA_ALLOW_LOCAL_JOBS=1 is set
+    (single-worker dev mode only — the in-process fallback is not multi-worker safe).
+    """
     from ..tasks import generate_draft, generate_research
 
     data_dir = os.environ.get("KLEMMA_DATA_DIR", str(Path.home() / ".klemma"))
@@ -129,7 +133,11 @@ async def _enqueue_write_task(
         except Exception:
             pass  # Redis unavailable — fall through to local execution
 
-    # Local fallback: run in asyncio thread pool
+    if not _local_jobs_allowed():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Redis unavailable. Set KLEMMA_ALLOW_LOCAL_JOBS=1 for local development without Redis.",
+        )
     job_id = str(uuid.uuid4())
     asyncio.create_task(_run_local_job(job_id, fn, *args))
     return WriteJobResponse(job_id=job_id, status="queued", section=section, task_type=task_name)

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -1099,6 +1099,7 @@ def test_generate_sentences_rewrites_external_to_internal(client, stores, monkey
     internal key before enqueue, otherwise external-key submissions fail
     async with "Source not found". Regression: Codex P1 on #349.
     """
+    monkeypatch.setenv("KLEMMA_ALLOW_LOCAL_JOBS", "1")
     user_store, paper_store, user_library, _, _ = stores
     token = _register_and_get_token(client)
     user_id = client.get("/auth/me", headers=_auth_headers(token)).json()["user_id"]

--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -96,6 +96,77 @@ def test_submit_process_enqueues_job(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Local-fallback gate (#369): KLEMMA_ALLOW_LOCAL_JOBS must be exactly "1"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        (None, False),       # unset → fallback disabled (production default)
+        ("", False),         # empty string → disabled
+        ("0", False),         # explicit-off, MUST NOT enable fallback
+        ("false", False),    # word-form-off, MUST NOT enable fallback
+        ("no", False),       # word-form-off, MUST NOT enable fallback
+        ("true", False),     # only "1" enables; word-form-on is rejected
+        ("1", True),         # documented opt-in
+    ],
+)
+def test_local_jobs_allowed_strict_equality(monkeypatch, env_value, expected):
+    """`bool(os.environ.get(...))` would treat "0"/"false"/"no" as truthy.
+
+    Regression for codex-rescue P1 on PR #377: ensure `_local_jobs_allowed()`
+    only honors the literal string "1" so an operator typing
+    `KLEMMA_ALLOW_LOCAL_JOBS=0` cannot accidentally re-enable the unsafe
+    per-process fallback in production.
+    """
+    from klemma.api.routes.process import _local_jobs_allowed
+
+    monkeypatch.delenv("KLEMMA_ALLOW_LOCAL_JOBS", raising=False)
+    if env_value is not None:
+        monkeypatch.setenv("KLEMMA_ALLOW_LOCAL_JOBS", env_value)
+    assert _local_jobs_allowed() is expected
+
+
+def test_submit_process_returns_503_when_redis_unavailable_and_fallback_off(
+    client, monkeypatch
+):
+    """No KLEMMA_ALLOW_LOCAL_JOBS=1 + Redis unavailable → 503, not silent local fallback."""
+    token = _auth_token(client)
+    _add_source(client, token)
+
+    monkeypatch.delenv("KLEMMA_ALLOW_LOCAL_JOBS", raising=False)
+
+    import klemma.api.routes.process as proc_mod
+
+    # Redis path disabled — would otherwise enqueue successfully
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", False)
+
+    resp = client.post("/process/sources/smithML2020", headers=_headers(token))
+    assert resp.status_code == 503
+    assert "KLEMMA_ALLOW_LOCAL_JOBS" in resp.json()["detail"]
+
+
+def test_submit_process_returns_503_when_fallback_var_is_zero(client, monkeypatch):
+    """Regression: KLEMMA_ALLOW_LOCAL_JOBS=0 must NOT enable the fallback.
+
+    Prior to the PR #377 strict-equality fix, `bool("0")` evaluated to True
+    and silently allowed the unsafe per-process fallback in production.
+    """
+    token = _auth_token(client)
+    _add_source(client, token)
+
+    monkeypatch.setenv("KLEMMA_ALLOW_LOCAL_JOBS", "0")
+
+    import klemma.api.routes.process as proc_mod
+
+    monkeypatch.setattr(proc_mod, "_RQ_AVAILABLE", False)
+
+    resp = client.post("/process/sources/smithML2020", headers=_headers(token))
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
 # Job status
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Async job routes (process, write, generate-sentences) silently fell back to a per-process asyncio store when Redis was unavailable. In production (`uvicorn --workers 2`) this means jobs submitted via worker-0 are invisible when polled via worker-1.
- Fix: return 503 when Redis is down unless `KLEMMA_ALLOW_LOCAL_JOBS=1` is explicitly set. Production keeps Redis as the sole backend; local dev without Redis must opt in.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `python -m pytest tests/ -q` → 2036 passed, 2 skipped
- [x] `python -m pytest tests/test_library_api.py tests/test_process_api.py tests/test_write_api.py -q` → 61 passed
- [x] Inspected docs for stale "falls back to in-process thread" wording — updated `routes/CLAUDE.md` + route docstrings

## Release Note

### Problem
Klemma's SaaS API ships three async job routes — `POST /process/sources/{citekey}`, `POST /write/research|/draft`, and `POST /projects/{id}/fragments/generate-sentences` — that were designed to enqueue work onto Redis/rq and fall back to an in-process asyncio task store when Redis was unavailable. The fallback was permissive: any failure to reach Redis silently switched the route to a per-process `_local_jobs: dict[str, dict]`. In production we run `uvicorn --workers 2` (see `saas/deploy/docker-compose.yml`), so each worker has its own copy of that dict. A job submitted via worker-0 would return `202 {job_id}`, but polling its status through worker-1 would return `404`, leaving the SaaS frontend in a permanent "queued" state with no surfaced error. The bug is MVP-grade — convenient for solo CLI development, lethal for a multi-worker deployment — and was flagged as a pre-M1 blocker in the PP2 audit (Backend Architecture Refactor, Epic #368).

### Academic Foundation
The remediation reflects the *fail-fast, fail-loud* discipline that distributed systems literature has settled on for shared-state primitives in horizontally-scaled application servers. Brewer's CAP analysis and the Tanenbaum/van Steen formulation of consistency under partition both warn against silently degrading partitioned reads — the per-process dict is exactly such a partitioned read masquerading as a shared one. The fix mirrors how mature web frameworks treat queue backends: required-by-default, opt-in for local development. No new academic claims are made here; the change is operational hygiene that aligns the deployed surface with how the rest of the SaaS stack already behaves (Postgres, Caddy, Ollama all fail loudly when their service is down).

### Implementation
- `src/klemma/api/routes/process.py` — added `_local_jobs_allowed()` returning `True` only when `KLEMMA_ALLOW_LOCAL_JOBS=1`. Tightened the comment block above `_local_jobs` to spell out the multi-worker hazard. Inserted a 503 guard in `submit_process_job` after the Redis attempt: missing env var → `HTTPException(503, "Redis unavailable. Set KLEMMA_ALLOW_LOCAL_JOBS=1 for local development without Redis.")`.
- `src/klemma/api/routes/write.py` — imported `_local_jobs_allowed`, applied the same 503 guard in `_enqueue_write_task` (covers both `/write/research` and `/write/draft`).
- `src/klemma/api/routes/curation.py` — same guard in the `/projects/{id}/fragments/generate-sentences` enqueue path; the route still uses `process.py`'s shared `_local_jobs` registry when the fallback is enabled.
- `src/klemma/api/routes/CLAUDE.md` — updated the `process.py` and `generate-sentences` entries so the documented contract matches the new behaviour.
- `.env.local.example` — added the `KLEMMA_ALLOW_LOCAL_JOBS=1` example with an explicit "never set this in production" warning and a one-line explanation of the multi-worker trap.
- `tests/test_library_api.py::test_generate_sentences_rewrites_external_to_internal` — set `KLEMMA_ALLOW_LOCAL_JOBS=1` via `monkeypatch.setenv`. The test deliberately exercises the local fallback (it monkeypatches `_run_local_job`); it now opts in cleanly instead of relying on the old permissive default.

### Results
- Lint: `ruff check src/ tests/` → All checks passed!
- Tests: full suite `python -m pytest tests/ -q` → 2036 passed, 2 skipped, ~111s.
- Diff: 6 files, +56/-12. No new dependencies.
- Behaviour change: in production (no `KLEMMA_ALLOW_LOCAL_JOBS` set, Redis up) — identical. In production with Redis down — now `503` instead of a worker-local job that silently disappears. In local dev with Redis up — identical. In local dev with Redis down — explicit opt-in via `KLEMMA_ALLOW_LOCAL_JOBS=1`, same fallback behaviour as before once enabled.

Closes #369
Part of #368