### PR TITLE
fix(dashboard): break login redirect loop on expired token

### DIFF
--- a/saas/dashboard/src/api/client.ts
+++ b/saas/dashboard/src/api/client.ts
@@ -71,7 +71,9 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     if (res.status === 401) {
       localStorage.removeItem('access_token')
       localStorage.removeItem('refresh_token')
-      window.location.href = '/login'
+      if (!['/login', '/register'].includes(window.location.pathname)) {
+        window.location.href = '/login'
+      }
       throw new ApiError(401, 'Session expired')
     }
   }

--- a/saas/dashboard/src/router/index.ts
+++ b/saas/dashboard/src/router/index.ts
@@ -103,7 +103,9 @@ router.beforeEach(async (to) => {
       const data = await userProjects.list()
       const first = data.projects[0]
       if (first) return { path: `/${first.project_id}/library` }
-    } catch { /* fall through */ }
+    } catch {
+      if (!localStorage.getItem('access_token')) return
+    }
     return { path: '/library' }
   }
 })


### PR DESCRIPTION
## Summary
- Two-line fix at the two redirect sites that caused a loop between `/login` and `/library` when the access token expired.
- No new tests — frontend has no test infrastructure (no vitest/jest); covered by manual verification.

## Test plan
- [x] \`npm run type-check\` (vue-tsc --build) — clean
- [ ] Manual: \`/login\` with valid token → redirects to \`/:projectId/library\` (unchanged behaviour).
- [ ] Manual: \`/login\` with expired token in localStorage → stays on \`/login\`, login form usable.
- [ ] Manual: \`/:projectId/library\` with expired token → 401 from any API call → exactly one redirect to \`/login\`, no loop.
- [ ] Manual: Direct nav to \`/register\` with expired session → no forced redirect.

## Release Note

### Problem
Returning to a stale dashboard tab where the access token had expired triggered a redirect loop:
1. \`/login\` mount → router \`beforeEach\` ran \`userProjects.list()\` to short-circuit already-logged-in users into the dashboard.
2. The list call returned 401 (token expired).
3. \`api/client.ts\` \`request()\` handled the 401 by setting \`window.location.href = '/login'\`.
4. \`/login\` mounted again → loop.

The user's browser would freeze in a tight client-side navigation cycle, with no way out except clearing localStorage manually.

### Implementation
\`saas/dashboard/src/api/client.ts\` — guard the hard-redirect on 401: only navigate to \`/login\` when not already on \`/login\` or \`/register\`. The 401 still raises \`ApiError(401, 'Session expired')\` so callers can decide how to handle it; we just stop forcing a navigation that re-triggers the same flow.

\`saas/dashboard/src/router/index.ts\` — in the \`beforeEach\` guard for \`/login\`, when the auto-redirect-into-app probe \`userProjects.list()\` throws AND \`localStorage.access_token\` is empty, return without navigating instead of falling through to \`/library\`. The fall-through was the second half of the loop: \`/library\` is auth-only, its guard would bounce back to \`/login\`.

### Results
- 2 files, +6 / −2 lines.
- \`npm run type-check\` passes (no TS regressions).
- Behaviour change: only on the redirect-loop path. Happy path (login with valid token, expired-token-on-protected-route) is unchanged — still exactly one redirect to \`/login\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>