### PR TITLE
fix(acquire): replace dead Semantic Scholar metadata lookup with OpenAlex

### DIFF
--- a/src/klemma/literature/metadata.py
+++ b/src/klemma/literature/metadata.py
@@ -330,6 +330,75 @@ def lookup_crossref(title: str, mailto: Optional[str] = None, timeout: int = 10)
     return None
 
 
+def _reconstruct_oa_abstract(inverted_index: Optional[dict]) -> str:
+    """Reconstruct abstract text from OpenAlex inverted-index format.
+
+    Format: ``{word: [pos1, pos2, ...], ...}``. Returns ``""`` when absent.
+    """
+    if not inverted_index:
+        return ""
+    words: list[tuple[int, str]] = []
+    for word, positions in inverted_index.items():
+        for pos in positions:
+            words.append((pos, word))
+    words.sort()
+    return " ".join(w for _, w in words)
+
+
+def lookup_openalex(title: str, mailto: Optional[str] = None, timeout: int = 10) -> Optional[dict]:
+    """Look up paper metadata on OpenAlex by title.
+
+    Returns ``{"title", "authors", "year", "abstract", "doi"}`` or ``None``.
+
+    OpenAlex replaces the dead Semantic Scholar metadata path: ``lookup_s2``
+    returns HTTP 429 without an API key. OpenAlex is free, needs no auth, and —
+    like CrossRef — enters a polite pool via a ``mailto`` in the ``User-Agent``.
+    Unlike CrossRef it reliably carries abstracts (as an inverted index, which
+    :func:`_reconstruct_oa_abstract` rebuilds here). Title match is gated by the
+    same ``_titles_match`` fuzzy comparison used by CrossRef.
+    """
+    if not title:
+        return None
+
+    mailto = mailto or _crossref_mailto()
+    url = (
+        "https://api.openalex.org/works"
+        f"?search={quote_plus(title)}&per-page=3"
+    )
+    try:
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": f"klemma/1.0 (mailto:{mailto})"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.warning("OpenAlex lookup failed for '%s': %s", title[:60], e)
+        return None
+
+    for work in data.get("results", []):
+        work_title = work.get("title") or ""
+        if not _titles_match(title, work_title):
+            continue
+
+        authors = ", ".join(
+            (a.get("author") or {}).get("display_name", "")
+            for a in work.get("authorships", [])
+            if (a.get("author") or {}).get("display_name")
+        )
+
+        return {
+            "title": work_title,
+            "authors": authors,
+            "year": work.get("publication_year"),
+            "abstract": _reconstruct_oa_abstract(work.get("abstract_inverted_index")),
+            "doi": (work.get("doi") or "").replace("https://doi.org/", ""),
+        }
+
+    return None
+
+
 def _titles_match(query: str, candidate: str) -> bool:
     """Fuzzy title comparison: normalize and check word overlap (>0.6)."""
     def normalize(s: str) -> set[str]:

--- a/src/klemma/skills/acquirer.py
+++ b/src/klemma/skills/acquirer.py
@@ -358,10 +358,11 @@ def _try_zotero(
 
 
 def _enrich_metadata(meta: PaperMetadata) -> dict:
-    """Fill missing metadata from CrossRef (by DOI) or S2 (by title).
+    """Fill missing metadata from CrossRef (by DOI) or OpenAlex (by title).
 
     CrossRef is tried first when we have a DOI (common for DOI-only acquires).
-    S2 is tried when we have a title but no DOI.
+    OpenAlex is tried when we have a title — it carries abstracts (CrossRef
+    usually doesn't) and replaces the dead S2 path (429 without a key).
     Mutates meta in-place, returns resolved dict for abstract etc.
     """
     resolved: dict = {}
@@ -381,11 +382,11 @@ def _enrich_metadata(meta: PaperMetadata) -> dict:
         except Exception as e:
             logger.debug("CrossRef DOI lookup failed: %s", e)
 
-    # 2. S2 by title — fills abstract (CrossRef doesn't have it)
+    # 2. OpenAlex by title — fills abstract (CrossRef usually doesn't; S2 is dead)
     if meta.title:
         try:
-            from ..literature.metadata import lookup_s2
-            hit = lookup_s2(meta.title)
+            from ..literature.metadata import lookup_openalex
+            hit = lookup_openalex(meta.title)
             if hit:
                 if not resolved:
                     resolved = hit
@@ -397,11 +398,11 @@ def _enrich_metadata(meta: PaperMetadata) -> dict:
                     meta.year = hit["year"]
                 if not meta.doi and hit.get("doi"):
                     meta.doi = hit["doi"]
-                # S2 has abstracts, CrossRef usually doesn't
+                # OpenAlex carries abstracts, CrossRef usually doesn't
                 if hit.get("abstract") and not resolved.get("abstract"):
                     resolved["abstract"] = hit["abstract"]
         except Exception as e:
-            logger.debug("S2 metadata lookup failed: %s", e)
+            logger.debug("OpenAlex metadata lookup failed: %s", e)
 
     return resolved
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -170,6 +170,125 @@ class TestLookupS2:
 
 
 # ---------------------------------------------------------------------------
+# lookup_openalex  (replaces dead S2 metadata path)
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructOAAbstract:
+    def test_reconstruct_in_order(self):
+        from klemma.literature.metadata import _reconstruct_oa_abstract
+
+        assert _reconstruct_oa_abstract({"Hello": [0], "world": [1]}) == "Hello world"
+        # positions, not dict order, decide the sequence
+        assert _reconstruct_oa_abstract({"b": [1], "a": [0]}) == "a b"
+
+    def test_empty(self):
+        from klemma.literature.metadata import _reconstruct_oa_abstract
+
+        assert _reconstruct_oa_abstract(None) == ""
+        assert _reconstruct_oa_abstract({}) == ""
+
+
+class TestLookupOpenAlex:
+    def test_success(self):
+        """OpenAlex returns matching work → metadata + reconstructed abstract."""
+        from klemma.literature.metadata import lookup_openalex
+
+        oa_response = {
+            "results": [
+                {
+                    "title": "Deep Learning for NLP: A Survey",
+                    "publication_year": 2024,
+                    "doi": "https://doi.org/10.1234/test",
+                    "authorships": [
+                        {"author": {"display_name": "John Smith"}},
+                        {"author": {"display_name": "Kate Jones"}},
+                    ],
+                    "abstract_inverted_index": {"We": [0], "survey": [1], "methods": [2]},
+                }
+            ]
+        }
+
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = oa_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            result = lookup_openalex("Deep Learning for NLP", mailto="me@test.org")
+
+        assert result is not None
+        assert result["year"] == 2024
+        assert "Smith" in result["authors"] and "Jones" in result["authors"]
+        assert result["doi"] == "10.1234/test"  # https://doi.org/ prefix stripped
+        assert result["abstract"] == "We survey methods"
+        # polite-pool mailto reaches the User-Agent header
+        ua = mock_req.get.call_args.kwargs["headers"]["User-Agent"]
+        assert "me@test.org" in ua
+
+    def test_no_match(self):
+        """Result title fails the fuzzy match gate → None."""
+        from klemma.literature.metadata import lookup_openalex
+
+        oa_response = {
+            "results": [
+                {
+                    "title": "Completely Unrelated Paper on Chemistry",
+                    "publication_year": 2020,
+                    "doi": "",
+                    "authorships": [],
+                    "abstract_inverted_index": None,
+                }
+            ]
+        }
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = oa_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_req.get.return_value = mock_resp
+            result = lookup_openalex("Deep Learning for NLP")
+
+        assert result is None
+
+    def test_api_error(self):
+        """Requests raises → None (graceful)."""
+        from klemma.literature.metadata import lookup_openalex
+
+        with patch("klemma.literature.metadata.requests") as mock_req:
+            mock_req.get.side_effect = Exception("Connection timeout")
+            result = lookup_openalex("Deep Learning for NLP")
+
+        assert result is None
+
+    def test_empty_title(self):
+        from klemma.literature.metadata import lookup_openalex
+
+        assert lookup_openalex("") is None
+
+
+class TestEnrichMetadataUsesOpenAlex:
+    def test_openalex_fills_abstract_and_doi(self):
+        """_enrich_metadata calls OpenAlex by title and fills abstract/doi/year."""
+        from klemma.skills.acquirer import PaperMetadata, _enrich_metadata
+
+        meta = PaperMetadata(url="", title="Integrated ice edge error verification")
+        with patch("klemma.literature.metadata.lookup_openalex") as mock_oa:
+            mock_oa.return_value = {
+                "title": "Integrated ice edge error verification",
+                "authors": "Goessling H.",
+                "year": 2016,
+                "abstract": "A verification metric for the sea ice edge.",
+                "doi": "10.1002/grl.x",
+            }
+            resolved = _enrich_metadata(meta)
+
+        mock_oa.assert_called_once_with("Integrated ice edge error verification")
+        assert resolved["abstract"] == "A verification metric for the sea ice edge."
+        assert meta.year == 2016
+        assert meta.doi == "10.1002/grl.x"
+        assert meta.authors == "Goessling H."
+
+
+# ---------------------------------------------------------------------------
 # resolve_metadata
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
`klemma acquire`'s metadata enrichment (`_enrich_metadata`) used Semantic Scholar (`lookup_s2`) for the title→metadata step that fills the **abstract**. But `api.semanticscholar.org` now returns **HTTP 429** without an API key (none is configured), so abstract enrichment silently failed on every acquire — abstracts came back empty, degrading downstream annotation/RAG quality.

Found while evaluating paper-discovery backends (Firecrawl vs S2 vs OpenAlex): S2 is effectively dead for Klemma; OpenAlex covers the canonical literature with no auth and no IP block.

## Fix
- Add `lookup_openalex(title)` to `literature/metadata.py`, mirroring the existing `lookup_crossref` contract: polite-pool `mailto`, fuzzy `_titles_match` gate, returns `{title, authors, year, abstract, doi}`.
- `_reconstruct_oa_abstract()` rebuilds OpenAlex's inverted-index abstracts — the field CrossRef usually lacks, and the reason S2 was used here originally.
- `_enrich_metadata` now calls `lookup_openalex` instead of `lookup_s2`. `lookup_s2` is retained only behind the (dead-but-harmless) `S2SearchProvider` fallback.

## Results
- 5 new tests (`TestLookupOpenAlex`, `TestReconstructOAAbstract`, `TestEnrichMetadataUsesOpenAlex`); `ruff` clean; **1922 passed, 2 skipped**.
- No schema/migration changes, no new dependencies, no new StateManager methods. Completes the S2 decommission begun for `resolve_metadata`.

Part 1 of 2 — PR 2 adds `klemma gaps <citekey>` citation-graph discovery on the same OpenAlex backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)