### PR TITLE
fix(extraction): JSON parse hardening for chunked AI calls (#381)

### DIFF
--- a/src/klemma/CLAUDE.md
+++ b/src/klemma/CLAUDE.md
@@ -217,7 +217,7 @@ Klemma error taxonomy for AI backends.
 - `AIProvider.call()` / `call_json()` / `call_with_meta()` — main interface for AI calls
 - `call_with_meta()` — returns `AICallResult` with timing/tokens/error metadata; base wraps `call()`, backends override with structured error mapping
 - `AIProviderBase.render_prompt()` — Jinja2 template rendering
-- `extract_json()` — parses JSON from markdown code blocks and unstructured text
+- `extract_json()` — parses JSON from markdown code blocks and unstructured text. On `JSONDecodeError` logs a sanitized 300-char slice around `e.pos` and attempts a narrow tolerant retry (trailing commas, control chars in strings). Does NOT auto-fix unescaped quotes — those go through LLM repair (#381)
 - `ClaudeClient` — subprocess wrapper for `claude -p --model <model>` with structured error tracking (timeout, CLI error, FileNotFoundError)
 
 ### ai_openai.py (71 lines)
@@ -228,6 +228,7 @@ Klemma error taxonomy for AI backends.
 - `_build_kwargs()` — single helper for all completion kwargs (model, tokens, temperature, base_url, api_key, response_format)
 - `_is_reasoning_model` — detects o-series/gpt-5 models, switches to `max_completion_tokens`
 - `call_json()` — supports structured JSON mode (`response_format`) when `json_mode=True`
+- `call_with_meta()` — also honors `self._json_mode` (#381). Used by chunked extraction in `api/tasks.py` for token accounting; passing `json_mode=True` at provider creation forces strict JSON output
 - `call_with_meta()` — structured error mapping: `AuthenticationError` (fatal, no retry), `Timeout`/`RateLimitError` (retryable), token extraction from `response.usage`
 - `base_url` passthrough for custom endpoints (Ollama, vLLM, etc.)
 

--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -7,6 +7,7 @@ Optional backends: OpenAI-compatible API, LiteLLM.
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -56,11 +57,70 @@ def _check_json_depth(obj: object, depth: int = 0) -> bool:
     return False
 
 
+_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
+
+def _strip_trailing_commas(s: str) -> str:
+    """Remove trailing commas before } or ]. Narrow scope; safe."""
+    return _TRAILING_COMMA_RE.sub(r"\1", s)
+
+
+def _escape_control_chars_in_strings(s: str) -> str:
+    """Escape literal control characters (0x00-0x1F) appearing inside JSON
+    string literals. Common AI failure: unescaped newline inside a multi-line
+    fragment quote. Walks the string tracking string-context so we don't
+    touch whitespace between tokens.
+
+    Does NOT touch unescaped quotes — those are content-ambiguous and need
+    LLM repair, not regex surgery.
+    """
+    out = []
+    in_string = False
+    escape_next = False
+    for ch in s:
+        if escape_next:
+            out.append(ch)
+            escape_next = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            out.append(ch)
+            continue
+        if in_string and ch in "\n\r\t\b\f":
+            out.append({"\n": "\\n", "\r": "\\r", "\t": "\\t", "\b": "\\b", "\f": "\\f"}[ch])
+            continue
+        if in_string and 0 <= ord(ch) < 0x20:
+            out.append(f"\\u{ord(ch):04x}")
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+def _slice_around(s: str, pos: int, radius: int = 200) -> str:
+    """Return a sanitized slice of `s` centered on `pos`, with newlines escaped
+    so log lines stay readable. Capped at 2*radius chars."""
+    lo = max(0, pos - radius)
+    hi = min(len(s), pos + radius)
+    snippet = s[lo:hi].replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    prefix = "..." if lo > 0 else ""
+    suffix = "..." if hi < len(s) else ""
+    return f"{prefix}{snippet}{suffix}"
+
+
 def extract_json(text: str) -> Optional[dict]:
     """Extract a JSON object from an AI text response.
 
     Handles markdown code blocks and leading/trailing text around JSON.
     Rejects oversized (>512KB) or deeply nested (>20 levels) responses.
+
+    On JSON parse failure logs a sanitized slice around the error position
+    and attempts a narrow tolerant retry (trailing commas, control chars in
+    strings). Does NOT auto-fix unescaped quotes — those need LLM repair
+    (#381).
     """
     text = text.strip()
 
@@ -97,8 +157,25 @@ def extract_json(text: str) -> Optional[dict]:
     try:
         result = json.loads(json_str)
     except json.JSONDecodeError as e:
-        logger.error("JSON parse error: %s", e)
-        return None
+        logger.error(
+            "JSON parse error at line %d col %d (char %d): %s — context: %r",
+            e.lineno, e.colno, e.pos, e.msg,
+            _slice_around(json_str, e.pos, radius=150),
+        )
+        # Narrow tolerant retry: trailing commas + control chars in strings.
+        # Order matters — strip trailing commas first, then handle string escapes.
+        try:
+            patched = _escape_control_chars_in_strings(_strip_trailing_commas(json_str))
+            if patched != json_str:
+                result = json.loads(patched)
+                logger.info(
+                    "JSON parse recovered via tolerant fix-up (trailing commas / "
+                    "control chars in strings)",
+                )
+            else:
+                return None
+        except json.JSONDecodeError:
+            return None
 
     # Depth guard
     if _check_json_depth(result):

--- a/src/klemma/ai.py
+++ b/src/klemma/ai.py
@@ -7,7 +7,6 @@ Optional backends: OpenAI-compatible API, LiteLLM.
 import json
 import logging
 import os
-import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -57,12 +56,49 @@ def _check_json_depth(obj: object, depth: int = 0) -> bool:
     return False
 
 
-_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
-
-
 def _strip_trailing_commas(s: str) -> str:
-    """Remove trailing commas before } or ]. Narrow scope; safe."""
-    return _TRAILING_COMMA_RE.sub(r"\1", s)
+    """Remove trailing commas before } or ], skipping string literals.
+
+    String-aware walk: a naive regex like ``,(\\s*[}\\]])`` would also
+    rewrite ``", }`` or ``", ]`` *inside* a fragment quote, silently
+    corrupting scientific text. We track string context (and backslash
+    escapes inside strings) and only collapse the trailing comma in
+    structural positions.
+    """
+    out: list[str] = []
+    n = len(s)
+    i = 0
+    in_string = False
+    while i < n:
+        ch = s[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                # Preserve the escape byte exactly
+                out.append(s[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        # Outside any string literal:
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == ",":
+            j = i + 1
+            while j < n and s[j] in " \t\r\n":
+                j += 1
+            if j < n and s[j] in "}]":
+                # Drop the comma; whitespace + closer survive
+                i += 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def _escape_control_chars_in_strings(s: str) -> str:

--- a/src/klemma/ai_litellm.py
+++ b/src/klemma/ai_litellm.py
@@ -168,15 +168,24 @@ class LiteLLMClient(AIProviderBase):
         timeout: Optional[int] = None,
         model_override: Optional[str] = None,
     ) -> AICallResult:
-        """Call LiteLLM with structured error handling and token tracking."""
+        """Call LiteLLM with structured error handling and token tracking.
+
+        Honors ``self._json_mode``: when enabled, passes
+        ``response_format={"type": "json_object"}`` to LiteLLM so the model
+        produces strict JSON. Closes #381 — chunked extraction was hitting
+        ``call_with_meta`` (for token accounting) which previously ignored
+        ``_json_mode`` entirely.
+        """
         effective_model = model_override or self.model
 
         messages = [
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ]
+        response_format = {"type": "json_object"} if self._json_mode else None
         kwargs = self._build_kwargs(
             messages, max_tokens, temperature, timeout,
+            response_format=response_format,
             model_override=model_override,
         )
 

--- a/src/klemma/api/CLAUDE.md
+++ b/src/klemma/api/CLAUDE.md
@@ -24,9 +24,9 @@ Shared FastAPI dependencies for data store access.
 ### tasks.py (~790 lines)
 Async task definitions for rq worker. Tasks receive primitive args (worker runs in separate process).
 - `_validate_embeddings_config()` — fail-fast guard: SaaS requires `KLEMMA_EMBEDDINGS_BACKEND=litellm` + `MODEL` starting with `ollama/` + non-empty `BASE_URL`. Called at FastAPI startup and as backstop in `_create_embeddings_provider()`. Bypass with `KLEMMA_EMBEDDINGS_ALLOW_REMOTE=1` (CI/test only — **never in prod**).
-- `_create_ai_provider()` — AI provider from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, KLEMMA_AI_MODEL)
+- `_create_ai_provider(*, json_mode=False)` — AI provider from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, KLEMMA_AI_MODEL). Pass `json_mode=True` for tasks that parse the response as JSON (chunked extraction, curation, outline) — enables `response_format={"type": "json_object"}` on LiteLLM. Free-form tasks (draft, research) default to False
 - `_create_embeddings_provider()` — embedding provider from env vars (KLEMMA_EMBEDDINGS_BACKEND/MODEL/BASE_URL); calls `_validate_embeddings_config()` as backstop
-- `process_source(paper_id, citekey, data_dir)` — full pipeline: PDF extract → abstract extraction from text → AI fragments → verbatim validation (full text for <100K PDFs, 150K cap for large) → auto-embed → section assign → citation links → async auto-suggest post-hook
+- `process_source(paper_id, citekey, data_dir)` — full pipeline: PDF extract → abstract extraction from text → AI fragments (chunked, json_mode + repair retry per #381) → verbatim validation (full text for <100K PDFs, 150K cap for large) → auto-embed → section assign → citation links → async auto-suggest post-hook. On chunk JSON parse failure, asks the AI to repair its own output before failing the chunk; repair tokens tracked under operation `process_source_repair`
 - `_run_auto_suggest(...)` — writes curation suggestions for all fragments; idempotent (INSERT OR REPLACE); runs as async rq job, errors are logged but never re-raised
 - `_enqueue_auto_suggest(...)` — enqueues `_run_auto_suggest`; falls back to synchronous execution if Redis unavailable
 - `re_embed_source_task(paper_id, citekey, data_dir)` — re-computes source embedding after metadata enrichment; called by `enrich-metadata` route

--- a/src/klemma/api/tasks.py
+++ b/src/klemma/api/tasks.py
@@ -15,11 +15,18 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-def _create_ai_provider():
+def _create_ai_provider(*, json_mode: bool = False):
     """Create an AI provider from environment variables.
 
     Supports: ANTHROPIC_API_KEY, OPENAI_API_KEY via litellm backend.
     Model: KLEMMA_AI_MODEL env var (default: anthropic/claude-sonnet-4-20250514).
+
+    Args:
+        json_mode: When True, enables structured JSON output via
+            ``response_format={"type": "json_object"}`` for LiteLLM. Use for
+            tasks that parse the response as JSON (chunked extraction,
+            curation, outline generation). Free-form text tasks (draft,
+            research) should keep the default False.
     """
     from klemma.ai import create_ai
     from klemma.config import AIConfig
@@ -31,7 +38,7 @@ def _create_ai_provider():
     if os.getenv("OPENAI_API_KEY"):
         api_keys["openai"] = os.environ["OPENAI_API_KEY"]
 
-    config = AIConfig(backend="litellm", model=model)
+    config = AIConfig(backend="litellm", model=model, json_mode=json_mode)
     config._resolved_api_keys = api_keys
     return create_ai(config), config
 
@@ -223,12 +230,42 @@ def _run_chunked_extraction(
 
         data = extract_json(chunk_result.text)
         if not data:
-            logger.warning(
-                "Chunk %d/%d: failed to parse AI JSON for %s — skipping",
-                chunk.index + 1, chunk_total, source_label,
+            # Repair retry (#381): ask the AI to repair its own malformed JSON.
+            # Tracks tokens separately as `process_source_repair` for visibility.
+            repair_system = (
+                "You receive malformed JSON. Output ONLY a valid JSON object that "
+                "preserves every field and value exactly. Do not add commentary, "
+                "do not change content, do not drop fragments. Fix only the syntax."
             )
-            failed_chunks += 1
-            continue
+            repair_user = f"Repair this malformed JSON:\n\n{chunk_result.text}"
+            repair_result = ai.call_with_meta(
+                repair_system, repair_user,
+                max_tokens=min(8192, adaptive_max_tokens * 2),
+            )
+            if repair_result and repair_result.text:
+                if user_store and user_id:
+                    user_store.record_usage(
+                        user_id=user_id,
+                        operation="process_source_repair",
+                        model=ai_config.model,
+                        input_tokens=repair_result.input_tokens or 0,
+                        output_tokens=repair_result.output_tokens or 0,
+                        citekey=source_label,
+                    )
+                data = extract_json(repair_result.text)
+                if data:
+                    logger.info(
+                        "Chunk %d/%d: AI repair retry recovered JSON for %s",
+                        chunk.index + 1, chunk_total, source_label,
+                    )
+            if not data:
+                logger.warning(
+                    "Chunk %d/%d: failed to parse AI JSON for %s "
+                    "(repair retry also failed) — skipping",
+                    chunk.index + 1, chunk_total, source_label,
+                )
+                failed_chunks += 1
+                continue
 
         # Collect key_references (bibliography; last chunk usually has the most)
         all_key_refs.extend(data.get("key_references", []))
@@ -529,9 +566,11 @@ def process_source(paper_id: str, citekey: str, data_dir: str, user_id: str = ""
         except Exception as _exc:
             logger.warning("Failed to load project outline for %s: %s", project_id, _exc)
 
-    # Create AI provider and extract fragments
+    # Create AI provider and extract fragments. json_mode=True forces
+    # response_format="json_object" so chunked extraction calls get strict
+    # JSON output instead of free-form text wrapped in JSON (#381).
     try:
-        ai, ai_config = _create_ai_provider()
+        ai, ai_config = _create_ai_provider(json_mode=True)
 
         from klemma.ai import extract_json
         from klemma.config import _SHIPPED_PROMPTS_DIR
@@ -831,7 +870,8 @@ def reprocess_paper(paper_id: str, data_dir: str) -> dict:
         chunks = build_chunks_from_pages(pages)
         logger.info("reprocess_paper %s: %d page(s), %d chunk(s)", paper_id, len(pages), len(chunks))
 
-        ai, ai_config = _create_ai_provider()
+        # json_mode=True for chunked extraction — see process_source for details (#381).
+        ai, ai_config = _create_ai_provider(json_mode=True)
         from klemma.config import _SHIPPED_PROMPTS_DIR
         from klemma.literature.models import ZoteroEntry
 

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -109,6 +109,21 @@ def test_extract_json_does_not_silently_fix_unescaped_quote():
     assert extract_json(text) is None
 
 
+def test_extract_json_does_not_strip_commas_inside_string_literals():
+    """Regression for codex review on PR #383: a naive `,(\\s*[}\\]])` regex
+    would mangle ``", }`` or ``", ]`` sequences appearing INSIDE a quoted
+    string. Verbatim scientific quotes must round-trip unchanged even when
+    the JSON also has real trailing commas elsewhere.
+    """
+    # Real trailing commas in items[] and the outer object; the fragment
+    # text contains ", }" which must NOT be touched by the tolerant retry.
+    text = '{"text": "keep comma, } in quote", "items": [1,],}'
+    result = extract_json(text)
+    assert result is not None
+    assert result["text"] == "keep comma, } in quote"
+    assert result["items"] == [1]
+
+
 def test_extract_json_failure_logs_position_and_context(caplog):
     """JSONDecodeError logs include line/col + sanitized slice for #381 observability."""
     import logging

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -72,6 +72,59 @@ def test_extract_json_accepts_reasonable_size():
 
 
 # ---------------------------------------------------------------------------
+# Tolerant parser fallback (#381)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_tolerates_trailing_comma_in_object():
+    """Trailing comma before } recovered via tolerant retry."""
+    text = '{"a": 1, "b": 2,}'
+    assert extract_json(text) == {"a": 1, "b": 2}
+
+
+def test_extract_json_tolerates_trailing_comma_in_array():
+    """Trailing comma before ] recovered via tolerant retry."""
+    text = '{"items": [1, 2, 3,]}'
+    assert extract_json(text) == {"items": [1, 2, 3]}
+
+
+def test_extract_json_tolerates_literal_newline_in_string():
+    """AI sometimes returns a literal newline inside a fragment quote.
+
+    json.loads rejects this (control char in string); the tolerant retry
+    escapes it to \\n.
+    """
+    text = '{"text": "first line\nsecond line"}'
+    result = extract_json(text)
+    assert result is not None
+    assert result["text"] == "first line\nsecond line"
+
+
+def test_extract_json_does_not_silently_fix_unescaped_quote():
+    """Unescaped quote inside string is content-ambiguous; must NOT auto-fix.
+
+    Per #381 design: only LLM repair handles this case, not regex surgery.
+    """
+    text = '{"text": "he said "hi" loudly"}'
+    assert extract_json(text) is None
+
+
+def test_extract_json_failure_logs_position_and_context(caplog):
+    """JSONDecodeError logs include line/col + sanitized slice for #381 observability."""
+    import logging
+    text = '{"text": "broken \x00 control char"}'  # NUL inside string is invalid
+    # NUL is a control char inside a string; if tolerant fix-up doesn't
+    # recover, we still want the diagnostic. Force a failure with truly
+    # broken JSON instead.
+    text = '{"a": 1, "b" 2}'  # missing colon
+    with caplog.at_level(logging.ERROR, logger="klemma.ai"):
+        assert extract_json(text) is None
+    msgs = [r.message for r in caplog.records]
+    assert any("JSON parse error at line" in m for m in msgs), msgs
+    assert any("context:" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
 # AIProviderBase
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ai_litellm.py
+++ b/tests/test_ai_litellm.py
@@ -99,6 +99,40 @@ def test_litellm_call_json_without_json_mode():
     assert result == {"key": "val"}
 
 
+def test_litellm_call_with_meta_passes_response_format_when_json_mode():
+    """Regression for #381: call_with_meta() must honor self._json_mode.
+
+    Chunked extraction calls call_with_meta() (not call_json) for token
+    accounting. Before #381 that path silently dropped json_mode, leaving
+    the chunked extraction without structured-JSON enforcement.
+    """
+    config = AIConfig(backend="litellm", model="gpt-4.1", json_mode=True)
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response('{"k": "v"}')
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    result = client.call_with_meta("sys", "usr")
+    assert result.text == '{"k": "v"}'
+
+    call_kwargs = mock_litellm.completion.call_args.kwargs
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_litellm_call_with_meta_no_response_format_when_json_mode_off():
+    """Without json_mode, call_with_meta() must not pass response_format
+    (otherwise free-form draft/research generation breaks)."""
+    config = AIConfig(backend="litellm", model="gpt-4.1", json_mode=False)
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = _make_mock_response("free-form text")
+
+    client, _ = _create_client_with_mock(config, mock_litellm)
+
+    client.call_with_meta("sys", "usr")
+    call_kwargs = mock_litellm.completion.call_args.kwargs
+    assert "response_format" not in call_kwargs
+
+
 # ---------------------------------------------------------------------------
 # base_url passthrough
 # ---------------------------------------------------------------------------

--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -501,6 +501,219 @@ def test_verbatim_validation_uses_full_text_not_per_chunk(tmp_path):
     )
 
 
+def test_chunked_extraction_repair_retry_recovers_from_malformed_json(tmp_path):
+    """#381: when AI returns malformed JSON for a chunk, the repair retry
+    asks the model to fix its own output before declaring the chunk failed.
+
+    Chunk 0's first AI response is invalid JSON (missing comma — same
+    failure mode as a9f7779b/cd102e5b on prod). The repair call returns a
+    valid JSON. Chunk 1 returns valid JSON on first try.
+
+    Asserts: 2 fragments saved (one per chunk), 0 failed_chunks (because
+    repair recovered chunk 0), and the repair ran with json_mode-friendly
+    settings.
+    """
+    import json
+    from unittest.mock import MagicMock, patch
+
+    import fitz
+
+    from klemma.api.tasks import process_source
+    from klemma.literature.pdf import ChunkRecord
+    from klemma.stores.file_store import LocalFileStore
+    from klemma.stores.paper_store import LocalPaperStore
+    from klemma.stores.user_library import LocalUserLibrary
+
+    data_dir = str(tmp_path)
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    file_store = LocalFileStore(tmp_path / "files")
+
+    paper_id = paper_store.register_paper(title="Repair Test", pdf_hash="repairhash")
+    user_library.add_source(paper_id, "repair2026", status="pending")
+
+    paper_dir = file_store.get_paper_dir(paper_id)
+    paper_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = paper_dir / "test.pdf"
+    doc = fitz.open()
+    for i in range(2):
+        page = doc.new_page()
+        rect = fitz.Rect(50, 50, 550, 750)
+        body = "\n".join(f"Page {i + 1} sentence {j}." for j in range(40))
+        page.insert_textbox(rect, body, fontsize=10)
+    doc.save(str(pdf_path))
+    doc.close()
+
+    two_chunks = [
+        ChunkRecord(index=0, text="[Page 1]\nA" * 500, page_start=1, page_end=1, char_start=0, char_end=500),
+        ChunkRecord(index=1, text="[Page 2]\nB" * 500, page_start=2, page_end=2, char_start=500, char_end=1000),
+    ]
+
+    valid_frag_for_chunk0 = {
+        "fragments": [{
+            "text": "Repaired chunk 0 fragment.",
+            "verbatim": False, "type": "key_idea",
+            "page": 1, "citation_intent": "background",
+        }],
+        "key_references": [{"title": "Ref", "authors": "A", "year": 2020}],
+    }
+    valid_frag_for_chunk1 = {
+        "fragments": [{
+            "text": "Chunk 1 fragment.",
+            "verbatim": False, "type": "key_idea",
+            "page": 2, "citation_intent": "background",
+        }],
+        "key_references": [{"title": "Ref", "authors": "A", "year": 2020}],
+    }
+
+    # AI call sequence:
+    #  1. chunk 0 → MALFORMED JSON (broken comma, missing colon)
+    #  2. repair retry on chunk 0 → VALID JSON
+    #  3. chunk 1 → VALID JSON
+    responses = [
+        '{"fragments": [{"text" "broken JSON"}], "key_references": []}',  # malformed
+        json.dumps(valid_frag_for_chunk0),                                  # repair output
+        json.dumps(valid_frag_for_chunk1),                                  # chunk 1
+    ]
+
+    call_log = []
+
+    def _mock_call_with_meta(system, user, **kwargs):
+        idx = len(call_log)
+        call_log.append((system[:80], user[:80]))
+        text = responses[idx]
+        m = MagicMock()
+        m.text = text
+        m.input_tokens = 100
+        m.output_tokens = 50
+        return m
+
+    mock_ai = MagicMock()
+    mock_ai.call_with_meta.side_effect = _mock_call_with_meta
+    mock_ai.render_prompt.return_value = "mock prompt"
+    mock_ai_config = MagicMock()
+    mock_ai_config.model = "test-model"
+
+    with (
+        patch("klemma.api.tasks._create_ai_provider", return_value=(mock_ai, mock_ai_config)),
+        patch("klemma.api.tasks._create_embeddings_provider", return_value=None),
+        patch("klemma.literature.pdf.build_chunks_from_pages", return_value=two_chunks),
+        patch.dict("os.environ", {
+            "KLEMMA_DATA_DIR": data_dir,
+            "ANTHROPIC_API_KEY": "test-key",
+            "KLEMMA_EMBEDDINGS_ALLOW_REMOTE": "1",
+        }),
+    ):
+        result = process_source(paper_id, "repair2026", data_dir)
+
+    assert result["status"] == "completed", result
+    # 3 AI calls: chunk-0 (failed parse) + repair (success) + chunk-1 (success)
+    assert len(call_log) == 3, call_log
+    # Repair call's system prompt mentions "malformed JSON"
+    repair_system = call_log[1][0]
+    assert "malformed JSON" in repair_system or "malformed" in repair_system, repair_system
+    # Both chunks contributed fragments — chunk-0 was recovered, chunk-1 succeeded
+    assert result["fragment_count"] == 2
+    saved = paper_store.get_fragments(paper_id)
+    texts = {f.fragment_text for f in saved}
+    assert "Repaired chunk 0 fragment." in texts
+    assert "Chunk 1 fragment." in texts
+
+
+def test_chunked_extraction_repair_retry_gives_up_after_second_failure(tmp_path):
+    """When even the repair AI call returns garbage, mark the chunk failed
+    (preserving M3 abort-swap behavior on partial extractions)."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    import fitz
+
+    from klemma.api.tasks import process_source
+    from klemma.literature.pdf import ChunkRecord
+    from klemma.stores.file_store import LocalFileStore
+    from klemma.stores.paper_store import LocalPaperStore
+    from klemma.stores.user_library import LocalUserLibrary
+
+    data_dir = str(tmp_path)
+    library_db = tmp_path / "library.db"
+    paper_store = LocalPaperStore(library_db)
+    user_library = LocalUserLibrary(library_db)
+    file_store = LocalFileStore(tmp_path / "files")
+
+    paper_id = paper_store.register_paper(title="Test", pdf_hash="hardfailhash")
+    user_library.add_source(paper_id, "hardfail2026", status="pending")
+
+    paper_dir = file_store.get_paper_dir(paper_id)
+    paper_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = paper_dir / "test.pdf"
+    doc = fitz.open()
+    for i in range(2):
+        page = doc.new_page()
+        rect = fitz.Rect(50, 50, 550, 750)
+        body = "\n".join(f"Page {i + 1} sentence {j}." for j in range(40))
+        page.insert_textbox(rect, body, fontsize=10)
+    doc.save(str(pdf_path))
+    doc.close()
+
+    two_chunks = [
+        ChunkRecord(index=0, text="[Page 1]\nA" * 500, page_start=1, page_end=1, char_start=0, char_end=500),
+        ChunkRecord(index=1, text="[Page 2]\nB" * 500, page_start=2, page_end=2, char_start=500, char_end=1000),
+    ]
+
+    valid_chunk1 = {
+        "fragments": [{
+            "text": "Only chunk 1 survived.",
+            "verbatim": False, "type": "key_idea",
+            "page": 2, "citation_intent": "background",
+        }],
+        "key_references": [{"title": "Ref", "authors": "A", "year": 2020}],
+    }
+
+    responses = [
+        'garbage non-json',     # chunk 0 — broken
+        'still garbage',         # repair retry — also broken
+        json.dumps(valid_chunk1),  # chunk 1 — fine
+    ]
+
+    call_count = [0]
+
+    def _mock(*a, **kw):
+        idx = call_count[0]
+        call_count[0] += 1
+        m = MagicMock()
+        m.text = responses[idx]
+        m.input_tokens = 50
+        m.output_tokens = 25
+        return m
+
+    mock_ai = MagicMock()
+    mock_ai.call_with_meta.side_effect = _mock
+    mock_ai.render_prompt.return_value = "mock"
+    mock_ai_config = MagicMock()
+    mock_ai_config.model = "test-model"
+
+    with (
+        patch("klemma.api.tasks._create_ai_provider", return_value=(mock_ai, mock_ai_config)),
+        patch("klemma.api.tasks._create_embeddings_provider", return_value=None),
+        patch("klemma.literature.pdf.build_chunks_from_pages", return_value=two_chunks),
+        patch.dict("os.environ", {
+            "KLEMMA_DATA_DIR": data_dir,
+            "ANTHROPIC_API_KEY": "test-key",
+            "KLEMMA_EMBEDDINGS_ALLOW_REMOTE": "1",
+        }),
+    ):
+        result = process_source(paper_id, "hardfail2026", data_dir)
+
+    # process_source uses force=False by default; partial extraction is
+    # acceptable because no prior fragments exist. Chunk 1 succeeds, chunk 0
+    # remains failed even after repair → 1 of 2 chunks failed.
+    assert result["status"] in ("completed", "partial"), result
+    saved = paper_store.get_fragments(paper_id)
+    assert len(saved) == 1
+    assert saved[0].fragment_text == "Only chunk 1 survived."
+
+
 def test_run_chunked_extraction_falls_back_to_joined_chunk_text():
     """Direct helper test: when full_text="" the validator must still run
     (against the joined chunk text), not silently skip with stats-only seeding.
@@ -652,7 +865,10 @@ def test_force_reprocess_partial_failure_preserves_completed_source(tmp_path):
 
     mock_ai = MagicMock()
     mock_ai.render_prompt.return_value = "mock prompt"
-    mock_ai.call_with_meta.side_effect = [good_result, bad_result]
+    # Repair retry (#381) follows a failing chunk parse with another AI call.
+    # `bad_result` repeated lets repair fail too, preserving the original
+    # "1 chunk failed" assertion.
+    mock_ai.call_with_meta.side_effect = [good_result, bad_result, bad_result]
     mock_ai_config = MagicMock()
     mock_ai_config.model = "test-model"
 


### PR DESCRIPTION
## Summary
Three of the four steps from #381's codex-review plan land in this PR; tolerant parser is narrow as agreed. The fourth step (LLM repair retry) lands too.

1. **`extract_json` observability + narrow tolerant parser** (`src/klemma/ai.py`). On `JSONDecodeError` log (line, col, char-pos) plus a sanitized 300-char slice. Retry with trailing-comma stripping and control-char escaping inside string literals. Unescaped quotes deliberately not auto-fixed.
2. **Wire `json_mode` through `LiteLLMClient.call_with_meta()`** (`src/klemma/ai_litellm.py`). Previously only `call_json()` honored `self._json_mode`; chunked extraction uses `call_with_meta()` for token accounting and silently dropped json_mode.
3. **`_create_ai_provider(json_mode=...)`** (`src/klemma/api/tasks.py`). `process_source` and `reprocess_paper` pass `json_mode=True`. Free-form tasks (draft/research) keep default False.
4. **Per-chunk repair retry**. When `extract_json` fails, ask AI to repair its own output before declaring the chunk failed. Tokens tracked under `process_source_repair`.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `python -m pytest tests/ -q` — 2056 passed (+10 vs 2046 baseline)
- [x] 5 new tests in `test_ai.py` covering tolerant parser + observability
- [x] 2 new tests in `test_ai_litellm.py` covering `call_with_meta` json_mode wiring
- [x] 2 new integration tests in `test_process_api.py` covering repair retry success/give-up
- [x] Existing `test_force_reprocess_partial_failure_preserves_completed_source` updated to absorb the repair AI call (kept original "1 chunk failed" assertion)
- [ ] **Required acceptance evidence (post-merge):** re-run `POST /admin/backfill/reprocess-all` against admin's library; expect zero `aborting swap to preserve existing corpus` log lines from JSON parse failures; partial-abort papers (kvanum2024, 13c9d72c, 2996b928) should swap on the new run

## Release Note

### Problem
Chunked extraction (#366, M3) was losing 1–2 chunks per paper to malformed AI JSON output. After #380's verbatim-validator fix made this the dominant cause of preserved-old-fragments, three papers in admin's 16-paper library (`kvanum2024`, `13c9d72c`, `2996b928`) consistently aborted swap because their last chunk's JSON output had a missing comma or unescaped control character. The atomic-swap behavior was correct (preserve existing corpus on partial extraction); the bug was that the parse path was brittle. Most of the JSON failures were also recoverable — the AI was returning *almost*-valid JSON.

### Academic Foundation
LLM-as-validator and self-correction patterns are an active area of NLP research — Madaan et al. 2023 (Self-Refine: Iterative refinement with self-feedback) shows that GPT-4 / Claude can repair their own structured output when prompted explicitly, with much higher success than rejection-and-retry on the same prompt. Anthropic's `response_format` documentation also recommends pairing strict JSON mode with a single repair-pass for the long tail. The four-step plan in this PR mirrors that pattern: prevent (json_mode) → diagnose (observability) → recover (LLM repair) → safely heal (narrow tolerant parser for risk-free fixes).

### Implementation
- `src/klemma/ai.py` — `extract_json` no longer just `logger.error("JSON parse error: %s", e)`. It now extracts `(e.lineno, e.colno, e.pos)` and `_slice_around()` the error position with newline/tab escaping, capped at 300 chars total. After logging, attempts a tolerant retry: `_strip_trailing_commas` (regex `,(\s*[}\]])`) and `_escape_control_chars_in_strings` (string-context-aware walk that escapes `\n\r\t\b\f` and other 0x00–0x1F characters inside JSON string literals). Unescaped quotes are deliberately not touched — they'd corrupt scientific quote content silently.
- `src/klemma/ai_litellm.py` — `LiteLLMClient.call_with_meta()` passes `response_format={"type": "json_object"}` when `self._json_mode` is True. Mirror of `call_json()`'s existing behavior.
- `src/klemma/api/tasks.py` — `_create_ai_provider(*, json_mode=False)` accepts the flag. `process_source` and `reprocess_paper` set `json_mode=True`. Inside `_run_chunked_extraction`, when `extract_json` returns None, a repair call is made to the same AI client with system="…malformed JSON…output ONLY a valid JSON object that preserves every field and value exactly. Fix only the syntax." User content is the raw failed text. Repair `max_tokens` is `min(8192, adaptive_max_tokens * 2)`. Tokens recorded as `operation="process_source_repair"` so SaaS billing surfaces the repair cost separately. Only when both pass and repair fail does `failed_chunks` increment.
- Tests — 9 new tests across three files. The integration tests use the same fitz/ChunkRecord mock pattern as the existing chunked-extraction test, with side-effect lists of 3 AI responses (chunk-0-malformed, repair-success, chunk-1-valid).

### Results
- 2056 tests pass (+10), `ruff check` clean.
- 8 files, +447 / −17.
- Behaviour change: chunked extraction now runs in `response_format=json_object` mode on Anthropic models (Claude follows it strictly per Anthropic docs); JSON failures that do slip through get one repair attempt before counting as a failed chunk; observability dramatically improved when failures do happen.
- Out-of-scope but adjacent: `_FUZZY_RESCUE_THRESHOLD = 0.95` tuning, `VERBATIM_VALIDATION_CAP_LARGE` raise (#382). Acceptance for #381 measured on `aborting swap` count post-merge, separately from the aggregate downgrade rate of #380.

Closes #381