### PR TITLE
fix(ci): bump-version workflow used a broken regex

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -26,15 +26,19 @@ jobs:
           python-version: "3.12"
 
       - name: Bump version
-        run: python scripts/bump_version.py ${{ github.event.inputs.bump }}
+        id: bump
+        run: |
+          NEW_VERSION=$(python scripts/bump_version.py ${{ github.event.inputs.bump }})
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit, tag, and push
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
         run: |
-          NEW_VERSION=$(python -c 'import re; print(re.search(r"version = .(.+?).", open("pyproject.toml").read()).group(1))')
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/klemma/__init__.py
           git commit -m "chore: bump version to ${NEW_VERSION}"
           git tag "v${NEW_VERSION}"
           git push
-          git push --tags
+          git push origin "v${NEW_VERSION}"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -57,7 +57,8 @@ def main() -> None:
     replace_in_file(PYPROJECT, r'^(version = ")[^"]+"', rf'\g<1>{new}"')
     replace_in_file(INIT, r'^(__version__ = ")[^"]+"', rf'\g<1>{new}"')
 
-    print(f"{old} → {new}")
+    print(f"{old} → {new}", file=sys.stderr)
+    print(new)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- The previous \`Bump version\` workflow re-parsed \`pyproject.toml\` with `re.search(r"version = .(.+?).", ...)` — non-greedy `.+?` plus unescaped `.` characters captured a single char.
- Most recent run committed \`chore: bump version to 0\` and tried to tag \`v0\` (collision with a leftover junk tag from an earlier broken bump). The version files were correct (0.18.0 → 0.18.1) but the release tag was never pushed; I manually tagged v0.18.1 after merging #377.
- Replace the duplicate parser with `bump_version.py`'s own output. The script now prints the new version on stdout (parseable) and the arrow form on stderr (still in CI logs). Workflow captures stdout via `$GITHUB_OUTPUT`. No regex.
- `git push origin "v${NEW_VERSION}"` instead of `git push --tags` so an unrelated stale tag can't reject the push.

## Test plan
- [x] Local sanity: `python scripts/bump_version.py patch` → stdout `0.18.2`, stderr `0.18.1 → 0.18.2`
- [ ] Next bump after merge will validate the workflow change end-to-end

## Release Note (CI fix, not a feature)

### Problem
The bump-version workflow regex captured one character of the version (the leading "0") because of an unescaped-dot, non-greedy regex. Tag `v0` was created, collided with a leftover junk tag, and the push got rejected — silently breaking the release-tag chain. The version files in `master` are correct (the script works); the workflow's own re-parsing is what was broken.

### Implementation
- `scripts/bump_version.py` — split human output (stderr) from machine output (stdout). Stdout is now the new version, nothing else.
- `.github/workflows/bump-version.yml` — capture stdout into a step output, pass to the commit/tag step via env. Removed the second regex entirely. Push the specific `v${VERSION}` tag instead of `--tags`.

### Results
- 2 files, +9/-4. No code paths in `src/` touched.
- Future bumps produce correct commit messages (`chore: bump version to 0.18.2`) and correct tags (`v0.18.2`).