### PR TITLE
ci: add Bonum portal deploy workflow

### DIFF
--- a/.github/workflows/deploy-bonum.yml
+++ b/.github/workflows/deploy-bonum.yml
@@ -1,0 +1,112 @@
+name: Deploy Bonum Portal
+
+# Separate build for the Bonum meeting-analytics portal — its own container,
+# volume and subdomain on the klemma VPS. Manual trigger, pick the branch.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/ref to deploy"
+        required: true
+        default: "feat/bonum-meeting-portal"
+
+concurrency:
+  group: deploy-bonum
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      # Build the portal-only SPA (served by the bonum container at root)
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: saas/dashboard/package-lock.json
+      - name: Build portal frontend
+        env:
+          VITE_API_BASE: ""
+          VITE_PORTAL_ONLY: "1"
+        run: cd saas/dashboard && npm ci && npm run build
+
+      # Build the bonum image (bakes the dist via saas/deploy/bonum/Dockerfile)
+      - uses: docker/setup-buildx-action@v4
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: saas/deploy/bonum/Dockerfile
+          tags: bonum-portal:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Save image
+        run: docker save bonum-portal:latest | gzip > bonum-portal.tar.gz
+
+      - name: Deploy to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_SSH_PORT: ${{ secrets.VPS_SSH_PORT }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$VPS_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          SSH_PORT="${VPS_SSH_PORT:-2222}"
+          SSH_OPTS="-i ~/.ssh/deploy_key -p $SSH_PORT -o StrictHostKeyChecking=accept-new"
+          SCP_OPTS="-i ~/.ssh/deploy_key -P $SSH_PORT -o StrictHostKeyChecking=accept-new"
+
+          scp $SCP_OPTS bonum-portal.tar.gz "${VPS_USER}@${VPS_HOST}:/tmp/"
+          # Ship compose + caddy snippet (NOT .env — set once on the server)
+          ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" "mkdir -p /opt/bonum/deploy"
+          scp $SCP_OPTS saas/deploy/bonum/docker-compose.yml saas/deploy/bonum/caddy-block.conf \
+            "${VPS_USER}@${VPS_HOST}:/opt/bonum/deploy/"
+
+          set +e
+          timeout --signal=KILL 600 ssh $SSH_OPTS "${VPS_USER}@${VPS_HOST}" > /tmp/deploy.out 2>&1 << 'DEPLOY_SCRIPT'
+            set -e
+            cd /opt/bonum/deploy
+            if [ ! -f .env ]; then
+              echo "ERROR: /opt/bonum/deploy/.env missing — create it from .env.example first"
+              exit 1
+            fi
+            sudo docker load < /tmp/bonum-portal.tar.gz
+            rm /tmp/bonum-portal.tar.gz
+            sudo docker compose up -d --force-recreate </dev/null
+
+            # Ensure the shared Caddy has the bonum site block, then reload.
+            CADDY=/opt/klemma/deploy/Caddyfile
+            if ! grep -q "bonum-analytics.bolkhovsky.ru" "$CADDY"; then
+              echo "" | sudo tee -a "$CADDY" >/dev/null
+              cat /opt/bonum/deploy/caddy-block.conf | sudo tee -a "$CADDY" >/dev/null
+              echo "Added bonum block to shared Caddyfile"
+            fi
+            sudo docker exec deploy-caddy-1 caddy reload --config /etc/caddy/Caddyfile </dev/null || true
+
+            # Health via container (no published host port)
+            for i in 1 2 3 4 5; do
+              sleep 3
+              if sudo docker exec bonum-portal python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" 2>/dev/null; then
+                echo "BONUM_DEPLOY_OK"
+                exit 0
+              fi
+              echo "health attempt $i failed..."
+            done
+            echo "health check failed"; exit 1
+          DEPLOY_SCRIPT
+          SSH_EXIT=$?
+          set -e
+          cat /tmp/deploy.out
+          grep -q "^BONUM_DEPLOY_OK$" /tmp/deploy.out && exit 0
+          echo "deploy marker missing — ssh exit $SSH_EXIT"; exit 1
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-bonum.yml` (workflow_dispatch) so it becomes dispatchable — GitHub only allows manual-trigger workflows to be invoked via API when the workflow file exists on the default branch, even when the `ref` input targets a different branch for the actual checkout.
- No other code from `feat/bonum-meeting-portal` is included here. The Bonum meeting-analytics portal stays a separate, isolated build (own container, data volume, subdomain) — this PR is pure CI plumbing.

## Reviews
- `/pm-review`: ✅ Approve — infra plumbing, no core-loop/product surface touched, no scope concerns.
- `/cto-review`: ✅ Approve — no red lines, no dependency-direction changes, mirrors the existing `deploy.yml`/`miz-deploy` pattern already on the VPS (shared Caddy + `deploy_default` network). No required changes; one non-blocking suggestion (validate Caddyfile syntax before reload in a future iteration).

## Test plan
- [x] Workflow YAML reviewed for secrets handling (uses existing `VPS_*` repo secrets, no new ones)
- [ ] After merge: `gh workflow run deploy-bonum.yml -f ref=feat/bonum-meeting-portal` and confirm `BONUM_DEPLOY_OK` in the run log
- [ ] Confirm `https://bonum-analytics.bolkhovsky.ru/health` responds 200 after deploy

## Release Note

### Problem
The Bonum meeting-analytics portal (a separate client-specific build on `feat/bonum-meeting-portal`) is code-complete and test-covered but has no deploy path. `gh workflow run` requires a `workflow_dispatch`-triggered workflow file to already exist on the repository's default branch to be listed and invokable — a hard GitHub Actions platform constraint, independent of which `ref` the workflow itself checks out to build.

### Implementation
Single-file PR: `.github/workflows/deploy-bonum.yml`. Builds the portal-only Vue SPA (`VITE_API_BASE=''`, `VITE_PORTAL_ONLY=1`), builds the `bonum-portal` Docker image via `saas/deploy/bonum/Dockerfile`, ships it to the VPS over SSH using the existing `VPS_HOST/USER/SSH_KEY/SSH_PORT` secrets (already used by `deploy.yml`/miz-deploy), and brings up the isolated `bonum-portal` container on the shared `deploy_default` network (reusing Ollama + Caddy). Idempotently appends the Bonum Caddy site block to the shared Caddyfile if absent, then reloads Caddy and health-checks via `docker exec`.

### Results
1 file changed (112 lines), zero Python/business-logic changes. `ruff`/`pytest` untouched by this PR (CI-only file). Unblocks manual deployment of the already-merged-to-branch, fully tested (1962 passed / 2 skipped) Bonum portal feature.